### PR TITLE
dont use z.record(z.any()), replace with z.object({}).catchall(z.any())

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -526,7 +526,7 @@ export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemp
         description: "The results of the query",
         items: {
           type: "object",
-          required: ["latitude", "longitude"],
+          required: ["latitude", "longitude", "display_name"],
           properties: {
             latitude: {
               type: "number",
@@ -535,6 +535,10 @@ export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemp
             longitude: {
               type: "number",
               description: "The longitude of the location",
+            },
+            display_name: {
+              type: "string",
+              description: "The display name of the location",
             },
           },
         },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -165,7 +165,7 @@ export const googlemapsValidateAddressOutputSchema = z.object({
     .optional(),
   uspsData: z
     .object({
-      standardizedAddress: z.record(z.any()).describe("The standardized USPS address.").optional(),
+      standardizedAddress: z.object({}).catchall(z.any()).describe("The standardized USPS address.").optional(),
       deliveryPointValidation: z.string().describe("The USPS delivery point validation status.").optional(),
       uspsAddressPrecision: z.string().describe("The level of precision for the USPS address.").optional(),
     })
@@ -223,7 +223,7 @@ export type zendeskCreateZendeskTicketFunction = ActionFunction<
 export const mongoInsertMongoDocParamsSchema = z.object({
   databaseName: z.string().describe("Database to connect to"),
   collectionName: z.string().describe("Collection to insert the document into"),
-  document: z.record(z.any()).describe("The document to insert"),
+  document: z.object({}).catchall(z.any()).describe("The document to insert"),
 });
 
 export type mongoInsertMongoDocParamsType = z.infer<typeof mongoInsertMongoDocParamsSchema>;
@@ -255,7 +255,7 @@ export const snowflakeGetRowByFieldValueOutputSchema = z.object({
   row: z
     .object({
       id: z.string().describe("The ID of the row").optional(),
-      rowContents: z.record(z.any()).describe("The contents of the row").optional(),
+      rowContents: z.object({}).catchall(z.any()).describe("The contents of the row").optional(),
     })
     .describe("The row from the Snowflake table"),
 });
@@ -281,6 +281,7 @@ export const openstreetmapGetLatitudeLongitudeFromLocationOutputSchema = z.objec
       z.object({
         latitude: z.number().describe("The latitude of the location"),
         longitude: z.number().describe("The longitude of the location"),
+        display_name: z.string().describe("The display name of the location"),
       }),
     )
     .describe("The results of the query")

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -103,7 +103,8 @@ async function addTypesToFile({
   fallback: string;
   name: string;
 }) {
-  const zodSchema = obj ? convert(obj) : fallback;
+  // Tool calling framework currently having trouble filling in records as opposed to objects
+  const zodSchema = obj ? convert(obj).replace(/z\.record\(z\.any\(\)\)/g, "z.object({}).catchall(z.any())") : fallback;
   const zodName = `${name}Schema`;
   file.addVariableStatement({
     declarationKind: VariableDeclarationKind.Const,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `z.record(z.any())` with `z.object({}).catchall(z.any())` for improved type safety and update version to `0.1.2`.
> 
>   - **Behavior**:
>     - Replace `z.record(z.any())` with `z.object({}).catchall(z.any())` in `googlemapsValidateAddressOutputSchema`, `mongoInsertMongoDocParamsSchema`, and `snowflakeGetRowByFieldValueOutputSchema` in `types.ts`.
>     - Add `display_name` as a required field in `openstreetmapGetLatitudeLongitudeFromLocationDefinition` in `templates.ts`.
>   - **Misc**:
>     - Update version in `package.json` from `0.1.1` to `0.1.2`.
>     - Modify `addTypesToFile()` in `parse.ts` to replace `z.record(z.any())` with `z.object({}).catchall(z.any())`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 7d77cf82f21e12f4ff1b66be790b12645fc1a30e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->