### PR TITLE
add weather forecast action using NWS API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@slack/web-api": "^7.8.0",
         "@types/snowflake-sdk": "^1.6.24",
         "ajv": "^8.17.1",
+        "date-fns": "^4.1.0",
         "json-schema-to-zod": "^2.5.0",
         "mongodb": "^6.13.1",
         "snowflake-sdk": "^2.0.2",
@@ -3248,6 +3249,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@slack/web-api": "^7.8.0",
     "@types/snowflake-sdk": "^1.6.24",
     "ajv": "^8.17.1",
+    "date-fns": "^4.1.0",
     "json-schema-to-zod": "^2.5.0",
     "mongodb": "^6.13.1",
     "snowflake-sdk": "^2.0.2",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -23,6 +23,8 @@ import {
   jiraCreateJiraTicketOutputSchema,
   openstreetmapGetLatitudeLongitudeFromLocationParamsSchema,
   openstreetmapGetLatitudeLongitudeFromLocationOutputSchema,
+  nwsGetForecastForLocationParamsSchema,
+  nwsGetForecastForLocationOutputSchema,
 } from "./autogen/types";
 import updatePage from "./providers/confluence/updatePage";
 import callCopilot from "./providers/credal/callCopilot";
@@ -35,6 +37,7 @@ import getRowByFieldValue from "./providers/snowflake/getRowByFieldValue";
 import createZendeskTicket from "./providers/zendesk/createZendeskTicket";
 import createJiraTicket from "./providers/jira/createJiraTicket";
 import getLatitudeLongitudeFromLocation from "./providers/openstreetmap/getLatitudeLongitudeFromLocation";
+import getForecastForLocation from "./providers/nws/getForecastForLocation";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -117,6 +120,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: getLatitudeLongitudeFromLocation,
       paramsSchema: openstreetmapGetLatitudeLongitudeFromLocationParamsSchema,
       outputSchema: openstreetmapGetLatitudeLongitudeFromLocationOutputSchema,
+    },
+  },
+  nws: {
+    getForecastForLocation: {
+      fn: getForecastForLocation,
+      paramsSchema: nwsGetForecastForLocationParamsSchema,
+      outputSchema: nwsGetForecastForLocationOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -548,3 +548,50 @@ export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemp
   name: "getLatitudeLongitudeFromLocation",
   provider: "openstreetmap",
 };
+export const nwsGetForecastForLocationDefinition: ActionTemplate = {
+  description: "Get the weather forecast for a location using latitude and longitude",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["latitude", "longitude", "isoDate"],
+    properties: {
+      latitude: {
+        type: "number",
+        description: "The latitude of the location",
+      },
+      longitude: {
+        type: "number",
+      },
+      isoDate: {
+        type: "string",
+        description: "The date to get the forecast for, in ISO datetime format",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: [],
+    properties: {
+      result: {
+        type: "object",
+        required: ["temperature", "temperatureUnit", "forecast"],
+        properties: {
+          temperature: {
+            type: "number",
+            description: "The temperature at the location",
+          },
+          temperatureUnit: {
+            type: "string",
+            description: "The unit of temperature",
+          },
+          forecast: {
+            type: "string",
+            description: "The forecast for the location",
+          },
+        },
+      },
+    },
+  },
+  name: "getForecastForLocation",
+  provider: "nws",
+};

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -561,6 +561,7 @@ export const nwsGetForecastForLocationDefinition: ActionTemplate = {
       },
       longitude: {
         type: "number",
+        description: "The longitude of the location",
       },
       isoDate: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -300,7 +300,7 @@ export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFuncti
 
 export const nwsGetForecastForLocationParamsSchema = z.object({
   latitude: z.number().describe("The latitude of the location"),
-  longitude: z.number(),
+  longitude: z.number().describe("The longitude of the location"),
   isoDate: z.string().describe("The date to get the forecast for, in ISO datetime format"),
 });
 

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -296,3 +296,28 @@ export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFuncti
   AuthParamsType,
   openstreetmapGetLatitudeLongitudeFromLocationOutputType
 >;
+
+export const nwsGetForecastForLocationParamsSchema = z.object({
+  latitude: z.number().describe("The latitude of the location"),
+  longitude: z.number(),
+  isoDate: z.string().describe("The date to get the forecast for, in ISO datetime format"),
+});
+
+export type nwsGetForecastForLocationParamsType = z.infer<typeof nwsGetForecastForLocationParamsSchema>;
+
+export const nwsGetForecastForLocationOutputSchema = z.object({
+  result: z
+    .object({
+      temperature: z.number().describe("The temperature at the location"),
+      temperatureUnit: z.string().describe("The unit of temperature"),
+      forecast: z.string().describe("The forecast for the location"),
+    })
+    .optional(),
+});
+
+export type nwsGetForecastForLocationOutputType = z.infer<typeof nwsGetForecastForLocationOutputSchema>;
+export type nwsGetForecastForLocationFunction = ActionFunction<
+  nwsGetForecastForLocationParamsType,
+  AuthParamsType,
+  nwsGetForecastForLocationOutputType
+>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6,6 +6,7 @@ export const AuthParamsSchema = z.object({
   authToken: z.string().optional(),
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
+  userAgent: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -41,6 +41,7 @@ z.object({
     authToken: z.string().optional(),
     baseUrl: z.string().optional(),
     apiKey: z.string().optional(),
+    userAgent: z.string().optional(),
 })
 `;
 

--- a/src/actions/providers/nws/getForecastForLocation.ts
+++ b/src/actions/providers/nws/getForecastForLocation.ts
@@ -17,11 +17,13 @@ interface Period {
 
 const getForecastForLocation: nwsGetForecastForLocationFunction = async ({
   params,
+  authParams,
 }: {
   params: nwsGetForecastForLocationParamsType;
   authParams: AuthParamsType;
 }): Promise<nwsGetForecastForLocationOutputType> => {
   const { latitude, longitude, isoDate } = params;
+  const { userAgent } = authParams;
 
   if (!isValidIsoDatestring(isoDate)) {
     throw new Error("Invalid ISO date format");
@@ -29,11 +31,11 @@ const getForecastForLocation: nwsGetForecastForLocationFunction = async ({
 
   const url = `https://api.weather.gov/points/${latitude},${longitude}`;
 
-  const pointsResponse = await axios.get(url, { headers: { "User-Agent": "(credal.ai, richard@credal.ai)" } });
+  const pointsResponse = await axios.get(url, { headers: { "User-Agent": userAgent } });
 
   const forecastUrl = pointsResponse.data.properties.forecast;
   const forecastResponse = await axios.get(forecastUrl, {
-    headers: { "User-Agent": "(credal.ai, richard@credal.ai)" },
+    headers: { "User-Agent": userAgent },
   });
   const forecastData = forecastResponse.data;
 
@@ -51,7 +53,7 @@ const getForecastForLocation: nwsGetForecastForLocationFunction = async ({
       temperatureUnit: relevantForecasts[0].temperatureUnit,
       forecast: relevantForecasts[0].detailedForecast,
     };
-  } 
+  }
 
   return { result };
 };

--- a/src/actions/providers/nws/getForecastForLocation.ts
+++ b/src/actions/providers/nws/getForecastForLocation.ts
@@ -1,0 +1,59 @@
+import axios from "axios";
+import {
+  AuthParamsType,
+  nwsGetForecastForLocationFunction,
+  nwsGetForecastForLocationOutputType,
+  nwsGetForecastForLocationParamsType,
+} from "../../autogen/types";
+import { isBetweenDatetime, isValidIsoDatestring } from "../../../utils/datetime";
+interface Period {
+  startTime: string;
+  endTime: string;
+  temperature: number;
+  temperatureUnit: string;
+  shortForecast: string;
+  detailedForecast: string;
+}
+
+const getForecastForLocation: nwsGetForecastForLocationFunction = async ({
+  params,
+}: {
+  params: nwsGetForecastForLocationParamsType;
+  authParams: AuthParamsType;
+}): Promise<nwsGetForecastForLocationOutputType> => {
+  const { latitude, longitude, isoDate } = params;
+
+  if (!isValidIsoDatestring(isoDate)) {
+    throw new Error("Invalid ISO date format");
+  }
+
+  const url = `https://api.weather.gov/points/${latitude},${longitude}`;
+
+  const pointsResponse = await axios.get(url, { headers: { "User-Agent": "(credal.ai, richard@credal.ai)" } });
+
+  const forecastUrl = pointsResponse.data.properties.forecast;
+  const forecastResponse = await axios.get(forecastUrl, {
+    headers: { "User-Agent": "(credal.ai, richard@credal.ai)" },
+  });
+  const forecastData = forecastResponse.data;
+
+  // Step 4: Filter for the target date
+  const targetDateString = isoDate.split("T")[0];
+
+  const relevantForecasts = forecastData.properties.periods.filter((period: Period) => {
+    return isBetweenDatetime(targetDateString, period.startTime, period.endTime);
+  });
+
+  let result: nwsGetForecastForLocationOutputType["result"];
+  if (relevantForecasts.length > 0) {
+    result = {
+      temperature: relevantForecasts[0].temperature,
+      temperatureUnit: relevantForecasts[0].temperatureUnit,
+      forecast: relevantForecasts[0].detailedForecast,
+    };
+  } 
+
+  return { result };
+};
+
+export default getForecastForLocation;

--- a/src/actions/providers/openstreetmap/getLatitudeLongitudeFromLocation.ts
+++ b/src/actions/providers/openstreetmap/getLatitudeLongitudeFromLocation.ts
@@ -8,14 +8,16 @@ import {
 
 const getLatitudeLongitudeFromLocation: openstreetmapGetLatitudeLongitudeFromLocationFunction = async ({
   params,
+  authParams,
 }: {
   params: openstreetmapGetLatitudeLongitudeFromLocationParamsType;
   authParams: AuthParamsType;
 }): Promise<openstreetmapGetLatitudeLongitudeFromLocationOutputType> => {
   const { location } = params;
+  const { userAgent } = authParams;
   const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(location)}&format=json`;
 
-  const response = await axios.get(url, { headers: { "User-Agent": "Credal/1.0" } });
+  const response = await axios.get(url, { headers: { "User-Agent": userAgent } });
 
   return response.data.map((result: { lat: string; lon: string; display_name: string }) => ({
     latitude: parseFloat(result.lat),

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -400,3 +400,36 @@ actions:
                 display_name:
                   type: string
                   description: The display name of the location
+  nws:
+    getForecastForLocation:
+      description: Get the weather forecast for a location using latitude and longitude
+      scopes: []
+      parameters:
+        type: object
+        required: [latitude, longitude, isoDate]
+        properties:
+          latitude:
+            type: number
+            description: The latitude of the location
+          longitude:
+            type: number
+          isoDate:
+            type: string
+            description: The date to get the forecast for, in ISO datetime format
+      output:
+        type: object
+        required: []
+        properties:
+          result:
+            type: object
+            required: [temperature, temperatureUnit, forecast]
+            properties:
+              temperature:
+                type: number
+                description: The temperature at the location
+              temperatureUnit:
+                type: string
+                description: The unit of temperature
+              forecast:
+                type: string
+                description: The forecast for the location

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -413,6 +413,7 @@ actions:
             description: The latitude of the location
           longitude:
             type: number
+            description: The longitude of the location
           isoDate:
             type: string
             description: The date to get the forecast for, in ISO datetime format

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,14 @@
+import { isValid, parseISO } from 'date-fns';
+
+
+export function isBetweenDatetime(isoDatetime: string, isoStart: string, isoEnd: string): boolean {
+  const datetime = new Date(isoDatetime);
+  const start = new Date(isoStart);
+  const end = new Date(isoEnd);
+
+  return datetime >= start && datetime <= end;
+}
+
+export function isValidIsoDatestring(isoDatetime: string): boolean {
+  return isValid(parseISO(isoDatetime));
+}

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,5 +1,4 @@
-import { isValid, parseISO } from 'date-fns';
-
+import { isValid, parseISO } from "date-fns";
 
 export function isBetweenDatetime(isoDatetime: string, isoStart: string, isoEnd: string): boolean {
   const datetime = new Date(isoDatetime);

--- a/tests/testCallNWSGetForecast.ts
+++ b/tests/testCallNWSGetForecast.ts
@@ -1,4 +1,5 @@
 import { runAction } from "../src/app";
+import { assert } from "node:console";
 
 async function runTest() {
   const result = await runAction(
@@ -8,6 +9,7 @@ async function runTest() {
     { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" }
   );
   console.log(result);
+  assert(result.result !== undefined, "Result should not be undefined");
 }
 
 runTest().catch(console.error);

--- a/tests/testCallNWSGetForecast.ts
+++ b/tests/testCallNWSGetForecast.ts
@@ -1,7 +1,12 @@
 import { runAction } from "../src/app";
 
 async function runTest() {
-  const result = await runAction("getForecastForLocation", "nws", {}, { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" });
+  const result = await runAction(
+    "getForecastForLocation",
+    "nws",
+    { userAgent: "insert-test-user-agent" }, // format is "(example.com, name@example.com)"
+    { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" }
+  );
   console.log(result);
 }
 

--- a/tests/testCallNWSGetForecast.ts
+++ b/tests/testCallNWSGetForecast.ts
@@ -1,0 +1,9 @@
+import { runAction } from "../src/app";
+
+async function runTest() {
+  const result = await runAction("getForecastForLocation", "nws", {}, { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" });
+  console.log(result);
+}
+
+runTest().catch(console.error);
+

--- a/tests/testCallOSMGetLatitudeLongitude.ts
+++ b/tests/testCallOSMGetLatitudeLongitude.ts
@@ -5,7 +5,7 @@ async function runTest() {
   const result = await runAction(
     "getLatitudeLongitudeFromLocation",
     "openstreetmap",
-    {}, // authParams
+    { userAgent: "insert-test-user-agent" }, // format is "ExampleApp/1.0"
     { location: "Lower East Side" }
   );
   console.log(result);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add NWS weather forecast action with schema, type definitions, and tests.
> 
>   - **New Feature**:
>     - Add `getForecastForLocation` action using NWS API in `getForecastForLocation.ts`.
>     - Integrates with `actionMapper.ts` and `schema.yaml` for action mapping and schema definition.
>   - **Utilities**:
>     - Add `isBetweenDatetime` and `isValidIsoDatestring` in `datetime.ts` for date validation.
>   - **Dependencies**:
>     - Add `date-fns` to `package.json` for date handling.
>   - **Tests**:
>     - Add `testCallNWSGetForecast.ts` for testing NWS forecast action.
>     - Update `testCallOSMGetLatitudeLongitude.ts` to use `userAgent` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for bc968c1471c36e5b85308948fc84d8dae04ca4cf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->