### PR TITLE
Add action to send email using resend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",
@@ -17,6 +17,7 @@
         "date-fns": "^4.1.0",
         "json-schema-to-zod": "^2.5.0",
         "mongodb": "^6.13.1",
+        "resend": "^4.1.2",
         "snowflake-sdk": "^2.0.2",
         "ts-node": "^10.9.2",
         "zod": "^3.24.1"
@@ -1558,6 +1559,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1566,6 +1573,37 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.1.tgz",
+      "integrity": "sha512-W3gTrcmLOVYnG80QuUp22ReIT/xfLsVJ+n7ghSlG2BITB8evNABn1AO2rGQoXuK84zKtDAlxCdm3hRyIpZdGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "9.0.5",
+        "js-beautify": "^1.14.11",
+        "react-promise-suspense": "0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@slack/logger": {
@@ -2714,6 +2752,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3238,12 +3285,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3299,6 +3365,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3315,6 +3390,61 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -3382,6 +3512,39 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3401,6 +3564,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -4357,6 +4532,41 @@
       ],
       "license": "MIT"
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4456,6 +4666,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4622,6 +4838,56 @@
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4744,6 +5010,15 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5121,6 +5396,21 @@
         }
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5310,6 +5600,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -5369,6 +5672,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -5416,6 +5728,12 @@
       "engines": {
         "node": ">= 0.6.0"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5477,6 +5795,44 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -5513,6 +5869,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.1.2.tgz",
+      "integrity": "sha512-km0btrAj/BqIaRlS+SoLNMaCAUUWEgcEvZpycfVvoXEwAHCxU+vp/ikxPgKRkyKyiR2iDcdUq5uIBTDK9oSSSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/resolve": {
@@ -5649,6 +6017,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,6 +46,7 @@
     "date-fns": "^4.1.0",
     "json-schema-to-zod": "^2.5.0",
     "mongodb": "^6.13.1",
+    "resend": "^4.1.2",
     "snowflake-sdk": "^2.0.2",
     "ts-node": "^10.9.2",
     "zod": "^3.24.1"

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -29,6 +29,8 @@ import {
   googlemapsNearbysearchParamsSchema,
   firecrawlScrapeUrlOutputSchema,
   firecrawlScrapeUrlParamsSchema,
+  resendSendEmailOutputSchema,
+  resendSendEmailParamsSchema,
 } from "./autogen/types";
 import updatePage from "./providers/confluence/updatePage";
 import callCopilot from "./providers/credal/callCopilot";
@@ -44,6 +46,7 @@ import getLatitudeLongitudeFromLocation from "./providers/openstreetmap/getLatit
 import getForecastForLocation from "./providers/nws/getForecastForLocation";
 import nearbysearch from "./providers/googlemaps/nearbysearch";
 import scrapeUrl from "./providers/firecrawl/scrapeUrl";
+import sendEmail from "./providers/resend/sendEmail";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -145,6 +148,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: scrapeUrl,
       paramsSchema: firecrawlScrapeUrlParamsSchema,
       outputSchema: firecrawlScrapeUrlOutputSchema,
+    },
+  },
+  resend: {
+    sendEmail: {
+      fn: sendEmail,
+      paramsSchema: resendSendEmailParamsSchema,
+      outputSchema: resendSendEmailOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -685,3 +685,45 @@ export const firecrawlScrapeUrlDefinition: ActionTemplate = {
   name: "scrapeUrl",
   provider: "firecrawl",
 };
+export const resendSendEmailDefinition: ActionTemplate = {
+  description: "Send an email using Resend",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["to", "from", "subject", "content"],
+    properties: {
+      to: {
+        type: "string",
+        description: "The email address to send the email to",
+      },
+      from: {
+        type: "string",
+        description: "The email address to send the email from",
+      },
+      subject: {
+        type: "string",
+        description: "The subject of the email",
+      },
+      content: {
+        type: "string",
+        description: "The content of the email",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the email was sent successfully",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the email was not sent successfully",
+      },
+    },
+  },
+  name: "sendEmail",
+  provider: "resend",
+};

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -690,15 +690,11 @@ export const resendSendEmailDefinition: ActionTemplate = {
   scopes: [],
   parameters: {
     type: "object",
-    required: ["to", "from", "subject", "content"],
+    required: ["to", "subject", "content"],
     properties: {
       to: {
         type: "string",
         description: "The email address to send the email to",
-      },
-      from: {
-        type: "string",
-        description: "The email address to send the email from",
       },
       subject: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -7,6 +7,7 @@ export const AuthParamsSchema = z.object({
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
   userAgent: z.string().optional(),
+  emailFrom: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;
@@ -364,4 +365,25 @@ export type firecrawlScrapeUrlFunction = ActionFunction<
   firecrawlScrapeUrlParamsType,
   AuthParamsType,
   firecrawlScrapeUrlOutputType
+>;
+
+export const resendSendEmailParamsSchema = z.object({
+  to: z.string().describe("The email address to send the email to"),
+  from: z.string().describe("The email address to send the email from"),
+  subject: z.string().describe("The subject of the email"),
+  content: z.string().describe("The content of the email"),
+});
+
+export type resendSendEmailParamsType = z.infer<typeof resendSendEmailParamsSchema>;
+
+export const resendSendEmailOutputSchema = z.object({
+  success: z.boolean().describe("Whether the email was sent successfully"),
+  error: z.string().describe("The error that occurred if the email was not sent successfully").optional(),
+});
+
+export type resendSendEmailOutputType = z.infer<typeof resendSendEmailOutputSchema>;
+export type resendSendEmailFunction = ActionFunction<
+  resendSendEmailParamsType,
+  AuthParamsType,
+  resendSendEmailOutputType
 >;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -8,6 +8,7 @@ export const AuthParamsSchema = z.object({
   apiKey: z.string().optional(),
   userAgent: z.string().optional(),
   emailFrom: z.string().optional(),
+  emailReplyTo: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;
@@ -369,7 +370,6 @@ export type firecrawlScrapeUrlFunction = ActionFunction<
 
 export const resendSendEmailParamsSchema = z.object({
   to: z.string().describe("The email address to send the email to"),
-  from: z.string().describe("The email address to send the email from"),
   subject: z.string().describe("The subject of the email"),
   content: z.string().describe("The content of the email"),
 });

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -13,6 +13,7 @@ import {
   jiraCreateJiraTicketDefinition,
   googlemapsNearbysearchDefinition,
   firecrawlScrapeUrlDefinition,
+  resendSendEmailDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -66,5 +67,9 @@ export const ACTION_GROUPS: ActionGroups = {
   FIRECRAWL: {
     description: "Actions for interacting with Firecrawl",
     actions: [firecrawlScrapeUrlDefinition],
+  },
+  RESEND: {
+    description: "Action for sending an email",
+    actions: [resendSendEmailDefinition],
   },
 };

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -43,6 +43,7 @@ z.object({
     apiKey: z.string().optional(),
     userAgent: z.string().optional(),
     emailFrom: z.string().optional(),
+    emailReplyTo: z.string().optional(),
 })
 `;
 

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -42,6 +42,7 @@ z.object({
     baseUrl: z.string().optional(),
     apiKey: z.string().optional(),
     userAgent: z.string().optional(),
+    emailFrom: z.string().optional(),
 })
 `;
 

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -19,7 +19,7 @@ const sendEmail: resendSendEmailFunction = async ({
 
     const result = await resend.emails.send({
       from: authParams.emailFrom!,
-      replyTo: params.from,
+      replyTo: authParams.emailReplyTo!,
       to: params.to,
       subject: params.subject,
       text: params.content,

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -1,0 +1,43 @@
+import { Resend } from 'resend';
+import {
+    resendSendEmailFunction,
+    resendSendEmailParamsType,
+    resendSendEmailOutputType,
+    resendSendEmailOutputSchema,
+    AuthParamsType,
+} from "../../autogen/types";
+
+const sendEmail: resendSendEmailFunction = async ({
+    params,
+    authParams,
+}: {
+    params: resendSendEmailParamsType;
+    authParams: AuthParamsType;
+}): Promise<resendSendEmailOutputType> => {
+    try {
+        const resend = new Resend(authParams.apiKey);
+
+        const result = await resend.emails.send({
+            from: authParams.emailFrom!,
+            replyTo: params.from,
+            to: params.to,
+            subject: params.subject,
+            text: params.content,
+        });
+
+        if (result.error) {
+            throw new Error(result.error.message);
+        }
+
+        return resendSendEmailOutputSchema.parse({
+            success: true,
+        });
+    } catch (error) {
+        return resendSendEmailOutputSchema.parse({
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+        });
+    }
+};
+
+export default sendEmail;

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -1,43 +1,43 @@
-import { Resend } from 'resend';
+import { Resend } from "resend";
 import {
-    resendSendEmailFunction,
-    resendSendEmailParamsType,
-    resendSendEmailOutputType,
-    resendSendEmailOutputSchema,
-    AuthParamsType,
+  resendSendEmailFunction,
+  resendSendEmailParamsType,
+  resendSendEmailOutputType,
+  resendSendEmailOutputSchema,
+  AuthParamsType,
 } from "../../autogen/types";
 
 const sendEmail: resendSendEmailFunction = async ({
-    params,
-    authParams,
+  params,
+  authParams,
 }: {
-    params: resendSendEmailParamsType;
-    authParams: AuthParamsType;
+  params: resendSendEmailParamsType;
+  authParams: AuthParamsType;
 }): Promise<resendSendEmailOutputType> => {
-    try {
-        const resend = new Resend(authParams.apiKey);
+  try {
+    const resend = new Resend(authParams.apiKey);
 
-        const result = await resend.emails.send({
-            from: authParams.emailFrom!,
-            replyTo: params.from,
-            to: params.to,
-            subject: params.subject,
-            text: params.content,
-        });
+    const result = await resend.emails.send({
+      from: authParams.emailFrom!,
+      replyTo: params.from,
+      to: params.to,
+      subject: params.subject,
+      text: params.content,
+    });
 
-        if (result.error) {
-            throw new Error(result.error.message);
-        }
-
-        return resendSendEmailOutputSchema.parse({
-            success: true,
-        });
-    } catch (error) {
-        return resendSendEmailOutputSchema.parse({
-            success: false,
-            error: error instanceof Error ? error.message : "Unknown error",
-        });
+    if (result.error) {
+      throw new Error(result.error.message);
     }
+
+    return resendSendEmailOutputSchema.parse({
+      success: true,
+    });
+  } catch (error) {
+    return resendSendEmailOutputSchema.parse({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
 };
 
 export default sendEmail;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -503,14 +503,11 @@ actions:
       scopes: []
       parameters:
         type: object
-        required: [to, from, subject, content]
+        required: [to, subject, content]
         properties:
           to:
             type: string
             description: The email address to send the email to
-          from:
-            type: string
-            description: The email address to send the email from
           subject:
             type: string
             description: The subject of the email

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -497,3 +497,33 @@ actions:
           content:
             type: string
             description: The content of the URL
+  resend:
+    sendEmail:
+      description: Send an email using Resend
+      scopes: []
+      parameters:
+        type: object
+        required: [to, from, subject, content]
+        properties:
+          to:
+            type: string
+            description: The email address to send the email to
+          from:
+            type: string
+            description: The email address to send the email from
+          subject:
+            type: string
+            description: The subject of the email
+          content:
+            type: string
+            description: The content of the email
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the email was sent successfully
+          error:
+            type: string
+            description: The error that occurred if the email was not sent successfully

--- a/tests/testResendSendEmail.ts
+++ b/tests/testResendSendEmail.ts
@@ -1,0 +1,20 @@
+import { runAction } from "../src/app";
+import { assert } from "node:console"
+
+async function runTest() {
+    const result = await runAction(
+        "sendEmail",
+        "resend",
+        { apiKey: "insert-during-testing", emailFrom: "Example User <example@example.com>" }, // authParams
+        {
+            to: "insert-during-testing",
+            from: "insert-during-testing", // "Example User <example@example.com>"
+            subject: "Test Email",
+            content: "This is a test email",
+        },
+    );
+    console.log(result);
+    assert(result.success, "Email was not sent successfully");
+}
+
+runTest().catch(console.error);

--- a/tests/testResendSendEmail.ts
+++ b/tests/testResendSendEmail.ts
@@ -5,10 +5,13 @@ async function runTest() {
     const result = await runAction(
         "sendEmail",
         "resend",
-        { apiKey: "insert-during-testing", emailFrom: "Example User <example@example.com>" }, // authParams
+        { 
+            apiKey: "insert-during-testing", 
+            emailFrom: "Example User <example@example.com>",
+            emailReplyTo: "insert-during-testing", // "Example User <example@example.com>"
+        }, // authParams
         {
             to: "insert-during-testing",
-            from: "insert-during-testing", // "Example User <example@example.com>"
             subject: "Test Email",
             content: "This is a test email",
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `sendEmail` action using Resend service, including schema, type definitions, and a test case.
> 
>   - **Behavior**:
>     - Adds `sendEmail` action using Resend in `actionMapper.ts` and `groups.ts`.
>     - Defines `resendSendEmailParamsSchema` and `resendSendEmailOutputSchema` in `types.ts`.
>     - Implements `sendEmail` function in `sendEmail.ts` to send emails using Resend API.
>   - **Schema and Templates**:
>     - Updates `schema.yaml` and `templates.ts` with `resendSendEmailDefinition`.
>   - **Dependencies**:
>     - Adds `resend` package to `package.json`.
>   - **Testing**:
>     - Adds `testResendSendEmail.ts` to test the `sendEmail` action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 20e7676779119ceab232bc9c610fdb20d398336b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->