### PR TITLE
add option for email bcc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.10",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.10",
+      "version": "0.1.13",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -10,6 +10,7 @@ export const AuthParamsSchema = z.object({
   userAgent: z.string().optional(),
   emailFrom: z.string().optional(),
   emailReplyTo: z.string().optional(),
+  emailBcc: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -45,6 +45,7 @@ z.object({
     userAgent: z.string().optional(),
     emailFrom: z.string().optional(),
     emailReplyTo: z.string().optional(),
+    emailBcc: z.string().optional(),
 })
 `;
 

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -20,6 +20,7 @@ const sendEmail: resendSendEmailFunction = async ({
     const result = await resend.emails.send({
       from: authParams.emailFrom!,
       replyTo: authParams.emailReplyTo!,
+      bcc: authParams.emailBcc,
       to: params.to,
       subject: params.subject,
       text: params.content,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds optional `emailBcc` field to email sending functionality and updates version to `0.1.13`.
> 
>   - **Behavior**:
>     - Adds `emailBcc` as an optional field in `AuthParamsSchema` in `types.ts` and `parse.ts`.
>     - Updates `sendEmail` in `sendEmail.ts` to include `bcc` field when sending emails.
>   - **Version**:
>     - Bumps version in `package.json` from `0.1.12` to `0.1.13`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e1b184e84cabc86cef9535f4d004ec5268e9cbb2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->