### PR TITLE
use correct base url in call copilot action based on env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/credal/callCopilot.ts
+++ b/src/actions/providers/credal/callCopilot.ts
@@ -19,7 +19,9 @@ const callCopilot: credalCallCopilotFunction = async ({
     userEmail: params.userEmail,
   };
 
-  const client = new CredalClient({ apiKey: authParams.apiKey });
+  const baseUrl = authParams.baseUrl ?? "https://app.credal.ai/api";
+
+  const client = new CredalClient({ environment: baseUrl, apiKey: authParams.apiKey });
 
   const response = await client.copilots.sendMessage({
     agentId: requestBody.agentId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `callCopilot` now uses a dynamic base URL from `authParams` with a default fallback, and version updated to `0.1.15`.
> 
>   - **Behavior**:
>     - `callCopilot` in `callCopilot.ts` now uses `authParams.baseUrl` for `CredalClient` if provided, defaults to `https://app.credal.ai/api`.
>   - **Versioning**:
>     - Incremented version in `package.json` from `0.1.14` to `0.1.15`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 6187cd13947655f8eaec0d90dc8a9f41cf3bef86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->