### PR TITLE
[X - Formerly Twitter] Action to generate Reply Post and Action to Scrape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -37,6 +37,8 @@ import {
   linkedinCreateShareLinkedinPostUrlOutputSchema,
   xCreateShareXPostUrlParamsSchema,
   xCreateShareXPostUrlOutputSchema,
+  xScrapePostDataWithNitterParamsSchema,
+  xScrapePostDataWithNitterOutputSchema,
 } from "./autogen/types";
 import updatePage from "./providers/confluence/updatePage";
 import callCopilot from "./providers/credal/callCopilot";
@@ -56,6 +58,7 @@ import sendEmail from "./providers/resend/sendEmail";
 import createShareLinkedinPostUrl from "./providers/linkedin/createSharePostLinkedinUrl";
 import createNewGoogleDoc from "./providers/google-oauth/createNewGoogleDoc";
 import createXSharePostUrl from "./providers/x/createXSharePostUrl";
+import scrapeTweetDataWithNitter from "./providers/x/scrapeTweetDataWithNitter";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -185,6 +188,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: createXSharePostUrl,
       paramsSchema: xCreateShareXPostUrlParamsSchema,
       outputSchema: xCreateShareXPostUrlOutputSchema,
+    },
+    scrapePostDataWithNitter: {
+      fn: scrapeTweetDataWithNitter,
+      paramsSchema: xScrapePostDataWithNitterParamsSchema,
+      outputSchema: xScrapePostDataWithNitterOutputSchema,
     },
   },
 };

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -35,6 +35,8 @@ import {
   resendSendEmailParamsSchema,
   linkedinCreateShareLinkedinPostUrlParamsSchema,
   linkedinCreateShareLinkedinPostUrlOutputSchema,
+  xCreateShareXPostUrlParamsSchema,
+  xCreateShareXPostUrlOutputSchema,
 } from "./autogen/types";
 import updatePage from "./providers/confluence/updatePage";
 import callCopilot from "./providers/credal/callCopilot";
@@ -53,6 +55,7 @@ import scrapeUrl from "./providers/firecrawl/scrapeUrl";
 import sendEmail from "./providers/resend/sendEmail";
 import createShareLinkedinPostUrl from "./providers/linkedin/createSharePostLinkedinUrl";
 import createNewGoogleDoc from "./providers/google-oauth/createNewGoogleDoc";
+import createXSharePostUrl from "./providers/x/createXSharePostUrl";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -175,6 +178,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: createNewGoogleDoc,
       paramsSchema: googleOauthCreateNewGoogleDocParamsSchema,
       outputSchema: googleOauthCreateNewGoogleDocOutputSchema,
+    },
+  },
+  x: {
+    createShareXPostUrl: {
+      fn: createXSharePostUrl,
+      paramsSchema: xCreateShareXPostUrlParamsSchema,
+      outputSchema: xCreateShareXPostUrlOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -503,6 +503,51 @@ export const linkedinCreateShareLinkedinPostUrlDefinition: ActionTemplate = {
   name: "createShareLinkedinPostUrl",
   provider: "linkedin",
 };
+export const xCreateShareXPostUrlDefinition: ActionTemplate = {
+  description: "Create a share X (formerly twitter) post link",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["text"],
+    properties: {
+      text: {
+        type: "string",
+        description: "The text for the linkedin post",
+      },
+      url: {
+        type: "string",
+        description: "The url for the linkedin post",
+      },
+      hashtag: {
+        type: "array",
+        description: "List of hashtags to include in the post",
+        items: {
+          type: "string",
+        },
+      },
+      via: {
+        type: "string",
+        description: "The twitter username to associate with the tweet",
+      },
+      inReplyTo: {
+        type: "string",
+        description: "The tweet ID to reply to",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["xUrl"],
+    properties: {
+      xUrl: {
+        type: "string",
+        description: "The share post X(formerly twitter) URL",
+      },
+    },
+  },
+  name: "createShareXPostUrl",
+  provider: "x",
+};
 export const mongoInsertMongoDocDefinition: ActionTemplate = {
   description: "Insert a document into a MongoDB collection",
   scopes: [],

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -512,15 +512,15 @@ export const xCreateShareXPostUrlDefinition: ActionTemplate = {
     properties: {
       text: {
         type: "string",
-        description: "The text for the linkedin post",
+        description: "The text for the X(formerly twitter) post",
       },
       url: {
         type: "string",
-        description: "The url for the linkedin post",
+        description: "The url for the X(formerly twitter) post",
       },
       hashtag: {
         type: "array",
-        description: "List of hashtags to include in the post",
+        description: "List of hashtags to include in the X post",
         items: {
           type: "string",
         },
@@ -557,7 +557,7 @@ export const xScrapePostDataWithNitterDefinition: ActionTemplate = {
     properties: {
       tweetUrl: {
         type: "string",
-        description: "The text for the linkedin post",
+        description: "The url for the X(formerly twitter) post",
       },
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -548,6 +548,32 @@ export const xCreateShareXPostUrlDefinition: ActionTemplate = {
   name: "createShareXPostUrl",
   provider: "x",
 };
+export const xScrapePostDataWithNitterDefinition: ActionTemplate = {
+  description: "Given A tweet URL scrape the tweet data with nitter+firecrawl",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["tweetUrl"],
+    properties: {
+      tweetUrl: {
+        type: "string",
+        description: "The text for the linkedin post",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["text"],
+    properties: {
+      text: {
+        type: "string",
+        description: "The text in the tweet URL",
+      },
+    },
+  },
+  name: "scrapePostDataWithNitter",
+  provider: "x",
+};
 export const mongoInsertMongoDocDefinition: ActionTemplate = {
   description: "Insert a document into a MongoDB collection",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -298,6 +298,23 @@ export type xCreateShareXPostUrlFunction = ActionFunction<
   xCreateShareXPostUrlOutputType
 >;
 
+export const xScrapePostDataWithNitterParamsSchema = z.object({
+  tweetUrl: z.string().describe("The text for the linkedin post"),
+});
+
+export type xScrapePostDataWithNitterParamsType = z.infer<typeof xScrapePostDataWithNitterParamsSchema>;
+
+export const xScrapePostDataWithNitterOutputSchema = z.object({
+  text: z.string().describe("The text in the tweet URL"),
+});
+
+export type xScrapePostDataWithNitterOutputType = z.infer<typeof xScrapePostDataWithNitterOutputSchema>;
+export type xScrapePostDataWithNitterFunction = ActionFunction<
+  xScrapePostDataWithNitterParamsType,
+  AuthParamsType,
+  xScrapePostDataWithNitterOutputType
+>;
+
 export const mongoInsertMongoDocParamsSchema = z.object({
   databaseName: z.string().describe("Database to connect to"),
   collectionName: z.string().describe("Collection to insert the document into"),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -277,6 +277,27 @@ export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<
   linkedinCreateShareLinkedinPostUrlOutputType
 >;
 
+export const xCreateShareXPostUrlParamsSchema = z.object({
+  text: z.string().describe("The text for the linkedin post"),
+  url: z.string().describe("The url for the linkedin post").optional(),
+  hashtag: z.array(z.string()).describe("List of hashtags to include in the post").optional(),
+  via: z.string().describe("The twitter username to associate with the tweet").optional(),
+  inReplyTo: z.string().describe("The tweet ID to reply to").optional(),
+});
+
+export type xCreateShareXPostUrlParamsType = z.infer<typeof xCreateShareXPostUrlParamsSchema>;
+
+export const xCreateShareXPostUrlOutputSchema = z.object({
+  xUrl: z.string().describe("The share post X(formerly twitter) URL"),
+});
+
+export type xCreateShareXPostUrlOutputType = z.infer<typeof xCreateShareXPostUrlOutputSchema>;
+export type xCreateShareXPostUrlFunction = ActionFunction<
+  xCreateShareXPostUrlParamsType,
+  AuthParamsType,
+  xCreateShareXPostUrlOutputType
+>;
+
 export const mongoInsertMongoDocParamsSchema = z.object({
   databaseName: z.string().describe("Database to connect to"),
   collectionName: z.string().describe("Collection to insert the document into"),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -278,9 +278,9 @@ export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<
 >;
 
 export const xCreateShareXPostUrlParamsSchema = z.object({
-  text: z.string().describe("The text for the linkedin post"),
-  url: z.string().describe("The url for the linkedin post").optional(),
-  hashtag: z.array(z.string()).describe("List of hashtags to include in the post").optional(),
+  text: z.string().describe("The text for the X(formerly twitter) post"),
+  url: z.string().describe("The url for the X(formerly twitter) post").optional(),
+  hashtag: z.array(z.string()).describe("List of hashtags to include in the X post").optional(),
   via: z.string().describe("The twitter username to associate with the tweet").optional(),
   inReplyTo: z.string().describe("The tweet ID to reply to").optional(),
 });
@@ -299,7 +299,7 @@ export type xCreateShareXPostUrlFunction = ActionFunction<
 >;
 
 export const xScrapePostDataWithNitterParamsSchema = z.object({
-  tweetUrl: z.string().describe("The text for the linkedin post"),
+  tweetUrl: z.string().describe("The url for the X(formerly twitter) post"),
 });
 
 export type xScrapePostDataWithNitterParamsType = z.infer<typeof xScrapePostDataWithNitterParamsSchema>;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -16,6 +16,7 @@ import {
   resendSendEmailDefinition,
   linkedinCreateShareLinkedinPostUrlDefinition,
   googleOauthCreateNewGoogleDocDefinition,
+  xCreateShareXPostUrlDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -81,5 +82,9 @@ export const ACTION_GROUPS: ActionGroups = {
   RESEND: {
     description: "Action for sending an email",
     actions: [resendSendEmailDefinition],
+  },
+  X: {
+    description: "Actions for interacting with X(formerly twitter)",
+    actions: [xCreateShareXPostUrlDefinition],
   },
 };

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -17,6 +17,7 @@ import {
   linkedinCreateShareLinkedinPostUrlDefinition,
   googleOauthCreateNewGoogleDocDefinition,
   xCreateShareXPostUrlDefinition,
+  xScrapePostDataWithNitterDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -85,6 +86,6 @@ export const ACTION_GROUPS: ActionGroups = {
   },
   X: {
     description: "Actions for interacting with X(formerly twitter)",
-    actions: [xCreateShareXPostUrlDefinition],
+    actions: [xCreateShareXPostUrlDefinition, xScrapePostDataWithNitterDefinition],
   },
 };

--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -16,7 +16,7 @@ const createXSharePostUrl: xCreateShareXPostUrlFunction = ({
 
   // Add text parameter (required) with encoding
   if (params.text) {
-    queryParams.append("text", params.text + '\n');
+    queryParams.append("text", params.text + "\n");
   }
 
   // Add url parameter if it exists

--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -1,0 +1,50 @@
+import {
+  AuthParamsType,
+  xCreateShareXPostUrlFunction,
+  xCreateShareXPostUrlParamsType,
+  xCreateShareXPostUrlOutputType,
+} from "../../autogen/types";
+
+const createXSharePostUrl: xCreateShareXPostUrlFunction = ({
+  params,
+}: {
+  params: xCreateShareXPostUrlParamsType;
+  authParams: AuthParamsType;
+}): Promise<xCreateShareXPostUrlOutputType> => {
+  const baseUrl = "https://twitter.com/intent/tweet";
+  const queryParams = new URLSearchParams();
+
+  // Add text parameter (required) with encoding
+  if (params.text) {
+    queryParams.append("text", params.text + '\n');
+  }
+
+  // Add url parameter if it exists
+  if (params.url) {
+    queryParams.append("url", params.url);
+  }
+
+  // Add hashtags parameter if it exists
+  if (params.hashtag && params.hashtag.length > 0) {
+    queryParams.append("hashtags", params.hashtag.join(","));
+  }
+
+  // Add via parameter if it exists
+  if (params.via) {
+    queryParams.append("via", params.via);
+  }
+
+  // Add in_reply_to parameter if it exists
+  if (params.inReplyTo) {
+    queryParams.append("in_reply_to", params.inReplyTo);
+  }
+
+  // Build the final URL
+  const shareUrl = queryParams.toString() ? `${baseUrl}?${queryParams.toString()}` : baseUrl;
+
+  return Promise.resolve({
+    xUrl: shareUrl,
+  });
+};
+
+export default createXSharePostUrl;

--- a/src/actions/providers/x/scrapeTweetDataWithNitter.ts
+++ b/src/actions/providers/x/scrapeTweetDataWithNitter.ts
@@ -49,7 +49,7 @@ const scrapeTweetDataWithNitter: xScrapePostDataWithNitterFunction = async ({
       text: tweetContent || "Error scraping with firecrawl",
     };
   } catch (error) {
-    throw new Error(`Error scraping tweet: ${error}`);
+    throw new Error(`Error scraping tweet: ${error instanceof Error ? error.message : error}`);
   }
 };
 

--- a/src/actions/providers/x/scrapeTweetDataWithNitter.ts
+++ b/src/actions/providers/x/scrapeTweetDataWithNitter.ts
@@ -1,0 +1,56 @@
+import FirecrawlApp from "@mendable/firecrawl-js";
+import {
+  AuthParamsType,
+  xScrapePostDataWithNitterFunction,
+  xScrapePostDataWithNitterParamsType,
+  xScrapePostDataWithNitterOutputType,
+} from "../../autogen/types";
+
+const scrapeTweetDataWithNitter: xScrapePostDataWithNitterFunction = async ({
+  params,
+  authParams,
+}: {
+  params: xScrapePostDataWithNitterParamsType;
+  authParams: AuthParamsType;
+}): Promise<xScrapePostDataWithNitterOutputType> => {
+  const tweetUrlRegex = /^(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/([a-zA-Z0-9_]+)\/status\/(\d+)(?:\?.*)?$/;
+
+  if (!tweetUrlRegex.test(params.tweetUrl)) {
+    throw new Error(
+      "Invalid tweet URL. Expected format: https://twitter.com/username/status/id or https://x.com/username/status/id",
+    );
+  }
+  const nitterUrl = params.tweetUrl.replace(
+    /^(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)/i,
+    "https://nitter.net",
+  );
+
+  // Initialize Firecrawl
+  if (!authParams.apiKey) {
+    throw new Error("API key is required for X+Nitter+Firecrawl");
+  }
+
+  const firecrawl = new FirecrawlApp({
+    apiKey: authParams.apiKey,
+  });
+
+  try {
+    // Scrape the Nitter URL
+    const result = await firecrawl.scrapeUrl(nitterUrl);
+
+    if (!result.success) {
+      throw new Error(`Failed to scrape tweet: ${result.error || "Unknown error"}`);
+    }
+
+    // Extract the tweet text from the scraped content - simple approach - in practice, you might need more robust parsing based on nitter html structure
+    const tweetContent = result.markdown;
+
+    return {
+      text: tweetContent || "Error scraping with firecrawl",
+    };
+  } catch (error) {
+    throw new Error(`Error scraping tweet: ${error}`);
+  }
+};
+
+export default scrapeTweetDataWithNitter;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -367,6 +367,39 @@ actions:
             type: string
             description: The share post linkedin URL
 
+  x:
+    createShareXPostUrl:
+      description: Create a share X (formerly twitter) post link
+      scopes: []
+      parameters:
+        type: object
+        required: [text]
+        properties:
+          text:
+            type: string
+            description: The text for the linkedin post
+          url:
+            type: string
+            description: The url for the linkedin post
+          hashtag:
+            type: array
+            description: List of hashtags to include in the post
+            items:
+              type: string
+          via:
+            type: string
+            description: The twitter username to associate with the tweet
+          inReplyTo:
+            type: string
+            description: The tweet ID to reply to
+      output:
+        type: object
+        required: [xUrl]
+        properties:
+          xUrl:
+            type: string
+            description: The share post X(formerly twitter) URL
+
   mongo:
     insertMongoDoc:
       description: Insert a document into a MongoDB collection

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -400,6 +400,24 @@ actions:
             type: string
             description: The share post X(formerly twitter) URL
 
+    scrapePostDataWithNitter:
+      description: Given A tweet URL scrape the tweet data with nitter+firecrawl
+      scopes: []
+      parameters:
+        type: object
+        required: [tweetUrl]
+        properties:
+          tweetUrl:
+            type: string
+            description: The text for the linkedin post
+      output:
+        type: object
+        required: [text]
+        properties:
+          text:
+            type: string
+            description: The text in the tweet URL
+
   mongo:
     insertMongoDoc:
       description: Insert a document into a MongoDB collection

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -377,13 +377,13 @@ actions:
         properties:
           text:
             type: string
-            description: The text for the linkedin post
+            description: The text for the X(formerly twitter) post
           url:
             type: string
-            description: The url for the linkedin post
+            description: The url for the X(formerly twitter) post
           hashtag:
             type: array
-            description: List of hashtags to include in the post
+            description: List of hashtags to include in the X post
             items:
               type: string
           via:
@@ -409,7 +409,7 @@ actions:
         properties:
           tweetUrl:
             type: string
-            description: The text for the linkedin post
+            description: The url for the X(formerly twitter) post
       output:
         type: object
         required: [text]

--- a/tests/testCreateXSharePostUrl.ts
+++ b/tests/testCreateXSharePostUrl.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert";
+import { runAction } from "../src/app";
+
+async function runTest() {
+    const text = `
+    Check out this cool project 👋
+    with multi-line text
+
+    This should properly encode spaces and special characters!
+    `;
+    const url = "https://app.credal.ai/";
+    const hashtag = ["AI", "DevTools", "Productivity"];
+    const via = "credalai";
+    const inReplyTo = "1899674121098957217";
+    
+    const result = await runAction(
+        "createShareXPostUrl",
+        "x",
+        {}, 
+        {
+            text,
+            url,
+            hashtag,
+            via,
+            inReplyTo
+        }
+    );
+        
+    assert(result, "Response should not be null");
+    assert(result.xUrl, "Response should contain a shareable X URL");
+    
+    console.log(`Successfully created X Share Post URL: ${result.xUrl}`);
+
+    // Test with minimal parameters (just text)
+    const minimalResult = await runAction(
+        "createShareXPostUrl",
+        "x",
+        {},
+        {
+            text: "Simple test tweet"
+        }
+    );
+
+    assert(minimalResult, "Minimal response should not be null");
+    assert(minimalResult.xUrl, "Minimal response should contain a shareable X URL");
+    
+    console.log(`Successfully created minimal X Share Post URL: ${minimalResult.xUrl}`);
+}
+
+runTest().catch(error => {
+    console.error("Test failed:", error);
+    if (error.response) {
+        console.error("API response:", error.response.data);
+        console.error("Status code:", error.response.status);
+    }
+    process.exit(1);
+});

--- a/tests/testScrapeXWithNitter.ts
+++ b/tests/testScrapeXWithNitter.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+import { runAction } from "../src/app";
+
+async function runTest() {
+    // Note: This test requires a valid FIRECRAWL_API_KEY in your environment variables
+    if (!process.env.FIRECRAWL_API_KEY) {
+        console.warn("Warning: FIRECRAWL_API_KEY not found in environment variables. Test will likely fail.");
+    }
+
+    // Test with a real tweet URL from X.com (formerly Twitter)
+    const tweetUrl = "https://twitter.com/elonmusk/status/1899583456050598202";
+    
+    const result = await runAction(
+        "scrapePostDataWithNitter",
+        "x",
+        {
+            apiKey: process.env.FIRECRAWL_API_KEY
+        }, 
+        {
+            tweetUrl
+        }
+    );
+        
+    assert(result, "Response should not be null");
+    assert(result.text, "Response should contain tweet text");
+    
+    console.log(`Successfully scraped tweet content: ${result.text.substring(0, 100)}...`);
+
+    // Test with an X.com URL
+    const xUrl = "https://x.com/elonmusk/status/1899583456050598202";
+    
+    const xResult = await runAction(
+        "scrapePostDataWithNitter",
+        "x",
+        {
+            apiKey: process.env.FIRECRAWL_API_KEY
+        }, 
+        {
+            tweetUrl: xUrl
+        }
+    );
+        
+    assert(xResult, "X.com response should not be null");
+    assert(xResult.text, "X.com response should contain tweet text");
+    
+    console.log(`Successfully scraped X.com tweet content: ${xResult.text.substring(0, 100)}...`);
+}
+
+runTest().catch(error => {
+    console.error("Test failed:", error);
+    if (error.response) {
+        console.error("API response:", error.response.data);
+        console.error("Status code:", error.response.status);
+    }
+    process.exit(1);
+});


### PR DESCRIPTION

Adding in 2 new actions here

1. Using twitter web intent api you can create a reply to post to an actual post given the replyID: https://developer.x.com/en/docs/x-for-websites/tweet-button/guides/web-intent

2. Using the nitter.net website - we can scrape the content of a twitter post using firecrawl (twitter blocks crawlers)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add actions to generate shareable post URLs and scrape tweet data for X (formerly Twitter) using Nitter and Firecrawl.
> 
>   - **New Actions**:
>     - `createShareXPostUrl` in `createXSharePostUrl.ts`: Generates a shareable post URL using X's web intent API.
>     - `scrapePostDataWithNitter` in `scrapeTweetDataWithNitter.ts`: Scrapes tweet data using Nitter and Firecrawl.
>   - **Schemas and Types**:
>     - Added `xCreateShareXPostUrlParamsSchema`, `xCreateShareXPostUrlOutputSchema`, `xScrapePostDataWithNitterParamsSchema`, and `xScrapePostDataWithNitterOutputSchema` in `types.ts`.
>     - Updated `actionMapper.ts` to include new actions under `x`.
>   - **Templates**:
>     - Added `xCreateShareXPostUrlDefinition` and `xScrapePostDataWithNitterDefinition` in `templates.ts`.
>   - **Tests**:
>     - Added `testCreateXSharePostUrl.ts` and `testScrapeXWithNitter.ts` to test new actions.
>   - **Miscellaneous**:
>     - Updated `package.json` version to `0.1.16`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 32ea1354788daffe334b532d2667584554c4e6b4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->