### PR TITLE
[X Action] Scarpe should be Firecrawl route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -32,13 +32,13 @@ import {
   firecrawlScrapeUrlOutputSchema,
   firecrawlScrapeUrlParamsSchema,
   resendSendEmailOutputSchema,
+  firecrawlScrapeTweetDataWithNitterParamsSchema,
+  firecrawlScrapeTweetDataWithNitterOutputSchema,
   resendSendEmailParamsSchema,
   linkedinCreateShareLinkedinPostUrlParamsSchema,
   linkedinCreateShareLinkedinPostUrlOutputSchema,
   xCreateShareXPostUrlParamsSchema,
   xCreateShareXPostUrlOutputSchema,
-  xScrapePostDataWithNitterParamsSchema,
-  xScrapePostDataWithNitterOutputSchema,
 } from "./autogen/types";
 import updatePage from "./providers/confluence/updatePage";
 import callCopilot from "./providers/credal/callCopilot";
@@ -58,7 +58,7 @@ import sendEmail from "./providers/resend/sendEmail";
 import createShareLinkedinPostUrl from "./providers/linkedin/createSharePostLinkedinUrl";
 import createNewGoogleDoc from "./providers/google-oauth/createNewGoogleDoc";
 import createXSharePostUrl from "./providers/x/createXSharePostUrl";
-import scrapeTweetDataWithNitter from "./providers/x/scrapeTweetDataWithNitter";
+import scrapeTweetDataWithNitter from "./providers/firecrawl/scrapeTweetDataWithNitter";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -168,6 +168,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       paramsSchema: firecrawlScrapeUrlParamsSchema,
       outputSchema: firecrawlScrapeUrlOutputSchema,
     },
+    scrapeTweetDataWithNitter: {
+      fn: scrapeTweetDataWithNitter,
+      paramsSchema: firecrawlScrapeTweetDataWithNitterParamsSchema,
+      outputSchema: firecrawlScrapeTweetDataWithNitterOutputSchema,
+    },
   },
   resend: {
     sendEmail: {
@@ -188,11 +193,6 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: createXSharePostUrl,
       paramsSchema: xCreateShareXPostUrlParamsSchema,
       outputSchema: xCreateShareXPostUrlOutputSchema,
-    },
-    scrapePostDataWithNitter: {
-      fn: scrapeTweetDataWithNitter,
-      paramsSchema: xScrapePostDataWithNitterParamsSchema,
-      outputSchema: xScrapePostDataWithNitterOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1,860 +1,972 @@
 import { ActionTemplate } from "../../actions/parse";
 
 export const slackSendMessageDefinition: ActionTemplate = {
-  description: "Sends a message to a Slack channel",
-  scopes: ["chat:write"],
-  parameters: {
-    type: "object",
-    required: ["channelName", "message"],
-    properties: {
-      channelName: {
-        type: "string",
-        description: "The name of the Slack channel to send the message to (e.g. general, alerts)",
-      },
-      message: {
-        type: "string",
-        description: "The message content to send to Slack. Can include markdown formatting.",
-      },
-    },
-  },
-  name: "sendMessage",
-  provider: "slack",
-};
+        "description": "Sends a message to a Slack channel",
+        "scopes": [
+            "chat:write"
+        ],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "channelName",
+                "message"
+            ],
+            "properties": {
+                "channelName": {
+                    "type": "string",
+                    "description": "The name of the Slack channel to send the message to (e.g. general, alerts)"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "The message content to send to Slack. Can include markdown formatting."
+                }
+            }
+        },
+        "name": "sendMessage",
+        "provider": "slack"
+    };
 export const slackListConversationsDefinition: ActionTemplate = {
-  description: "Lists all conversations in a Slack workspace",
-  scopes: ["channels:read", "groups:read", "im:read", "mpim:read"],
-  output: {
-    type: "object",
-    required: ["channels"],
-    properties: {
-      channels: {
-        type: "array",
-        description: "A list of channels in Slack",
-        items: {
-          type: "object",
-          description: "A channel in Slack",
-          required: ["id", "name", "topic", "purpose"],
-          properties: {
-            id: {
-              type: "string",
-              description: "The ID of the channel",
-            },
-            name: {
-              type: "string",
-              description: "The name of the channel",
-            },
-            topic: {
-              type: "string",
-              description: "The topic of the channel",
-            },
-            purpose: {
-              type: "string",
-              description: "The purpose of the channel",
-            },
-          },
+        "description": "Lists all conversations in a Slack workspace",
+        "scopes": [
+            "channels:read",
+            "groups:read",
+            "im:read",
+            "mpim:read"
+        ],
+        "output": {
+            "type": "object",
+            "required": [
+                "channels"
+            ],
+            "properties": {
+                "channels": {
+                    "type": "array",
+                    "description": "A list of channels in Slack",
+                    "items": {
+                        "type": "object",
+                        "description": "A channel in Slack",
+                        "required": [
+                            "id",
+                            "name",
+                            "topic",
+                            "purpose"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "The ID of the channel"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the channel"
+                            },
+                            "topic": {
+                                "type": "string",
+                                "description": "The topic of the channel"
+                            },
+                            "purpose": {
+                                "type": "string",
+                                "description": "The purpose of the channel"
+                            }
+                        }
+                    }
+                }
+            }
         },
-      },
-    },
-  },
-  name: "listConversations",
-  provider: "slack",
-};
+        "name": "listConversations",
+        "provider": "slack"
+    };
 export const mathAddDefinition: ActionTemplate = {
-  description: "Adds two numbers together",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["a", "b"],
-    properties: {
-      a: {
-        type: "number",
-        description: "The first number to add",
-      },
-      b: {
-        type: "number",
-        description: "The second number to add",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["result"],
-    properties: {
-      result: {
-        type: "number",
-        description: "The sum of the two numbers",
-      },
-    },
-  },
-  name: "add",
-  provider: "math",
-};
+        "description": "Adds two numbers together",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "a",
+                "b"
+            ],
+            "properties": {
+                "a": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "b": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "result"
+            ],
+            "properties": {
+                "result": {
+                    "type": "number",
+                    "description": "The sum of the two numbers"
+                }
+            }
+        },
+        "name": "add",
+        "provider": "math"
+    };
 export const confluenceUpdatePageDefinition: ActionTemplate = {
-  description: "Updates a Confluence page with the new content specified",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["pageId", "title", "username", "content"],
-    properties: {
-      pageId: {
-        type: "string",
-        description: "The page id that should be updated",
-      },
-      title: {
-        type: "string",
-        description: "The title of the page that should be updated",
-      },
-      username: {
-        type: "string",
-        description: "The username of the person updating the page",
-      },
-      content: {
-        type: "string",
-        description: "The new content for the page",
-      },
-    },
-  },
-  name: "updatePage",
-  provider: "confluence",
-};
+        "description": "Updates a Confluence page with the new content specified",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "pageId",
+                "title",
+                "username",
+                "content"
+            ],
+            "properties": {
+                "pageId": {
+                    "type": "string",
+                    "description": "The page id that should be updated"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "The title of the page that should be updated"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "The username of the person updating the page"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The new content for the page"
+                }
+            }
+        },
+        "name": "updatePage",
+        "provider": "confluence"
+    };
 export const jiraCreateJiraTicketDefinition: ActionTemplate = {
-  description: "Create a jira ticket with new content specified",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["projectKey", "summary", "description", "issueType"],
-    properties: {
-      projectKey: {
-        type: "string",
-        description: "The key for the project you want to add it to",
-      },
-      summary: {
-        type: "string",
-        description: "The summary of the new ticket",
-      },
-      description: {
-        type: "string",
-        description: "The description for the new ticket",
-      },
-      issueType: {
-        type: "string",
-        description: "The issue type of the new ticket",
-      },
-      reporter: {
-        type: "string",
-        description: "The reporter for the new ticket creation",
-      },
-      assignee: {
-        type: "string",
-        description: "The assignee for the new ticket creation",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["ticketUrl"],
-    properties: {
-      ticketUrl: {
-        type: "string",
-        description: "The url to the created Jira Ticket",
-      },
-    },
-  },
-  name: "createJiraTicket",
-  provider: "jira",
-};
+        "description": "Create a jira ticket with new content specified",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "projectKey",
+                "summary",
+                "description",
+                "issueType"
+            ],
+            "properties": {
+                "projectKey": {
+                    "type": "string",
+                    "description": "The key for the project you want to add it to"
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "The summary of the new ticket"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "The description for the new ticket"
+                },
+                "issueType": {
+                    "type": "string",
+                    "description": "The issue type of the new ticket"
+                },
+                "reporter": {
+                    "type": "string",
+                    "description": "The reporter for the new ticket creation"
+                },
+                "assignee": {
+                    "type": "string",
+                    "description": "The assignee for the new ticket creation"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "ticketUrl"
+            ],
+            "properties": {
+                "ticketUrl": {
+                    "type": "string",
+                    "description": "The url to the created Jira Ticket"
+                }
+            }
+        },
+        "name": "createJiraTicket",
+        "provider": "jira"
+    };
 export const googlemapsValidateAddressDefinition: ActionTemplate = {
-  description: "Validate a Google Maps address",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["regionCode", "locality", "addressLines", "postalCode"],
-    properties: {
-      regionCode: {
-        type: "string",
-        description: "The country of the address being verified.",
-      },
-      locality: {
-        type: "string",
-        description: "The locality of the address being verified. This is likely a city.",
-      },
-      postalCode: {
-        type: "string",
-        description: "The postal code of the address being verified.",
-      },
-      addressLines: {
-        type: "array",
-        description: "A list of lines of the address. These should be in order as they would appear on an envelope.",
-        items: {
-          type: "string",
-        },
-      },
-      addressType: {
-        type: "string",
-        description: "The type of address being validated.",
-        enum: ["residential", "business", "poBox"],
-      },
-      allowFuzzyMatches: {
-        type: "boolean",
-        description: "Whether to allow fuzzy matches in the address validation by inferring components.",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["valid"],
-    properties: {
-      valid: {
-        type: "boolean",
-        description: "Whether the address is valid.",
-      },
-      formattedAddress: {
-        type: "string",
-        description: "The standardized formatted address.",
-      },
-      addressComponents: {
-        type: "array",
-        description: "Components of the address, such as street number and route.",
-        items: {
-          type: "object",
-          properties: {
-            componentName: {
-              type: "string",
-              description: "The name of the address component.",
-            },
-            componentType: {
-              type: "array",
-              description: "The types associated with this component (e.g., street_number, route).",
-              items: {
-                type: "string",
-              },
-            },
-          },
-        },
-      },
-      missingComponentTypes: {
-        type: "array",
-        description: "List of components missing in the input address.",
-        items: {
-          type: "string",
-        },
-      },
-      unresolvedTokens: {
-        type: "array",
-        description: "Unrecognized parts of the address.",
-        items: {
-          type: "string",
-        },
-      },
-      geocode: {
-        type: "object",
-        description: "Geocode data for the address.",
-        properties: {
-          location: {
-            type: "object",
-            properties: {
-              latitude: {
-                type: "number",
-                description: "The latitude of the address.",
-              },
-              longitude: {
-                type: "number",
-                description: "The longitude of the address.",
-              },
-            },
-          },
-          plusCode: {
-            type: "object",
-            description: "The Plus Code for the address.",
-            properties: {
-              globalCode: {
-                type: "string",
-                description: "The global Plus Code.",
-              },
-              compoundCode: {
-                type: "string",
-                description: "The compound Plus Code.",
-              },
-            },
-          },
-          bounds: {
-            type: "object",
-            description: "The viewport bounds for the address.",
-            properties: {
-              northeast: {
-                type: "object",
-                properties: {
-                  latitude: {
-                    type: "number",
-                  },
-                  longitude: {
-                    type: "number",
-                  },
+        "description": "Validate a Google Maps address",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "regionCode",
+                "locality",
+                "addressLines",
+                "postalCode"
+            ],
+            "properties": {
+                "regionCode": {
+                    "type": "string",
+                    "description": "The country of the address being verified."
                 },
-              },
-              southwest: {
-                type: "object",
-                properties: {
-                  latitude: {
-                    type: "number",
-                  },
-                  longitude: {
-                    type: "number",
-                  },
+                "locality": {
+                    "type": "string",
+                    "description": "The locality of the address being verified. This is likely a city."
                 },
-              },
-            },
-          },
+                "postalCode": {
+                    "type": "string",
+                    "description": "The postal code of the address being verified."
+                },
+                "addressLines": {
+                    "type": "array",
+                    "description": "A list of lines of the address. These should be in order as they would appear on an envelope.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "addressType": {
+                    "type": "string",
+                    "description": "The type of address being validated.",
+                    "enum": [
+                        "residential",
+                        "business",
+                        "poBox"
+                    ]
+                },
+                "allowFuzzyMatches": {
+                    "type": "boolean",
+                    "description": "Whether to allow fuzzy matches in the address validation by inferring components."
+                }
+            }
         },
-      },
-      uspsData: {
-        type: "object",
-        description: "USPS-specific validation details.",
-        properties: {
-          standardizedAddress: {
-            type: "object",
-            description: "The standardized USPS address.",
-          },
-          deliveryPointValidation: {
-            type: "string",
-            description: "The USPS delivery point validation status.",
-          },
-          uspsAddressPrecision: {
-            type: "string",
-            description: "The level of precision for the USPS address.",
-          },
+        "output": {
+            "type": "object",
+            "required": [
+                "valid"
+            ],
+            "properties": {
+                "valid": {
+                    "type": "boolean",
+                    "description": "Whether the address is valid."
+                },
+                "formattedAddress": {
+                    "type": "string",
+                    "description": "The standardized formatted address."
+                },
+                "addressComponents": {
+                    "type": "array",
+                    "description": "Components of the address, such as street number and route.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "componentName": {
+                                "type": "string",
+                                "description": "The name of the address component."
+                            },
+                            "componentType": {
+                                "type": "array",
+                                "description": "The types associated with this component (e.g., street_number, route).",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "missingComponentTypes": {
+                    "type": "array",
+                    "description": "List of components missing in the input address.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "unresolvedTokens": {
+                    "type": "array",
+                    "description": "Unrecognized parts of the address.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "geocode": {
+                    "type": "object",
+                    "description": "Geocode data for the address.",
+                    "properties": {
+                        "location": {
+                            "type": "object",
+                            "properties": {
+                                "latitude": {
+                                    "type": "number",
+                                    "description": "The latitude of the address."
+                                },
+                                "longitude": {
+                                    "type": "number",
+                                    "description": "The longitude of the address."
+                                }
+                            }
+                        },
+                        "plusCode": {
+                            "type": "object",
+                            "description": "The Plus Code for the address.",
+                            "properties": {
+                                "globalCode": {
+                                    "type": "string",
+                                    "description": "The global Plus Code."
+                                },
+                                "compoundCode": {
+                                    "type": "string",
+                                    "description": "The compound Plus Code."
+                                }
+                            }
+                        },
+                        "bounds": {
+                            "type": "object",
+                            "description": "The viewport bounds for the address.",
+                            "properties": {
+                                "northeast": {
+                                    "type": "object",
+                                    "properties": {
+                                        "latitude": {
+                                            "type": "number"
+                                        },
+                                        "longitude": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "southwest": {
+                                    "type": "object",
+                                    "properties": {
+                                        "latitude": {
+                                            "type": "number"
+                                        },
+                                        "longitude": {
+                                            "type": "number"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "uspsData": {
+                    "type": "object",
+                    "description": "USPS-specific validation details.",
+                    "properties": {
+                        "standardizedAddress": {
+                            "type": "object",
+                            "description": "The standardized USPS address."
+                        },
+                        "deliveryPointValidation": {
+                            "type": "string",
+                            "description": "The USPS delivery point validation status."
+                        },
+                        "uspsAddressPrecision": {
+                            "type": "string",
+                            "description": "The level of precision for the USPS address."
+                        }
+                    }
+                }
+            }
         },
-      },
-    },
-  },
-  name: "validateAddress",
-  provider: "googlemaps",
-};
+        "name": "validateAddress",
+        "provider": "googlemaps"
+    };
 export const googlemapsNearbysearchRestaurantsDefinition: ActionTemplate = {
-  description: "Search for nearby places using Google Maps",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["latitude", "longitude"],
-    properties: {
-      latitude: {
-        type: "number",
-        description: "The latitude of the location to search nearby",
-      },
-      longitude: {
-        type: "number",
-        description: "The longitude of the location to search nearby",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["results"],
-    properties: {
-      results: {
-        type: "array",
-        description: "The results of the nearby search",
-        items: {
-          type: "object",
-          properties: {
-            name: {
-              type: "string",
-              description: "The name of the place",
-            },
-            address: {
-              type: "string",
-              description: "The address of the place",
-            },
-            rating: {
-              type: "number",
-              description: "The rating of the place",
-            },
-            priceLevel: {
-              type: "string",
-              description: "The price level of the place",
-            },
-            openingHours: {
-              type: "string",
-              description: "The opening hours of the place",
-            },
-            primaryType: {
-              type: "string",
-              description: "The primary type of the place",
-            },
-            editorialSummary: {
-              type: "string",
-              description: "The editorial summary of the place",
-            },
-            websiteUri: {
-              type: "string",
-              description: "The website URI of the place",
-            },
-          },
+        "description": "Search for nearby places using Google Maps",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "latitude",
+                "longitude"
+            ],
+            "properties": {
+                "latitude": {
+                    "type": "number",
+                    "description": "The latitude of the location to search nearby"
+                },
+                "longitude": {
+                    "type": "number",
+                    "description": "The longitude of the location to search nearby"
+                }
+            }
         },
-      },
-    },
-  },
-  name: "nearbysearchRestaurants",
-  provider: "googlemaps",
-};
+        "output": {
+            "type": "object",
+            "required": [
+                "results"
+            ],
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "description": "The results of the nearby search",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the place"
+                            },
+                            "address": {
+                                "type": "string",
+                                "description": "The address of the place"
+                            },
+                            "rating": {
+                                "type": "number",
+                                "description": "The rating of the place"
+                            },
+                            "priceLevel": {
+                                "type": "string",
+                                "description": "The price level of the place"
+                            },
+                            "openingHours": {
+                                "type": "string",
+                                "description": "The opening hours of the place"
+                            },
+                            "primaryType": {
+                                "type": "string",
+                                "description": "The primary type of the place"
+                            },
+                            "editorialSummary": {
+                                "type": "string",
+                                "description": "The editorial summary of the place"
+                            },
+                            "websiteUri": {
+                                "type": "string",
+                                "description": "The website URI of the place"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "name": "nearbysearchRestaurants",
+        "provider": "googlemaps"
+    };
 export const credalCallCopilotDefinition: ActionTemplate = {
-  description: "Call Credal Copilot for response on a given query",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["agentId", "query", "userEmail"],
-    properties: {
-      agentId: {
-        type: "string",
-        description: "The ID of the copilot to call",
-      },
-      query: {
-        type: "string",
-        description: "The query to ask Credal Copilot",
-      },
-      userEmail: {
-        type: "string",
-        description: "The email of the user sending or authorizing the query",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["response"],
-    properties: {
-      response: {
-        type: "string",
-        description: "The response from the Credal Copilot",
-      },
-    },
-  },
-  name: "callCopilot",
-  provider: "credal",
-};
+        "description": "Call Credal Copilot for response on a given query",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "agentId",
+                "query",
+                "userEmail"
+            ],
+            "properties": {
+                "agentId": {
+                    "type": "string",
+                    "description": "The ID of the copilot to call"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "The query to ask Credal Copilot"
+                },
+                "userEmail": {
+                    "type": "string",
+                    "description": "The email of the user sending or authorizing the query"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "response"
+            ],
+            "properties": {
+                "response": {
+                    "type": "string",
+                    "description": "The response from the Credal Copilot"
+                }
+            }
+        },
+        "name": "callCopilot",
+        "provider": "credal"
+    };
 export const zendeskCreateZendeskTicketDefinition: ActionTemplate = {
-  description: "Create a ticket in Zendesk",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["subject", "requesterEmail", "subdomain"],
-    properties: {
-      subject: {
-        type: "string",
-        description: "The subject of the ticket",
-      },
-      body: {
-        type: "string",
-        description: "The body of the ticket",
-      },
-      requesterEmail: {
-        type: "string",
-        description: "The email of the requester",
-      },
-      subdomain: {
-        type: "string",
-        description: "The subdomain of the Zendesk account",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["ticketId"],
-    properties: {
-      ticketId: {
-        type: "string",
-        description: "The ID of the ticket created",
-      },
-      ticketUrl: {
-        type: "string",
-        description: "The URL of the ticket created",
-      },
-    },
-  },
-  name: "createZendeskTicket",
-  provider: "zendesk",
-};
+        "description": "Create a ticket in Zendesk",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "subject",
+                "requesterEmail",
+                "subdomain"
+            ],
+            "properties": {
+                "subject": {
+                    "type": "string",
+                    "description": "The subject of the ticket"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "The body of the ticket"
+                },
+                "requesterEmail": {
+                    "type": "string",
+                    "description": "The email of the requester"
+                },
+                "subdomain": {
+                    "type": "string",
+                    "description": "The subdomain of the Zendesk account"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "ticketId"
+            ],
+            "properties": {
+                "ticketId": {
+                    "type": "string",
+                    "description": "The ID of the ticket created"
+                },
+                "ticketUrl": {
+                    "type": "string",
+                    "description": "The URL of the ticket created"
+                }
+            }
+        },
+        "name": "createZendeskTicket",
+        "provider": "zendesk"
+    };
 export const linkedinCreateShareLinkedinPostUrlDefinition: ActionTemplate = {
-  description: "Create a share linkedin post link",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: [],
-    properties: {
-      text: {
-        type: "string",
-        description: "The text for the linkedin post",
-      },
-      url: {
-        type: "string",
-        description: "The url for the linkedin post",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["linkedinUrl"],
-    properties: {
-      linkedinUrl: {
-        type: "string",
-        description: "The share post linkedin URL",
-      },
-    },
-  },
-  name: "createShareLinkedinPostUrl",
-  provider: "linkedin",
-};
+        "description": "Create a share linkedin post link",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text for the linkedin post"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The url for the linkedin post"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "linkedinUrl"
+            ],
+            "properties": {
+                "linkedinUrl": {
+                    "type": "string",
+                    "description": "The share post linkedin URL"
+                }
+            }
+        },
+        "name": "createShareLinkedinPostUrl",
+        "provider": "linkedin"
+    };
 export const xCreateShareXPostUrlDefinition: ActionTemplate = {
-  description: "Create a share X (formerly twitter) post link",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["text"],
-    properties: {
-      text: {
-        type: "string",
-        description: "The text for the X(formerly twitter) post",
-      },
-      url: {
-        type: "string",
-        description: "The url for the X(formerly twitter) post",
-      },
-      hashtag: {
-        type: "array",
-        description: "List of hashtags to include in the X post",
-        items: {
-          type: "string",
+        "description": "Create a share X (formerly twitter) post link",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text for the X(formerly twitter) post"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The url for the X(formerly twitter) post"
+                },
+                "hashtag": {
+                    "type": "array",
+                    "description": "List of hashtags to include in the X post",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "via": {
+                    "type": "string",
+                    "description": "The twitter username to associate with the tweet"
+                },
+                "inReplyTo": {
+                    "type": "string",
+                    "description": "The tweet ID to reply to"
+                }
+            }
         },
-      },
-      via: {
-        type: "string",
-        description: "The twitter username to associate with the tweet",
-      },
-      inReplyTo: {
-        type: "string",
-        description: "The tweet ID to reply to",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["xUrl"],
-    properties: {
-      xUrl: {
-        type: "string",
-        description: "The share post X(formerly twitter) URL",
-      },
-    },
-  },
-  name: "createShareXPostUrl",
-  provider: "x",
-};
-export const xScrapePostDataWithNitterDefinition: ActionTemplate = {
-  description: "Given A tweet URL scrape the tweet data with nitter+firecrawl",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["tweetUrl"],
-    properties: {
-      tweetUrl: {
-        type: "string",
-        description: "The url for the X(formerly twitter) post",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["text"],
-    properties: {
-      text: {
-        type: "string",
-        description: "The text in the tweet URL",
-      },
-    },
-  },
-  name: "scrapePostDataWithNitter",
-  provider: "x",
-};
+        "output": {
+            "type": "object",
+            "required": [
+                "xUrl"
+            ],
+            "properties": {
+                "xUrl": {
+                    "type": "string",
+                    "description": "The share post X(formerly twitter) URL"
+                }
+            }
+        },
+        "name": "createShareXPostUrl",
+        "provider": "x"
+    };
 export const mongoInsertMongoDocDefinition: ActionTemplate = {
-  description: "Insert a document into a MongoDB collection",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["databaseName", "collectionName", "document"],
-    properties: {
-      databaseName: {
-        type: "string",
-        description: "Database to connect to",
-      },
-      collectionName: {
-        type: "string",
-        description: "Collection to insert the document into",
-      },
-      document: {
-        type: "object",
-        description: "The document to insert",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["objectId"],
-    properties: {
-      objectId: {
-        type: "string",
-        description: "The new ID of the document inserted",
-      },
-    },
-  },
-  name: "insertMongoDoc",
-  provider: "mongo",
-};
+        "description": "Insert a document into a MongoDB collection",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "databaseName",
+                "collectionName",
+                "document"
+            ],
+            "properties": {
+                "databaseName": {
+                    "type": "string",
+                    "description": "Database to connect to"
+                },
+                "collectionName": {
+                    "type": "string",
+                    "description": "Collection to insert the document into"
+                },
+                "document": {
+                    "type": "object",
+                    "description": "The document to insert"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "objectId"
+            ],
+            "properties": {
+                "objectId": {
+                    "type": "string",
+                    "description": "The new ID of the document inserted"
+                }
+            }
+        },
+        "name": "insertMongoDoc",
+        "provider": "mongo"
+    };
 export const snowflakeGetRowByFieldValueDefinition: ActionTemplate = {
-  description: "Get a row from a Snowflake table by a field value",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["tableName", "fieldName", "fieldValue"],
-    properties: {
-      databaseName: {
-        type: "string",
-        description: "The name of the database to query",
-      },
-      tableName: {
-        type: "string",
-        description: "The name of the table to query",
-      },
-      fieldName: {
-        type: "string",
-        description: "The name of the field to query",
-      },
-      fieldValue: {
-        type: "string",
-        description: "The value of the field to query",
-      },
-      accountName: {
-        type: "string",
-        description: "The name of the Snowflake account",
-      },
-      user: {
-        type: "string",
-        description: "The user to authenticate with",
-      },
-      warehouse: {
-        type: "string",
-        description: "The warehouse to use",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["row"],
-    properties: {
-      row: {
-        type: "object",
-        description: "The row from the Snowflake table",
-        properties: {
-          id: {
-            type: "string",
-            description: "The ID of the row",
-          },
-          rowContents: {
-            type: "object",
-            description: "The contents of the row",
-          },
+        "description": "Get a row from a Snowflake table by a field value",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "tableName",
+                "fieldName",
+                "fieldValue"
+            ],
+            "properties": {
+                "databaseName": {
+                    "type": "string",
+                    "description": "The name of the database to query"
+                },
+                "tableName": {
+                    "type": "string",
+                    "description": "The name of the table to query"
+                },
+                "fieldName": {
+                    "type": "string",
+                    "description": "The name of the field to query"
+                },
+                "fieldValue": {
+                    "type": "string",
+                    "description": "The value of the field to query"
+                },
+                "accountName": {
+                    "type": "string",
+                    "description": "The name of the Snowflake account"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "The user to authenticate with"
+                },
+                "warehouse": {
+                    "type": "string",
+                    "description": "The warehouse to use"
+                }
+            }
         },
-      },
-    },
-  },
-  name: "getRowByFieldValue",
-  provider: "snowflake",
-};
+        "output": {
+            "type": "object",
+            "required": [
+                "row"
+            ],
+            "properties": {
+                "row": {
+                    "type": "object",
+                    "description": "The row from the Snowflake table",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "The ID of the row"
+                        },
+                        "rowContents": {
+                            "type": "object",
+                            "description": "The contents of the row"
+                        }
+                    }
+                }
+            }
+        },
+        "name": "getRowByFieldValue",
+        "provider": "snowflake"
+    };
 export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemplate = {
-  description: "Get the latitude and longitude of a location",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["location"],
-    properties: {
-      location: {
-        type: "string",
-        description: "The location to get the latitude and longitude of",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: [],
-    properties: {
-      results: {
-        type: "array",
-        description: "The results of the query",
-        items: {
-          type: "object",
-          required: ["latitude", "longitude", "display_name"],
-          properties: {
-            latitude: {
-              type: "number",
-              description: "The latitude of the location",
-            },
-            longitude: {
-              type: "number",
-              description: "The longitude of the location",
-            },
-            display_name: {
-              type: "string",
-              description: "The display name of the location",
-            },
-          },
+        "description": "Get the latitude and longitude of a location",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The location to get the latitude and longitude of"
+                }
+            }
         },
-      },
-    },
-  },
-  name: "getLatitudeLongitudeFromLocation",
-  provider: "openstreetmap",
-};
+        "output": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "description": "The results of the query",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "latitude",
+                            "longitude",
+                            "display_name"
+                        ],
+                        "properties": {
+                            "latitude": {
+                                "type": "number",
+                                "description": "The latitude of the location"
+                            },
+                            "longitude": {
+                                "type": "number",
+                                "description": "The longitude of the location"
+                            },
+                            "display_name": {
+                                "type": "string",
+                                "description": "The display name of the location"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "name": "getLatitudeLongitudeFromLocation",
+        "provider": "openstreetmap"
+    };
 export const nwsGetForecastForLocationDefinition: ActionTemplate = {
-  description: "Get the weather forecast for a location using latitude and longitude",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["latitude", "longitude", "isoDate"],
-    properties: {
-      latitude: {
-        type: "number",
-        description: "The latitude of the location",
-      },
-      longitude: {
-        type: "number",
-        description: "The longitude of the location",
-      },
-      isoDate: {
-        type: "string",
-        description: "The date to get the forecast for, in ISO datetime format",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: [],
-    properties: {
-      result: {
-        type: "object",
-        required: ["temperature", "temperatureUnit", "forecast"],
-        properties: {
-          temperature: {
-            type: "number",
-            description: "The temperature at the location",
-          },
-          temperatureUnit: {
-            type: "string",
-            description: "The unit of temperature",
-          },
-          forecast: {
-            type: "string",
-            description: "The forecast for the location",
-          },
+        "description": "Get the weather forecast for a location using latitude and longitude",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "latitude",
+                "longitude",
+                "isoDate"
+            ],
+            "properties": {
+                "latitude": {
+                    "type": "number",
+                    "description": "The latitude of the location"
+                },
+                "longitude": {
+                    "type": "number",
+                    "description": "The longitude of the location"
+                },
+                "isoDate": {
+                    "type": "string",
+                    "description": "The date to get the forecast for, in ISO datetime format"
+                }
+            }
         },
-      },
-    },
-  },
-  name: "getForecastForLocation",
-  provider: "nws",
-};
+        "output": {
+            "type": "object",
+            "required": [],
+            "properties": {
+                "result": {
+                    "type": "object",
+                    "required": [
+                        "temperature",
+                        "temperatureUnit",
+                        "forecast"
+                    ],
+                    "properties": {
+                        "temperature": {
+                            "type": "number",
+                            "description": "The temperature at the location"
+                        },
+                        "temperatureUnit": {
+                            "type": "string",
+                            "description": "The unit of temperature"
+                        },
+                        "forecast": {
+                            "type": "string",
+                            "description": "The forecast for the location"
+                        }
+                    }
+                }
+            }
+        },
+        "name": "getForecastForLocation",
+        "provider": "nws"
+    };
 export const firecrawlScrapeUrlDefinition: ActionTemplate = {
-  description: "Scrape a URL and get website content using Firecrawl",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["url"],
-    properties: {
-      url: {
-        type: "string",
-        description: "The URL to scrape",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["content"],
-    properties: {
-      content: {
-        type: "string",
-        description: "The content of the URL",
-      },
-    },
-  },
-  name: "scrapeUrl",
-  provider: "firecrawl",
-};
+        "description": "Scrape a URL and get website content using Firecrawl",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to scrape"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The content of the URL"
+                }
+            }
+        },
+        "name": "scrapeUrl",
+        "provider": "firecrawl"
+    };
+export const firecrawlScrapeTweetDataWithNitterDefinition: ActionTemplate = {
+        "description": "Given A tweet URL scrape the tweet data with nitter+firecrawl",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "tweetUrl"
+            ],
+            "properties": {
+                "tweetUrl": {
+                    "type": "string",
+                    "description": "The url for the X(formerly twitter) post"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text in the tweet URL"
+                }
+            }
+        },
+        "name": "scrapeTweetDataWithNitter",
+        "provider": "firecrawl"
+    };
 export const resendSendEmailDefinition: ActionTemplate = {
-  description: "Send an email using Resend",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["to", "subject", "content"],
-    properties: {
-      to: {
-        type: "string",
-        description: "The email address to send the email to",
-      },
-      subject: {
-        type: "string",
-        description: "The subject of the email",
-      },
-      content: {
-        type: "string",
-        description: "The content of the email",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["success"],
-    properties: {
-      success: {
-        type: "boolean",
-        description: "Whether the email was sent successfully",
-      },
-      error: {
-        type: "string",
-        description: "The error that occurred if the email was not sent successfully",
-      },
-    },
-  },
-  name: "sendEmail",
-  provider: "resend",
-};
+        "description": "Send an email using Resend",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "to",
+                "subject",
+                "content"
+            ],
+            "properties": {
+                "to": {
+                    "type": "string",
+                    "description": "The email address to send the email to"
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "The subject of the email"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The content of the email"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "properties": {
+                "success": {
+                    "type": "boolean",
+                    "description": "Whether the email was sent successfully"
+                },
+                "error": {
+                    "type": "string",
+                    "description": "The error that occurred if the email was not sent successfully"
+                }
+            }
+        },
+        "name": "sendEmail",
+        "provider": "resend"
+    };
 export const googleOauthCreateNewGoogleDocDefinition: ActionTemplate = {
-  description: "Create a new Google Docs document using OAuth authentication",
-  scopes: [],
-  parameters: {
-    type: "object",
-    required: ["title"],
-    properties: {
-      title: {
-        type: "string",
-        description: "The title of the new Google Doc",
-      },
-      content: {
-        type: "string",
-        description: "The content to add to the new Google Doc",
-      },
-    },
-  },
-  output: {
-    type: "object",
-    required: ["documentId"],
-    properties: {
-      documentId: {
-        type: "string",
-        description: "The ID of the created Google Doc",
-      },
-      documentUrl: {
-        type: "string",
-        description: "The URL to access the created Google Doc",
-      },
-    },
-  },
-  name: "createNewGoogleDoc",
-  provider: "googleOauth",
-};
+        "description": "Create a new Google Docs document using OAuth authentication",
+        "scopes": [],
+        "parameters": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "The title of the new Google Doc"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The content to add to the new Google Doc"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "documentId"
+            ],
+            "properties": {
+                "documentId": {
+                    "type": "string",
+                    "description": "The ID of the created Google Doc"
+                },
+                "documentUrl": {
+                    "type": "string",
+                    "description": "The URL to access the created Google Doc"
+                }
+            }
+        },
+        "name": "createNewGoogleDoc",
+        "provider": "googleOauth"
+    };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1,972 +1,860 @@
 import { ActionTemplate } from "../../actions/parse";
 
 export const slackSendMessageDefinition: ActionTemplate = {
-        "description": "Sends a message to a Slack channel",
-        "scopes": [
-            "chat:write"
-        ],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "channelName",
-                "message"
-            ],
-            "properties": {
-                "channelName": {
-                    "type": "string",
-                    "description": "The name of the Slack channel to send the message to (e.g. general, alerts)"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "The message content to send to Slack. Can include markdown formatting."
-                }
-            }
-        },
-        "name": "sendMessage",
-        "provider": "slack"
-    };
+  description: "Sends a message to a Slack channel",
+  scopes: ["chat:write"],
+  parameters: {
+    type: "object",
+    required: ["channelName", "message"],
+    properties: {
+      channelName: {
+        type: "string",
+        description: "The name of the Slack channel to send the message to (e.g. general, alerts)",
+      },
+      message: {
+        type: "string",
+        description: "The message content to send to Slack. Can include markdown formatting.",
+      },
+    },
+  },
+  name: "sendMessage",
+  provider: "slack",
+};
 export const slackListConversationsDefinition: ActionTemplate = {
-        "description": "Lists all conversations in a Slack workspace",
-        "scopes": [
-            "channels:read",
-            "groups:read",
-            "im:read",
-            "mpim:read"
-        ],
-        "output": {
-            "type": "object",
-            "required": [
-                "channels"
-            ],
-            "properties": {
-                "channels": {
-                    "type": "array",
-                    "description": "A list of channels in Slack",
-                    "items": {
-                        "type": "object",
-                        "description": "A channel in Slack",
-                        "required": [
-                            "id",
-                            "name",
-                            "topic",
-                            "purpose"
-                        ],
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "description": "The ID of the channel"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "The name of the channel"
-                            },
-                            "topic": {
-                                "type": "string",
-                                "description": "The topic of the channel"
-                            },
-                            "purpose": {
-                                "type": "string",
-                                "description": "The purpose of the channel"
-                            }
-                        }
-                    }
-                }
-            }
+  description: "Lists all conversations in a Slack workspace",
+  scopes: ["channels:read", "groups:read", "im:read", "mpim:read"],
+  output: {
+    type: "object",
+    required: ["channels"],
+    properties: {
+      channels: {
+        type: "array",
+        description: "A list of channels in Slack",
+        items: {
+          type: "object",
+          description: "A channel in Slack",
+          required: ["id", "name", "topic", "purpose"],
+          properties: {
+            id: {
+              type: "string",
+              description: "The ID of the channel",
+            },
+            name: {
+              type: "string",
+              description: "The name of the channel",
+            },
+            topic: {
+              type: "string",
+              description: "The topic of the channel",
+            },
+            purpose: {
+              type: "string",
+              description: "The purpose of the channel",
+            },
+          },
         },
-        "name": "listConversations",
-        "provider": "slack"
-    };
+      },
+    },
+  },
+  name: "listConversations",
+  provider: "slack",
+};
 export const mathAddDefinition: ActionTemplate = {
-        "description": "Adds two numbers together",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "a",
-                "b"
-            ],
-            "properties": {
-                "a": {
-                    "type": "number",
-                    "description": "The first number to add"
-                },
-                "b": {
-                    "type": "number",
-                    "description": "The second number to add"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "result"
-            ],
-            "properties": {
-                "result": {
-                    "type": "number",
-                    "description": "The sum of the two numbers"
-                }
-            }
-        },
-        "name": "add",
-        "provider": "math"
-    };
+  description: "Adds two numbers together",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["a", "b"],
+    properties: {
+      a: {
+        type: "number",
+        description: "The first number to add",
+      },
+      b: {
+        type: "number",
+        description: "The second number to add",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["result"],
+    properties: {
+      result: {
+        type: "number",
+        description: "The sum of the two numbers",
+      },
+    },
+  },
+  name: "add",
+  provider: "math",
+};
 export const confluenceUpdatePageDefinition: ActionTemplate = {
-        "description": "Updates a Confluence page with the new content specified",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "pageId",
-                "title",
-                "username",
-                "content"
-            ],
-            "properties": {
-                "pageId": {
-                    "type": "string",
-                    "description": "The page id that should be updated"
-                },
-                "title": {
-                    "type": "string",
-                    "description": "The title of the page that should be updated"
-                },
-                "username": {
-                    "type": "string",
-                    "description": "The username of the person updating the page"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "The new content for the page"
-                }
-            }
-        },
-        "name": "updatePage",
-        "provider": "confluence"
-    };
+  description: "Updates a Confluence page with the new content specified",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["pageId", "title", "username", "content"],
+    properties: {
+      pageId: {
+        type: "string",
+        description: "The page id that should be updated",
+      },
+      title: {
+        type: "string",
+        description: "The title of the page that should be updated",
+      },
+      username: {
+        type: "string",
+        description: "The username of the person updating the page",
+      },
+      content: {
+        type: "string",
+        description: "The new content for the page",
+      },
+    },
+  },
+  name: "updatePage",
+  provider: "confluence",
+};
 export const jiraCreateJiraTicketDefinition: ActionTemplate = {
-        "description": "Create a jira ticket with new content specified",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "projectKey",
-                "summary",
-                "description",
-                "issueType"
-            ],
-            "properties": {
-                "projectKey": {
-                    "type": "string",
-                    "description": "The key for the project you want to add it to"
-                },
-                "summary": {
-                    "type": "string",
-                    "description": "The summary of the new ticket"
-                },
-                "description": {
-                    "type": "string",
-                    "description": "The description for the new ticket"
-                },
-                "issueType": {
-                    "type": "string",
-                    "description": "The issue type of the new ticket"
-                },
-                "reporter": {
-                    "type": "string",
-                    "description": "The reporter for the new ticket creation"
-                },
-                "assignee": {
-                    "type": "string",
-                    "description": "The assignee for the new ticket creation"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "ticketUrl"
-            ],
-            "properties": {
-                "ticketUrl": {
-                    "type": "string",
-                    "description": "The url to the created Jira Ticket"
-                }
-            }
-        },
-        "name": "createJiraTicket",
-        "provider": "jira"
-    };
+  description: "Create a jira ticket with new content specified",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["projectKey", "summary", "description", "issueType"],
+    properties: {
+      projectKey: {
+        type: "string",
+        description: "The key for the project you want to add it to",
+      },
+      summary: {
+        type: "string",
+        description: "The summary of the new ticket",
+      },
+      description: {
+        type: "string",
+        description: "The description for the new ticket",
+      },
+      issueType: {
+        type: "string",
+        description: "The issue type of the new ticket",
+      },
+      reporter: {
+        type: "string",
+        description: "The reporter for the new ticket creation",
+      },
+      assignee: {
+        type: "string",
+        description: "The assignee for the new ticket creation",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["ticketUrl"],
+    properties: {
+      ticketUrl: {
+        type: "string",
+        description: "The url to the created Jira Ticket",
+      },
+    },
+  },
+  name: "createJiraTicket",
+  provider: "jira",
+};
 export const googlemapsValidateAddressDefinition: ActionTemplate = {
-        "description": "Validate a Google Maps address",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "regionCode",
-                "locality",
-                "addressLines",
-                "postalCode"
-            ],
-            "properties": {
-                "regionCode": {
-                    "type": "string",
-                    "description": "The country of the address being verified."
-                },
-                "locality": {
-                    "type": "string",
-                    "description": "The locality of the address being verified. This is likely a city."
-                },
-                "postalCode": {
-                    "type": "string",
-                    "description": "The postal code of the address being verified."
-                },
-                "addressLines": {
-                    "type": "array",
-                    "description": "A list of lines of the address. These should be in order as they would appear on an envelope.",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "addressType": {
-                    "type": "string",
-                    "description": "The type of address being validated.",
-                    "enum": [
-                        "residential",
-                        "business",
-                        "poBox"
-                    ]
-                },
-                "allowFuzzyMatches": {
-                    "type": "boolean",
-                    "description": "Whether to allow fuzzy matches in the address validation by inferring components."
-                }
-            }
+  description: "Validate a Google Maps address",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["regionCode", "locality", "addressLines", "postalCode"],
+    properties: {
+      regionCode: {
+        type: "string",
+        description: "The country of the address being verified.",
+      },
+      locality: {
+        type: "string",
+        description: "The locality of the address being verified. This is likely a city.",
+      },
+      postalCode: {
+        type: "string",
+        description: "The postal code of the address being verified.",
+      },
+      addressLines: {
+        type: "array",
+        description: "A list of lines of the address. These should be in order as they would appear on an envelope.",
+        items: {
+          type: "string",
         },
-        "output": {
-            "type": "object",
-            "required": [
-                "valid"
-            ],
-            "properties": {
-                "valid": {
-                    "type": "boolean",
-                    "description": "Whether the address is valid."
-                },
-                "formattedAddress": {
-                    "type": "string",
-                    "description": "The standardized formatted address."
-                },
-                "addressComponents": {
-                    "type": "array",
-                    "description": "Components of the address, such as street number and route.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "componentName": {
-                                "type": "string",
-                                "description": "The name of the address component."
-                            },
-                            "componentType": {
-                                "type": "array",
-                                "description": "The types associated with this component (e.g., street_number, route).",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "missingComponentTypes": {
-                    "type": "array",
-                    "description": "List of components missing in the input address.",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "unresolvedTokens": {
-                    "type": "array",
-                    "description": "Unrecognized parts of the address.",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "geocode": {
-                    "type": "object",
-                    "description": "Geocode data for the address.",
-                    "properties": {
-                        "location": {
-                            "type": "object",
-                            "properties": {
-                                "latitude": {
-                                    "type": "number",
-                                    "description": "The latitude of the address."
-                                },
-                                "longitude": {
-                                    "type": "number",
-                                    "description": "The longitude of the address."
-                                }
-                            }
-                        },
-                        "plusCode": {
-                            "type": "object",
-                            "description": "The Plus Code for the address.",
-                            "properties": {
-                                "globalCode": {
-                                    "type": "string",
-                                    "description": "The global Plus Code."
-                                },
-                                "compoundCode": {
-                                    "type": "string",
-                                    "description": "The compound Plus Code."
-                                }
-                            }
-                        },
-                        "bounds": {
-                            "type": "object",
-                            "description": "The viewport bounds for the address.",
-                            "properties": {
-                                "northeast": {
-                                    "type": "object",
-                                    "properties": {
-                                        "latitude": {
-                                            "type": "number"
-                                        },
-                                        "longitude": {
-                                            "type": "number"
-                                        }
-                                    }
-                                },
-                                "southwest": {
-                                    "type": "object",
-                                    "properties": {
-                                        "latitude": {
-                                            "type": "number"
-                                        },
-                                        "longitude": {
-                                            "type": "number"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "uspsData": {
-                    "type": "object",
-                    "description": "USPS-specific validation details.",
-                    "properties": {
-                        "standardizedAddress": {
-                            "type": "object",
-                            "description": "The standardized USPS address."
-                        },
-                        "deliveryPointValidation": {
-                            "type": "string",
-                            "description": "The USPS delivery point validation status."
-                        },
-                        "uspsAddressPrecision": {
-                            "type": "string",
-                            "description": "The level of precision for the USPS address."
-                        }
-                    }
-                }
-            }
+      },
+      addressType: {
+        type: "string",
+        description: "The type of address being validated.",
+        enum: ["residential", "business", "poBox"],
+      },
+      allowFuzzyMatches: {
+        type: "boolean",
+        description: "Whether to allow fuzzy matches in the address validation by inferring components.",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["valid"],
+    properties: {
+      valid: {
+        type: "boolean",
+        description: "Whether the address is valid.",
+      },
+      formattedAddress: {
+        type: "string",
+        description: "The standardized formatted address.",
+      },
+      addressComponents: {
+        type: "array",
+        description: "Components of the address, such as street number and route.",
+        items: {
+          type: "object",
+          properties: {
+            componentName: {
+              type: "string",
+              description: "The name of the address component.",
+            },
+            componentType: {
+              type: "array",
+              description: "The types associated with this component (e.g., street_number, route).",
+              items: {
+                type: "string",
+              },
+            },
+          },
         },
-        "name": "validateAddress",
-        "provider": "googlemaps"
-    };
+      },
+      missingComponentTypes: {
+        type: "array",
+        description: "List of components missing in the input address.",
+        items: {
+          type: "string",
+        },
+      },
+      unresolvedTokens: {
+        type: "array",
+        description: "Unrecognized parts of the address.",
+        items: {
+          type: "string",
+        },
+      },
+      geocode: {
+        type: "object",
+        description: "Geocode data for the address.",
+        properties: {
+          location: {
+            type: "object",
+            properties: {
+              latitude: {
+                type: "number",
+                description: "The latitude of the address.",
+              },
+              longitude: {
+                type: "number",
+                description: "The longitude of the address.",
+              },
+            },
+          },
+          plusCode: {
+            type: "object",
+            description: "The Plus Code for the address.",
+            properties: {
+              globalCode: {
+                type: "string",
+                description: "The global Plus Code.",
+              },
+              compoundCode: {
+                type: "string",
+                description: "The compound Plus Code.",
+              },
+            },
+          },
+          bounds: {
+            type: "object",
+            description: "The viewport bounds for the address.",
+            properties: {
+              northeast: {
+                type: "object",
+                properties: {
+                  latitude: {
+                    type: "number",
+                  },
+                  longitude: {
+                    type: "number",
+                  },
+                },
+              },
+              southwest: {
+                type: "object",
+                properties: {
+                  latitude: {
+                    type: "number",
+                  },
+                  longitude: {
+                    type: "number",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      uspsData: {
+        type: "object",
+        description: "USPS-specific validation details.",
+        properties: {
+          standardizedAddress: {
+            type: "object",
+            description: "The standardized USPS address.",
+          },
+          deliveryPointValidation: {
+            type: "string",
+            description: "The USPS delivery point validation status.",
+          },
+          uspsAddressPrecision: {
+            type: "string",
+            description: "The level of precision for the USPS address.",
+          },
+        },
+      },
+    },
+  },
+  name: "validateAddress",
+  provider: "googlemaps",
+};
 export const googlemapsNearbysearchRestaurantsDefinition: ActionTemplate = {
-        "description": "Search for nearby places using Google Maps",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "latitude",
-                "longitude"
-            ],
-            "properties": {
-                "latitude": {
-                    "type": "number",
-                    "description": "The latitude of the location to search nearby"
-                },
-                "longitude": {
-                    "type": "number",
-                    "description": "The longitude of the location to search nearby"
-                }
-            }
+  description: "Search for nearby places using Google Maps",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["latitude", "longitude"],
+    properties: {
+      latitude: {
+        type: "number",
+        description: "The latitude of the location to search nearby",
+      },
+      longitude: {
+        type: "number",
+        description: "The longitude of the location to search nearby",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["results"],
+    properties: {
+      results: {
+        type: "array",
+        description: "The results of the nearby search",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the place",
+            },
+            address: {
+              type: "string",
+              description: "The address of the place",
+            },
+            rating: {
+              type: "number",
+              description: "The rating of the place",
+            },
+            priceLevel: {
+              type: "string",
+              description: "The price level of the place",
+            },
+            openingHours: {
+              type: "string",
+              description: "The opening hours of the place",
+            },
+            primaryType: {
+              type: "string",
+              description: "The primary type of the place",
+            },
+            editorialSummary: {
+              type: "string",
+              description: "The editorial summary of the place",
+            },
+            websiteUri: {
+              type: "string",
+              description: "The website URI of the place",
+            },
+          },
         },
-        "output": {
-            "type": "object",
-            "required": [
-                "results"
-            ],
-            "properties": {
-                "results": {
-                    "type": "array",
-                    "description": "The results of the nearby search",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "The name of the place"
-                            },
-                            "address": {
-                                "type": "string",
-                                "description": "The address of the place"
-                            },
-                            "rating": {
-                                "type": "number",
-                                "description": "The rating of the place"
-                            },
-                            "priceLevel": {
-                                "type": "string",
-                                "description": "The price level of the place"
-                            },
-                            "openingHours": {
-                                "type": "string",
-                                "description": "The opening hours of the place"
-                            },
-                            "primaryType": {
-                                "type": "string",
-                                "description": "The primary type of the place"
-                            },
-                            "editorialSummary": {
-                                "type": "string",
-                                "description": "The editorial summary of the place"
-                            },
-                            "websiteUri": {
-                                "type": "string",
-                                "description": "The website URI of the place"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "name": "nearbysearchRestaurants",
-        "provider": "googlemaps"
-    };
+      },
+    },
+  },
+  name: "nearbysearchRestaurants",
+  provider: "googlemaps",
+};
 export const credalCallCopilotDefinition: ActionTemplate = {
-        "description": "Call Credal Copilot for response on a given query",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "agentId",
-                "query",
-                "userEmail"
-            ],
-            "properties": {
-                "agentId": {
-                    "type": "string",
-                    "description": "The ID of the copilot to call"
-                },
-                "query": {
-                    "type": "string",
-                    "description": "The query to ask Credal Copilot"
-                },
-                "userEmail": {
-                    "type": "string",
-                    "description": "The email of the user sending or authorizing the query"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "response"
-            ],
-            "properties": {
-                "response": {
-                    "type": "string",
-                    "description": "The response from the Credal Copilot"
-                }
-            }
-        },
-        "name": "callCopilot",
-        "provider": "credal"
-    };
+  description: "Call Credal Copilot for response on a given query",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["agentId", "query", "userEmail"],
+    properties: {
+      agentId: {
+        type: "string",
+        description: "The ID of the copilot to call",
+      },
+      query: {
+        type: "string",
+        description: "The query to ask Credal Copilot",
+      },
+      userEmail: {
+        type: "string",
+        description: "The email of the user sending or authorizing the query",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["response"],
+    properties: {
+      response: {
+        type: "string",
+        description: "The response from the Credal Copilot",
+      },
+    },
+  },
+  name: "callCopilot",
+  provider: "credal",
+};
 export const zendeskCreateZendeskTicketDefinition: ActionTemplate = {
-        "description": "Create a ticket in Zendesk",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "subject",
-                "requesterEmail",
-                "subdomain"
-            ],
-            "properties": {
-                "subject": {
-                    "type": "string",
-                    "description": "The subject of the ticket"
-                },
-                "body": {
-                    "type": "string",
-                    "description": "The body of the ticket"
-                },
-                "requesterEmail": {
-                    "type": "string",
-                    "description": "The email of the requester"
-                },
-                "subdomain": {
-                    "type": "string",
-                    "description": "The subdomain of the Zendesk account"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "ticketId"
-            ],
-            "properties": {
-                "ticketId": {
-                    "type": "string",
-                    "description": "The ID of the ticket created"
-                },
-                "ticketUrl": {
-                    "type": "string",
-                    "description": "The URL of the ticket created"
-                }
-            }
-        },
-        "name": "createZendeskTicket",
-        "provider": "zendesk"
-    };
+  description: "Create a ticket in Zendesk",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["subject", "requesterEmail", "subdomain"],
+    properties: {
+      subject: {
+        type: "string",
+        description: "The subject of the ticket",
+      },
+      body: {
+        type: "string",
+        description: "The body of the ticket",
+      },
+      requesterEmail: {
+        type: "string",
+        description: "The email of the requester",
+      },
+      subdomain: {
+        type: "string",
+        description: "The subdomain of the Zendesk account",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["ticketId"],
+    properties: {
+      ticketId: {
+        type: "string",
+        description: "The ID of the ticket created",
+      },
+      ticketUrl: {
+        type: "string",
+        description: "The URL of the ticket created",
+      },
+    },
+  },
+  name: "createZendeskTicket",
+  provider: "zendesk",
+};
 export const linkedinCreateShareLinkedinPostUrlDefinition: ActionTemplate = {
-        "description": "Create a share linkedin post link",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [],
-            "properties": {
-                "text": {
-                    "type": "string",
-                    "description": "The text for the linkedin post"
-                },
-                "url": {
-                    "type": "string",
-                    "description": "The url for the linkedin post"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "linkedinUrl"
-            ],
-            "properties": {
-                "linkedinUrl": {
-                    "type": "string",
-                    "description": "The share post linkedin URL"
-                }
-            }
-        },
-        "name": "createShareLinkedinPostUrl",
-        "provider": "linkedin"
-    };
+  description: "Create a share linkedin post link",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: [],
+    properties: {
+      text: {
+        type: "string",
+        description: "The text for the linkedin post",
+      },
+      url: {
+        type: "string",
+        description: "The url for the linkedin post",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["linkedinUrl"],
+    properties: {
+      linkedinUrl: {
+        type: "string",
+        description: "The share post linkedin URL",
+      },
+    },
+  },
+  name: "createShareLinkedinPostUrl",
+  provider: "linkedin",
+};
 export const xCreateShareXPostUrlDefinition: ActionTemplate = {
-        "description": "Create a share X (formerly twitter) post link",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "text"
-            ],
-            "properties": {
-                "text": {
-                    "type": "string",
-                    "description": "The text for the X(formerly twitter) post"
-                },
-                "url": {
-                    "type": "string",
-                    "description": "The url for the X(formerly twitter) post"
-                },
-                "hashtag": {
-                    "type": "array",
-                    "description": "List of hashtags to include in the X post",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "via": {
-                    "type": "string",
-                    "description": "The twitter username to associate with the tweet"
-                },
-                "inReplyTo": {
-                    "type": "string",
-                    "description": "The tweet ID to reply to"
-                }
-            }
+  description: "Create a share X (formerly twitter) post link",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["text"],
+    properties: {
+      text: {
+        type: "string",
+        description: "The text for the X(formerly twitter) post",
+      },
+      url: {
+        type: "string",
+        description: "The url for the X(formerly twitter) post",
+      },
+      hashtag: {
+        type: "array",
+        description: "List of hashtags to include in the X post",
+        items: {
+          type: "string",
         },
-        "output": {
-            "type": "object",
-            "required": [
-                "xUrl"
-            ],
-            "properties": {
-                "xUrl": {
-                    "type": "string",
-                    "description": "The share post X(formerly twitter) URL"
-                }
-            }
-        },
-        "name": "createShareXPostUrl",
-        "provider": "x"
-    };
+      },
+      via: {
+        type: "string",
+        description: "The twitter username to associate with the tweet",
+      },
+      inReplyTo: {
+        type: "string",
+        description: "The tweet ID to reply to",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["xUrl"],
+    properties: {
+      xUrl: {
+        type: "string",
+        description: "The share post X(formerly twitter) URL",
+      },
+    },
+  },
+  name: "createShareXPostUrl",
+  provider: "x",
+};
 export const mongoInsertMongoDocDefinition: ActionTemplate = {
-        "description": "Insert a document into a MongoDB collection",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "databaseName",
-                "collectionName",
-                "document"
-            ],
-            "properties": {
-                "databaseName": {
-                    "type": "string",
-                    "description": "Database to connect to"
-                },
-                "collectionName": {
-                    "type": "string",
-                    "description": "Collection to insert the document into"
-                },
-                "document": {
-                    "type": "object",
-                    "description": "The document to insert"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "objectId"
-            ],
-            "properties": {
-                "objectId": {
-                    "type": "string",
-                    "description": "The new ID of the document inserted"
-                }
-            }
-        },
-        "name": "insertMongoDoc",
-        "provider": "mongo"
-    };
+  description: "Insert a document into a MongoDB collection",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["databaseName", "collectionName", "document"],
+    properties: {
+      databaseName: {
+        type: "string",
+        description: "Database to connect to",
+      },
+      collectionName: {
+        type: "string",
+        description: "Collection to insert the document into",
+      },
+      document: {
+        type: "object",
+        description: "The document to insert",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["objectId"],
+    properties: {
+      objectId: {
+        type: "string",
+        description: "The new ID of the document inserted",
+      },
+    },
+  },
+  name: "insertMongoDoc",
+  provider: "mongo",
+};
 export const snowflakeGetRowByFieldValueDefinition: ActionTemplate = {
-        "description": "Get a row from a Snowflake table by a field value",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "tableName",
-                "fieldName",
-                "fieldValue"
-            ],
-            "properties": {
-                "databaseName": {
-                    "type": "string",
-                    "description": "The name of the database to query"
-                },
-                "tableName": {
-                    "type": "string",
-                    "description": "The name of the table to query"
-                },
-                "fieldName": {
-                    "type": "string",
-                    "description": "The name of the field to query"
-                },
-                "fieldValue": {
-                    "type": "string",
-                    "description": "The value of the field to query"
-                },
-                "accountName": {
-                    "type": "string",
-                    "description": "The name of the Snowflake account"
-                },
-                "user": {
-                    "type": "string",
-                    "description": "The user to authenticate with"
-                },
-                "warehouse": {
-                    "type": "string",
-                    "description": "The warehouse to use"
-                }
-            }
+  description: "Get a row from a Snowflake table by a field value",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["tableName", "fieldName", "fieldValue"],
+    properties: {
+      databaseName: {
+        type: "string",
+        description: "The name of the database to query",
+      },
+      tableName: {
+        type: "string",
+        description: "The name of the table to query",
+      },
+      fieldName: {
+        type: "string",
+        description: "The name of the field to query",
+      },
+      fieldValue: {
+        type: "string",
+        description: "The value of the field to query",
+      },
+      accountName: {
+        type: "string",
+        description: "The name of the Snowflake account",
+      },
+      user: {
+        type: "string",
+        description: "The user to authenticate with",
+      },
+      warehouse: {
+        type: "string",
+        description: "The warehouse to use",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["row"],
+    properties: {
+      row: {
+        type: "object",
+        description: "The row from the Snowflake table",
+        properties: {
+          id: {
+            type: "string",
+            description: "The ID of the row",
+          },
+          rowContents: {
+            type: "object",
+            description: "The contents of the row",
+          },
         },
-        "output": {
-            "type": "object",
-            "required": [
-                "row"
-            ],
-            "properties": {
-                "row": {
-                    "type": "object",
-                    "description": "The row from the Snowflake table",
-                    "properties": {
-                        "id": {
-                            "type": "string",
-                            "description": "The ID of the row"
-                        },
-                        "rowContents": {
-                            "type": "object",
-                            "description": "The contents of the row"
-                        }
-                    }
-                }
-            }
-        },
-        "name": "getRowByFieldValue",
-        "provider": "snowflake"
-    };
+      },
+    },
+  },
+  name: "getRowByFieldValue",
+  provider: "snowflake",
+};
 export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemplate = {
-        "description": "Get the latitude and longitude of a location",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "location"
-            ],
-            "properties": {
-                "location": {
-                    "type": "string",
-                    "description": "The location to get the latitude and longitude of"
-                }
-            }
+  description: "Get the latitude and longitude of a location",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["location"],
+    properties: {
+      location: {
+        type: "string",
+        description: "The location to get the latitude and longitude of",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: [],
+    properties: {
+      results: {
+        type: "array",
+        description: "The results of the query",
+        items: {
+          type: "object",
+          required: ["latitude", "longitude", "display_name"],
+          properties: {
+            latitude: {
+              type: "number",
+              description: "The latitude of the location",
+            },
+            longitude: {
+              type: "number",
+              description: "The longitude of the location",
+            },
+            display_name: {
+              type: "string",
+              description: "The display name of the location",
+            },
+          },
         },
-        "output": {
-            "type": "object",
-            "required": [],
-            "properties": {
-                "results": {
-                    "type": "array",
-                    "description": "The results of the query",
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "latitude",
-                            "longitude",
-                            "display_name"
-                        ],
-                        "properties": {
-                            "latitude": {
-                                "type": "number",
-                                "description": "The latitude of the location"
-                            },
-                            "longitude": {
-                                "type": "number",
-                                "description": "The longitude of the location"
-                            },
-                            "display_name": {
-                                "type": "string",
-                                "description": "The display name of the location"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "name": "getLatitudeLongitudeFromLocation",
-        "provider": "openstreetmap"
-    };
+      },
+    },
+  },
+  name: "getLatitudeLongitudeFromLocation",
+  provider: "openstreetmap",
+};
 export const nwsGetForecastForLocationDefinition: ActionTemplate = {
-        "description": "Get the weather forecast for a location using latitude and longitude",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "latitude",
-                "longitude",
-                "isoDate"
-            ],
-            "properties": {
-                "latitude": {
-                    "type": "number",
-                    "description": "The latitude of the location"
-                },
-                "longitude": {
-                    "type": "number",
-                    "description": "The longitude of the location"
-                },
-                "isoDate": {
-                    "type": "string",
-                    "description": "The date to get the forecast for, in ISO datetime format"
-                }
-            }
+  description: "Get the weather forecast for a location using latitude and longitude",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["latitude", "longitude", "isoDate"],
+    properties: {
+      latitude: {
+        type: "number",
+        description: "The latitude of the location",
+      },
+      longitude: {
+        type: "number",
+        description: "The longitude of the location",
+      },
+      isoDate: {
+        type: "string",
+        description: "The date to get the forecast for, in ISO datetime format",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: [],
+    properties: {
+      result: {
+        type: "object",
+        required: ["temperature", "temperatureUnit", "forecast"],
+        properties: {
+          temperature: {
+            type: "number",
+            description: "The temperature at the location",
+          },
+          temperatureUnit: {
+            type: "string",
+            description: "The unit of temperature",
+          },
+          forecast: {
+            type: "string",
+            description: "The forecast for the location",
+          },
         },
-        "output": {
-            "type": "object",
-            "required": [],
-            "properties": {
-                "result": {
-                    "type": "object",
-                    "required": [
-                        "temperature",
-                        "temperatureUnit",
-                        "forecast"
-                    ],
-                    "properties": {
-                        "temperature": {
-                            "type": "number",
-                            "description": "The temperature at the location"
-                        },
-                        "temperatureUnit": {
-                            "type": "string",
-                            "description": "The unit of temperature"
-                        },
-                        "forecast": {
-                            "type": "string",
-                            "description": "The forecast for the location"
-                        }
-                    }
-                }
-            }
-        },
-        "name": "getForecastForLocation",
-        "provider": "nws"
-    };
+      },
+    },
+  },
+  name: "getForecastForLocation",
+  provider: "nws",
+};
 export const firecrawlScrapeUrlDefinition: ActionTemplate = {
-        "description": "Scrape a URL and get website content using Firecrawl",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "url"
-            ],
-            "properties": {
-                "url": {
-                    "type": "string",
-                    "description": "The URL to scrape"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "content"
-            ],
-            "properties": {
-                "content": {
-                    "type": "string",
-                    "description": "The content of the URL"
-                }
-            }
-        },
-        "name": "scrapeUrl",
-        "provider": "firecrawl"
-    };
+  description: "Scrape a URL and get website content using Firecrawl",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["url"],
+    properties: {
+      url: {
+        type: "string",
+        description: "The URL to scrape",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["content"],
+    properties: {
+      content: {
+        type: "string",
+        description: "The content of the URL",
+      },
+    },
+  },
+  name: "scrapeUrl",
+  provider: "firecrawl",
+};
 export const firecrawlScrapeTweetDataWithNitterDefinition: ActionTemplate = {
-        "description": "Given A tweet URL scrape the tweet data with nitter+firecrawl",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "tweetUrl"
-            ],
-            "properties": {
-                "tweetUrl": {
-                    "type": "string",
-                    "description": "The url for the X(formerly twitter) post"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "text"
-            ],
-            "properties": {
-                "text": {
-                    "type": "string",
-                    "description": "The text in the tweet URL"
-                }
-            }
-        },
-        "name": "scrapeTweetDataWithNitter",
-        "provider": "firecrawl"
-    };
+  description: "Given A tweet URL scrape the tweet data with nitter+firecrawl",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["tweetUrl"],
+    properties: {
+      tweetUrl: {
+        type: "string",
+        description: "The url for the X(formerly twitter) post",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["text"],
+    properties: {
+      text: {
+        type: "string",
+        description: "The text in the tweet URL",
+      },
+    },
+  },
+  name: "scrapeTweetDataWithNitter",
+  provider: "firecrawl",
+};
 export const resendSendEmailDefinition: ActionTemplate = {
-        "description": "Send an email using Resend",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "to",
-                "subject",
-                "content"
-            ],
-            "properties": {
-                "to": {
-                    "type": "string",
-                    "description": "The email address to send the email to"
-                },
-                "subject": {
-                    "type": "string",
-                    "description": "The subject of the email"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "The content of the email"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "success"
-            ],
-            "properties": {
-                "success": {
-                    "type": "boolean",
-                    "description": "Whether the email was sent successfully"
-                },
-                "error": {
-                    "type": "string",
-                    "description": "The error that occurred if the email was not sent successfully"
-                }
-            }
-        },
-        "name": "sendEmail",
-        "provider": "resend"
-    };
+  description: "Send an email using Resend",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["to", "subject", "content"],
+    properties: {
+      to: {
+        type: "string",
+        description: "The email address to send the email to",
+      },
+      subject: {
+        type: "string",
+        description: "The subject of the email",
+      },
+      content: {
+        type: "string",
+        description: "The content of the email",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the email was sent successfully",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the email was not sent successfully",
+      },
+    },
+  },
+  name: "sendEmail",
+  provider: "resend",
+};
 export const googleOauthCreateNewGoogleDocDefinition: ActionTemplate = {
-        "description": "Create a new Google Docs document using OAuth authentication",
-        "scopes": [],
-        "parameters": {
-            "type": "object",
-            "required": [
-                "title"
-            ],
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "description": "The title of the new Google Doc"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "The content to add to the new Google Doc"
-                }
-            }
-        },
-        "output": {
-            "type": "object",
-            "required": [
-                "documentId"
-            ],
-            "properties": {
-                "documentId": {
-                    "type": "string",
-                    "description": "The ID of the created Google Doc"
-                },
-                "documentUrl": {
-                    "type": "string",
-                    "description": "The URL to access the created Google Doc"
-                }
-            }
-        },
-        "name": "createNewGoogleDoc",
-        "provider": "googleOauth"
-    };
+  description: "Create a new Google Docs document using OAuth authentication",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["title"],
+    properties: {
+      title: {
+        type: "string",
+        description: "The title of the new Google Doc",
+      },
+      content: {
+        type: "string",
+        description: "The content to add to the new Google Doc",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["documentId"],
+    properties: {
+      documentId: {
+        type: "string",
+        description: "The ID of the created Google Doc",
+      },
+      documentUrl: {
+        type: "string",
+        description: "The URL to access the created Google Doc",
+      },
+    },
+  },
+  name: "createNewGoogleDoc",
+  provider: "googleOauth",
+};

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1,189 +1,474 @@
 import { z } from "zod";
 
-export type ActionFunction<P, A, O> = (input: {params: P, authParams: A}) => Promise<O>;
+export type ActionFunction<P, A, O> = (input: { params: P; authParams: A }) => Promise<O>;
 
-export const AuthParamsSchema = 
-    z.object({
-        authToken: z.string().optional(),
-        baseUrl: z.string().optional(),
-        apiKey: z.string().optional(),
-        username: z.string().optional(),
-        userAgent: z.string().optional(),
-        emailFrom: z.string().optional(),
-        emailReplyTo: z.string().optional(),
-        emailBcc: z.string().optional(),
-    })
-;
+export const AuthParamsSchema = z.object({
+  authToken: z.string().optional(),
+  baseUrl: z.string().optional(),
+  apiKey: z.string().optional(),
+  username: z.string().optional(),
+  userAgent: z.string().optional(),
+  emailFrom: z.string().optional(),
+  emailReplyTo: z.string().optional(),
+  emailBcc: z.string().optional(),
+});
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;
 
-export const slackSendMessageParamsSchema = z.object({ "channelName": z.string().describe("The name of the Slack channel to send the message to (e.g. general, alerts)"), "message": z.string().describe("The message content to send to Slack. Can include markdown formatting.") });
+export const slackSendMessageParamsSchema = z.object({
+  channelName: z.string().describe("The name of the Slack channel to send the message to (e.g. general, alerts)"),
+  message: z.string().describe("The message content to send to Slack. Can include markdown formatting."),
+});
 
 export type slackSendMessageParamsType = z.infer<typeof slackSendMessageParamsSchema>;
 
 export const slackSendMessageOutputSchema = z.void();
 
 export type slackSendMessageOutputType = z.infer<typeof slackSendMessageOutputSchema>;
-export type slackSendMessageFunction = ActionFunction<slackSendMessageParamsType, AuthParamsType, slackSendMessageOutputType>;
+export type slackSendMessageFunction = ActionFunction<
+  slackSendMessageParamsType,
+  AuthParamsType,
+  slackSendMessageOutputType
+>;
 
 export const slackListConversationsParamsSchema = z.object({});
 
 export type slackListConversationsParamsType = z.infer<typeof slackListConversationsParamsSchema>;
 
-export const slackListConversationsOutputSchema = z.object({ "channels": z.array(z.object({ "id": z.string().describe("The ID of the channel"), "name": z.string().describe("The name of the channel"), "topic": z.string().describe("The topic of the channel"), "purpose": z.string().describe("The purpose of the channel") }).describe("A channel in Slack")).describe("A list of channels in Slack") });
+export const slackListConversationsOutputSchema = z.object({
+  channels: z
+    .array(
+      z
+        .object({
+          id: z.string().describe("The ID of the channel"),
+          name: z.string().describe("The name of the channel"),
+          topic: z.string().describe("The topic of the channel"),
+          purpose: z.string().describe("The purpose of the channel"),
+        })
+        .describe("A channel in Slack"),
+    )
+    .describe("A list of channels in Slack"),
+});
 
 export type slackListConversationsOutputType = z.infer<typeof slackListConversationsOutputSchema>;
-export type slackListConversationsFunction = ActionFunction<slackListConversationsParamsType, AuthParamsType, slackListConversationsOutputType>;
+export type slackListConversationsFunction = ActionFunction<
+  slackListConversationsParamsType,
+  AuthParamsType,
+  slackListConversationsOutputType
+>;
 
-export const mathAddParamsSchema = z.object({ "a": z.number().describe("The first number to add"), "b": z.number().describe("The second number to add") });
+export const mathAddParamsSchema = z.object({
+  a: z.number().describe("The first number to add"),
+  b: z.number().describe("The second number to add"),
+});
 
 export type mathAddParamsType = z.infer<typeof mathAddParamsSchema>;
 
-export const mathAddOutputSchema = z.object({ "result": z.number().describe("The sum of the two numbers") });
+export const mathAddOutputSchema = z.object({ result: z.number().describe("The sum of the two numbers") });
 
 export type mathAddOutputType = z.infer<typeof mathAddOutputSchema>;
 export type mathAddFunction = ActionFunction<mathAddParamsType, AuthParamsType, mathAddOutputType>;
 
-export const confluenceUpdatePageParamsSchema = z.object({ "pageId": z.string().describe("The page id that should be updated"), "title": z.string().describe("The title of the page that should be updated"), "username": z.string().describe("The username of the person updating the page"), "content": z.string().describe("The new content for the page") });
+export const confluenceUpdatePageParamsSchema = z.object({
+  pageId: z.string().describe("The page id that should be updated"),
+  title: z.string().describe("The title of the page that should be updated"),
+  username: z.string().describe("The username of the person updating the page"),
+  content: z.string().describe("The new content for the page"),
+});
 
 export type confluenceUpdatePageParamsType = z.infer<typeof confluenceUpdatePageParamsSchema>;
 
 export const confluenceUpdatePageOutputSchema = z.void();
 
 export type confluenceUpdatePageOutputType = z.infer<typeof confluenceUpdatePageOutputSchema>;
-export type confluenceUpdatePageFunction = ActionFunction<confluenceUpdatePageParamsType, AuthParamsType, confluenceUpdatePageOutputType>;
+export type confluenceUpdatePageFunction = ActionFunction<
+  confluenceUpdatePageParamsType,
+  AuthParamsType,
+  confluenceUpdatePageOutputType
+>;
 
-export const jiraCreateJiraTicketParamsSchema = z.object({ "projectKey": z.string().describe("The key for the project you want to add it to"), "summary": z.string().describe("The summary of the new ticket"), "description": z.string().describe("The description for the new ticket"), "issueType": z.string().describe("The issue type of the new ticket"), "reporter": z.string().describe("The reporter for the new ticket creation").optional(), "assignee": z.string().describe("The assignee for the new ticket creation").optional() });
+export const jiraCreateJiraTicketParamsSchema = z.object({
+  projectKey: z.string().describe("The key for the project you want to add it to"),
+  summary: z.string().describe("The summary of the new ticket"),
+  description: z.string().describe("The description for the new ticket"),
+  issueType: z.string().describe("The issue type of the new ticket"),
+  reporter: z.string().describe("The reporter for the new ticket creation").optional(),
+  assignee: z.string().describe("The assignee for the new ticket creation").optional(),
+});
 
 export type jiraCreateJiraTicketParamsType = z.infer<typeof jiraCreateJiraTicketParamsSchema>;
 
-export const jiraCreateJiraTicketOutputSchema = z.object({ "ticketUrl": z.string().describe("The url to the created Jira Ticket") });
+export const jiraCreateJiraTicketOutputSchema = z.object({
+  ticketUrl: z.string().describe("The url to the created Jira Ticket"),
+});
 
 export type jiraCreateJiraTicketOutputType = z.infer<typeof jiraCreateJiraTicketOutputSchema>;
-export type jiraCreateJiraTicketFunction = ActionFunction<jiraCreateJiraTicketParamsType, AuthParamsType, jiraCreateJiraTicketOutputType>;
+export type jiraCreateJiraTicketFunction = ActionFunction<
+  jiraCreateJiraTicketParamsType,
+  AuthParamsType,
+  jiraCreateJiraTicketOutputType
+>;
 
-export const googlemapsValidateAddressParamsSchema = z.object({ "regionCode": z.string().describe("The country of the address being verified."), "locality": z.string().describe("The locality of the address being verified. This is likely a city."), "postalCode": z.string().describe("The postal code of the address being verified."), "addressLines": z.array(z.string()).describe("A list of lines of the address. These should be in order as they would appear on an envelope."), "addressType": z.enum(["residential","business","poBox"]).describe("The type of address being validated.").optional(), "allowFuzzyMatches": z.boolean().describe("Whether to allow fuzzy matches in the address validation by inferring components.").optional() });
+export const googlemapsValidateAddressParamsSchema = z.object({
+  regionCode: z.string().describe("The country of the address being verified."),
+  locality: z.string().describe("The locality of the address being verified. This is likely a city."),
+  postalCode: z.string().describe("The postal code of the address being verified."),
+  addressLines: z
+    .array(z.string())
+    .describe("A list of lines of the address. These should be in order as they would appear on an envelope."),
+  addressType: z.enum(["residential", "business", "poBox"]).describe("The type of address being validated.").optional(),
+  allowFuzzyMatches: z
+    .boolean()
+    .describe("Whether to allow fuzzy matches in the address validation by inferring components.")
+    .optional(),
+});
 
 export type googlemapsValidateAddressParamsType = z.infer<typeof googlemapsValidateAddressParamsSchema>;
 
-export const googlemapsValidateAddressOutputSchema = z.object({ "valid": z.boolean().describe("Whether the address is valid."), "formattedAddress": z.string().describe("The standardized formatted address.").optional(), "addressComponents": z.array(z.object({ "componentName": z.string().describe("The name of the address component.").optional(), "componentType": z.array(z.string()).describe("The types associated with this component (e.g., street_number, route).").optional() })).describe("Components of the address, such as street number and route.").optional(), "missingComponentTypes": z.array(z.string()).describe("List of components missing in the input address.").optional(), "unresolvedTokens": z.array(z.string()).describe("Unrecognized parts of the address.").optional(), "geocode": z.object({ "location": z.object({ "latitude": z.number().describe("The latitude of the address.").optional(), "longitude": z.number().describe("The longitude of the address.").optional() }).optional(), "plusCode": z.object({ "globalCode": z.string().describe("The global Plus Code.").optional(), "compoundCode": z.string().describe("The compound Plus Code.").optional() }).describe("The Plus Code for the address.").optional(), "bounds": z.object({ "northeast": z.object({ "latitude": z.number().optional(), "longitude": z.number().optional() }).optional(), "southwest": z.object({ "latitude": z.number().optional(), "longitude": z.number().optional() }).optional() }).describe("The viewport bounds for the address.").optional() }).describe("Geocode data for the address.").optional(), "uspsData": z.object({ "standardizedAddress": z.object({}).catchall(z.any()).describe("The standardized USPS address.").optional(), "deliveryPointValidation": z.string().describe("The USPS delivery point validation status.").optional(), "uspsAddressPrecision": z.string().describe("The level of precision for the USPS address.").optional() }).describe("USPS-specific validation details.").optional() });
+export const googlemapsValidateAddressOutputSchema = z.object({
+  valid: z.boolean().describe("Whether the address is valid."),
+  formattedAddress: z.string().describe("The standardized formatted address.").optional(),
+  addressComponents: z
+    .array(
+      z.object({
+        componentName: z.string().describe("The name of the address component.").optional(),
+        componentType: z
+          .array(z.string())
+          .describe("The types associated with this component (e.g., street_number, route).")
+          .optional(),
+      }),
+    )
+    .describe("Components of the address, such as street number and route.")
+    .optional(),
+  missingComponentTypes: z.array(z.string()).describe("List of components missing in the input address.").optional(),
+  unresolvedTokens: z.array(z.string()).describe("Unrecognized parts of the address.").optional(),
+  geocode: z
+    .object({
+      location: z
+        .object({
+          latitude: z.number().describe("The latitude of the address.").optional(),
+          longitude: z.number().describe("The longitude of the address.").optional(),
+        })
+        .optional(),
+      plusCode: z
+        .object({
+          globalCode: z.string().describe("The global Plus Code.").optional(),
+          compoundCode: z.string().describe("The compound Plus Code.").optional(),
+        })
+        .describe("The Plus Code for the address.")
+        .optional(),
+      bounds: z
+        .object({
+          northeast: z.object({ latitude: z.number().optional(), longitude: z.number().optional() }).optional(),
+          southwest: z.object({ latitude: z.number().optional(), longitude: z.number().optional() }).optional(),
+        })
+        .describe("The viewport bounds for the address.")
+        .optional(),
+    })
+    .describe("Geocode data for the address.")
+    .optional(),
+  uspsData: z
+    .object({
+      standardizedAddress: z.object({}).catchall(z.any()).describe("The standardized USPS address.").optional(),
+      deliveryPointValidation: z.string().describe("The USPS delivery point validation status.").optional(),
+      uspsAddressPrecision: z.string().describe("The level of precision for the USPS address.").optional(),
+    })
+    .describe("USPS-specific validation details.")
+    .optional(),
+});
 
 export type googlemapsValidateAddressOutputType = z.infer<typeof googlemapsValidateAddressOutputSchema>;
-export type googlemapsValidateAddressFunction = ActionFunction<googlemapsValidateAddressParamsType, AuthParamsType, googlemapsValidateAddressOutputType>;
+export type googlemapsValidateAddressFunction = ActionFunction<
+  googlemapsValidateAddressParamsType,
+  AuthParamsType,
+  googlemapsValidateAddressOutputType
+>;
 
-export const googlemapsNearbysearchRestaurantsParamsSchema = z.object({ "latitude": z.number().describe("The latitude of the location to search nearby"), "longitude": z.number().describe("The longitude of the location to search nearby") });
+export const googlemapsNearbysearchRestaurantsParamsSchema = z.object({
+  latitude: z.number().describe("The latitude of the location to search nearby"),
+  longitude: z.number().describe("The longitude of the location to search nearby"),
+});
 
 export type googlemapsNearbysearchRestaurantsParamsType = z.infer<typeof googlemapsNearbysearchRestaurantsParamsSchema>;
 
-export const googlemapsNearbysearchRestaurantsOutputSchema = z.object({ "results": z.array(z.object({ "name": z.string().describe("The name of the place").optional(), "address": z.string().describe("The address of the place").optional(), "rating": z.number().describe("The rating of the place").optional(), "priceLevel": z.string().describe("The price level of the place").optional(), "openingHours": z.string().describe("The opening hours of the place").optional(), "primaryType": z.string().describe("The primary type of the place").optional(), "editorialSummary": z.string().describe("The editorial summary of the place").optional(), "websiteUri": z.string().describe("The website URI of the place").optional() })).describe("The results of the nearby search") });
+export const googlemapsNearbysearchRestaurantsOutputSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the place").optional(),
+        address: z.string().describe("The address of the place").optional(),
+        rating: z.number().describe("The rating of the place").optional(),
+        priceLevel: z.string().describe("The price level of the place").optional(),
+        openingHours: z.string().describe("The opening hours of the place").optional(),
+        primaryType: z.string().describe("The primary type of the place").optional(),
+        editorialSummary: z.string().describe("The editorial summary of the place").optional(),
+        websiteUri: z.string().describe("The website URI of the place").optional(),
+      }),
+    )
+    .describe("The results of the nearby search"),
+});
 
 export type googlemapsNearbysearchRestaurantsOutputType = z.infer<typeof googlemapsNearbysearchRestaurantsOutputSchema>;
-export type googlemapsNearbysearchRestaurantsFunction = ActionFunction<googlemapsNearbysearchRestaurantsParamsType, AuthParamsType, googlemapsNearbysearchRestaurantsOutputType>;
+export type googlemapsNearbysearchRestaurantsFunction = ActionFunction<
+  googlemapsNearbysearchRestaurantsParamsType,
+  AuthParamsType,
+  googlemapsNearbysearchRestaurantsOutputType
+>;
 
-export const credalCallCopilotParamsSchema = z.object({ "agentId": z.string().describe("The ID of the copilot to call"), "query": z.string().describe("The query to ask Credal Copilot"), "userEmail": z.string().describe("The email of the user sending or authorizing the query") });
+export const credalCallCopilotParamsSchema = z.object({
+  agentId: z.string().describe("The ID of the copilot to call"),
+  query: z.string().describe("The query to ask Credal Copilot"),
+  userEmail: z.string().describe("The email of the user sending or authorizing the query"),
+});
 
 export type credalCallCopilotParamsType = z.infer<typeof credalCallCopilotParamsSchema>;
 
-export const credalCallCopilotOutputSchema = z.object({ "response": z.string().describe("The response from the Credal Copilot") });
+export const credalCallCopilotOutputSchema = z.object({
+  response: z.string().describe("The response from the Credal Copilot"),
+});
 
 export type credalCallCopilotOutputType = z.infer<typeof credalCallCopilotOutputSchema>;
-export type credalCallCopilotFunction = ActionFunction<credalCallCopilotParamsType, AuthParamsType, credalCallCopilotOutputType>;
+export type credalCallCopilotFunction = ActionFunction<
+  credalCallCopilotParamsType,
+  AuthParamsType,
+  credalCallCopilotOutputType
+>;
 
-export const zendeskCreateZendeskTicketParamsSchema = z.object({ "subject": z.string().describe("The subject of the ticket"), "body": z.string().describe("The body of the ticket").optional(), "requesterEmail": z.string().describe("The email of the requester"), "subdomain": z.string().describe("The subdomain of the Zendesk account") });
+export const zendeskCreateZendeskTicketParamsSchema = z.object({
+  subject: z.string().describe("The subject of the ticket"),
+  body: z.string().describe("The body of the ticket").optional(),
+  requesterEmail: z.string().describe("The email of the requester"),
+  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+});
 
 export type zendeskCreateZendeskTicketParamsType = z.infer<typeof zendeskCreateZendeskTicketParamsSchema>;
 
-export const zendeskCreateZendeskTicketOutputSchema = z.object({ "ticketId": z.string().describe("The ID of the ticket created"), "ticketUrl": z.string().describe("The URL of the ticket created").optional() });
+export const zendeskCreateZendeskTicketOutputSchema = z.object({
+  ticketId: z.string().describe("The ID of the ticket created"),
+  ticketUrl: z.string().describe("The URL of the ticket created").optional(),
+});
 
 export type zendeskCreateZendeskTicketOutputType = z.infer<typeof zendeskCreateZendeskTicketOutputSchema>;
-export type zendeskCreateZendeskTicketFunction = ActionFunction<zendeskCreateZendeskTicketParamsType, AuthParamsType, zendeskCreateZendeskTicketOutputType>;
+export type zendeskCreateZendeskTicketFunction = ActionFunction<
+  zendeskCreateZendeskTicketParamsType,
+  AuthParamsType,
+  zendeskCreateZendeskTicketOutputType
+>;
 
-export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({ "text": z.string().describe("The text for the linkedin post").optional(), "url": z.string().describe("The url for the linkedin post").optional() });
+export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({
+  text: z.string().describe("The text for the linkedin post").optional(),
+  url: z.string().describe("The url for the linkedin post").optional(),
+});
 
-export type linkedinCreateShareLinkedinPostUrlParamsType = z.infer<typeof linkedinCreateShareLinkedinPostUrlParamsSchema>;
+export type linkedinCreateShareLinkedinPostUrlParamsType = z.infer<
+  typeof linkedinCreateShareLinkedinPostUrlParamsSchema
+>;
 
-export const linkedinCreateShareLinkedinPostUrlOutputSchema = z.object({ "linkedinUrl": z.string().describe("The share post linkedin URL") });
+export const linkedinCreateShareLinkedinPostUrlOutputSchema = z.object({
+  linkedinUrl: z.string().describe("The share post linkedin URL"),
+});
 
-export type linkedinCreateShareLinkedinPostUrlOutputType = z.infer<typeof linkedinCreateShareLinkedinPostUrlOutputSchema>;
-export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<linkedinCreateShareLinkedinPostUrlParamsType, AuthParamsType, linkedinCreateShareLinkedinPostUrlOutputType>;
+export type linkedinCreateShareLinkedinPostUrlOutputType = z.infer<
+  typeof linkedinCreateShareLinkedinPostUrlOutputSchema
+>;
+export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<
+  linkedinCreateShareLinkedinPostUrlParamsType,
+  AuthParamsType,
+  linkedinCreateShareLinkedinPostUrlOutputType
+>;
 
-export const xCreateShareXPostUrlParamsSchema = z.object({ "text": z.string().describe("The text for the X(formerly twitter) post"), "url": z.string().describe("The url for the X(formerly twitter) post").optional(), "hashtag": z.array(z.string()).describe("List of hashtags to include in the X post").optional(), "via": z.string().describe("The twitter username to associate with the tweet").optional(), "inReplyTo": z.string().describe("The tweet ID to reply to").optional() });
+export const xCreateShareXPostUrlParamsSchema = z.object({
+  text: z.string().describe("The text for the X(formerly twitter) post"),
+  url: z.string().describe("The url for the X(formerly twitter) post").optional(),
+  hashtag: z.array(z.string()).describe("List of hashtags to include in the X post").optional(),
+  via: z.string().describe("The twitter username to associate with the tweet").optional(),
+  inReplyTo: z.string().describe("The tweet ID to reply to").optional(),
+});
 
 export type xCreateShareXPostUrlParamsType = z.infer<typeof xCreateShareXPostUrlParamsSchema>;
 
-export const xCreateShareXPostUrlOutputSchema = z.object({ "xUrl": z.string().describe("The share post X(formerly twitter) URL") });
+export const xCreateShareXPostUrlOutputSchema = z.object({
+  xUrl: z.string().describe("The share post X(formerly twitter) URL"),
+});
 
 export type xCreateShareXPostUrlOutputType = z.infer<typeof xCreateShareXPostUrlOutputSchema>;
-export type xCreateShareXPostUrlFunction = ActionFunction<xCreateShareXPostUrlParamsType, AuthParamsType, xCreateShareXPostUrlOutputType>;
+export type xCreateShareXPostUrlFunction = ActionFunction<
+  xCreateShareXPostUrlParamsType,
+  AuthParamsType,
+  xCreateShareXPostUrlOutputType
+>;
 
-export const mongoInsertMongoDocParamsSchema = z.object({ "databaseName": z.string().describe("Database to connect to"), "collectionName": z.string().describe("Collection to insert the document into"), "document": z.object({}).catchall(z.any()).describe("The document to insert") });
+export const mongoInsertMongoDocParamsSchema = z.object({
+  databaseName: z.string().describe("Database to connect to"),
+  collectionName: z.string().describe("Collection to insert the document into"),
+  document: z.object({}).catchall(z.any()).describe("The document to insert"),
+});
 
 export type mongoInsertMongoDocParamsType = z.infer<typeof mongoInsertMongoDocParamsSchema>;
 
-export const mongoInsertMongoDocOutputSchema = z.object({ "objectId": z.string().describe("The new ID of the document inserted") });
+export const mongoInsertMongoDocOutputSchema = z.object({
+  objectId: z.string().describe("The new ID of the document inserted"),
+});
 
 export type mongoInsertMongoDocOutputType = z.infer<typeof mongoInsertMongoDocOutputSchema>;
-export type mongoInsertMongoDocFunction = ActionFunction<mongoInsertMongoDocParamsType, AuthParamsType, mongoInsertMongoDocOutputType>;
+export type mongoInsertMongoDocFunction = ActionFunction<
+  mongoInsertMongoDocParamsType,
+  AuthParamsType,
+  mongoInsertMongoDocOutputType
+>;
 
-export const snowflakeGetRowByFieldValueParamsSchema = z.object({ "databaseName": z.string().describe("The name of the database to query").optional(), "tableName": z.string().describe("The name of the table to query"), "fieldName": z.string().describe("The name of the field to query"), "fieldValue": z.string().describe("The value of the field to query"), "accountName": z.string().describe("The name of the Snowflake account").optional(), "user": z.string().describe("The user to authenticate with").optional(), "warehouse": z.string().describe("The warehouse to use").optional() });
+export const snowflakeGetRowByFieldValueParamsSchema = z.object({
+  databaseName: z.string().describe("The name of the database to query").optional(),
+  tableName: z.string().describe("The name of the table to query"),
+  fieldName: z.string().describe("The name of the field to query"),
+  fieldValue: z.string().describe("The value of the field to query"),
+  accountName: z.string().describe("The name of the Snowflake account").optional(),
+  user: z.string().describe("The user to authenticate with").optional(),
+  warehouse: z.string().describe("The warehouse to use").optional(),
+});
 
 export type snowflakeGetRowByFieldValueParamsType = z.infer<typeof snowflakeGetRowByFieldValueParamsSchema>;
 
-export const snowflakeGetRowByFieldValueOutputSchema = z.object({ "row": z.object({ "id": z.string().describe("The ID of the row").optional(), "rowContents": z.object({}).catchall(z.any()).describe("The contents of the row").optional() }).describe("The row from the Snowflake table") });
+export const snowflakeGetRowByFieldValueOutputSchema = z.object({
+  row: z
+    .object({
+      id: z.string().describe("The ID of the row").optional(),
+      rowContents: z.object({}).catchall(z.any()).describe("The contents of the row").optional(),
+    })
+    .describe("The row from the Snowflake table"),
+});
 
 export type snowflakeGetRowByFieldValueOutputType = z.infer<typeof snowflakeGetRowByFieldValueOutputSchema>;
-export type snowflakeGetRowByFieldValueFunction = ActionFunction<snowflakeGetRowByFieldValueParamsType, AuthParamsType, snowflakeGetRowByFieldValueOutputType>;
+export type snowflakeGetRowByFieldValueFunction = ActionFunction<
+  snowflakeGetRowByFieldValueParamsType,
+  AuthParamsType,
+  snowflakeGetRowByFieldValueOutputType
+>;
 
-export const openstreetmapGetLatitudeLongitudeFromLocationParamsSchema = z.object({ "location": z.string().describe("The location to get the latitude and longitude of") });
+export const openstreetmapGetLatitudeLongitudeFromLocationParamsSchema = z.object({
+  location: z.string().describe("The location to get the latitude and longitude of"),
+});
 
-export type openstreetmapGetLatitudeLongitudeFromLocationParamsType = z.infer<typeof openstreetmapGetLatitudeLongitudeFromLocationParamsSchema>;
+export type openstreetmapGetLatitudeLongitudeFromLocationParamsType = z.infer<
+  typeof openstreetmapGetLatitudeLongitudeFromLocationParamsSchema
+>;
 
-export const openstreetmapGetLatitudeLongitudeFromLocationOutputSchema = z.object({ "results": z.array(z.object({ "latitude": z.number().describe("The latitude of the location"), "longitude": z.number().describe("The longitude of the location"), "display_name": z.string().describe("The display name of the location") })).describe("The results of the query").optional() });
+export const openstreetmapGetLatitudeLongitudeFromLocationOutputSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        latitude: z.number().describe("The latitude of the location"),
+        longitude: z.number().describe("The longitude of the location"),
+        display_name: z.string().describe("The display name of the location"),
+      }),
+    )
+    .describe("The results of the query")
+    .optional(),
+});
 
-export type openstreetmapGetLatitudeLongitudeFromLocationOutputType = z.infer<typeof openstreetmapGetLatitudeLongitudeFromLocationOutputSchema>;
-export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFunction<openstreetmapGetLatitudeLongitudeFromLocationParamsType, AuthParamsType, openstreetmapGetLatitudeLongitudeFromLocationOutputType>;
+export type openstreetmapGetLatitudeLongitudeFromLocationOutputType = z.infer<
+  typeof openstreetmapGetLatitudeLongitudeFromLocationOutputSchema
+>;
+export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFunction<
+  openstreetmapGetLatitudeLongitudeFromLocationParamsType,
+  AuthParamsType,
+  openstreetmapGetLatitudeLongitudeFromLocationOutputType
+>;
 
-export const nwsGetForecastForLocationParamsSchema = z.object({ "latitude": z.number().describe("The latitude of the location"), "longitude": z.number().describe("The longitude of the location"), "isoDate": z.string().describe("The date to get the forecast for, in ISO datetime format") });
+export const nwsGetForecastForLocationParamsSchema = z.object({
+  latitude: z.number().describe("The latitude of the location"),
+  longitude: z.number().describe("The longitude of the location"),
+  isoDate: z.string().describe("The date to get the forecast for, in ISO datetime format"),
+});
 
 export type nwsGetForecastForLocationParamsType = z.infer<typeof nwsGetForecastForLocationParamsSchema>;
 
-export const nwsGetForecastForLocationOutputSchema = z.object({ "result": z.object({ "temperature": z.number().describe("The temperature at the location"), "temperatureUnit": z.string().describe("The unit of temperature"), "forecast": z.string().describe("The forecast for the location") }).optional() });
+export const nwsGetForecastForLocationOutputSchema = z.object({
+  result: z
+    .object({
+      temperature: z.number().describe("The temperature at the location"),
+      temperatureUnit: z.string().describe("The unit of temperature"),
+      forecast: z.string().describe("The forecast for the location"),
+    })
+    .optional(),
+});
 
 export type nwsGetForecastForLocationOutputType = z.infer<typeof nwsGetForecastForLocationOutputSchema>;
-export type nwsGetForecastForLocationFunction = ActionFunction<nwsGetForecastForLocationParamsType, AuthParamsType, nwsGetForecastForLocationOutputType>;
+export type nwsGetForecastForLocationFunction = ActionFunction<
+  nwsGetForecastForLocationParamsType,
+  AuthParamsType,
+  nwsGetForecastForLocationOutputType
+>;
 
-export const firecrawlScrapeUrlParamsSchema = z.object({ "url": z.string().describe("The URL to scrape") });
+export const firecrawlScrapeUrlParamsSchema = z.object({ url: z.string().describe("The URL to scrape") });
 
 export type firecrawlScrapeUrlParamsType = z.infer<typeof firecrawlScrapeUrlParamsSchema>;
 
-export const firecrawlScrapeUrlOutputSchema = z.object({ "content": z.string().describe("The content of the URL") });
+export const firecrawlScrapeUrlOutputSchema = z.object({ content: z.string().describe("The content of the URL") });
 
 export type firecrawlScrapeUrlOutputType = z.infer<typeof firecrawlScrapeUrlOutputSchema>;
-export type firecrawlScrapeUrlFunction = ActionFunction<firecrawlScrapeUrlParamsType, AuthParamsType, firecrawlScrapeUrlOutputType>;
+export type firecrawlScrapeUrlFunction = ActionFunction<
+  firecrawlScrapeUrlParamsType,
+  AuthParamsType,
+  firecrawlScrapeUrlOutputType
+>;
 
-export const firecrawlScrapeTweetDataWithNitterParamsSchema = z.object({ "tweetUrl": z.string().describe("The url for the X(formerly twitter) post") });
+export const firecrawlScrapeTweetDataWithNitterParamsSchema = z.object({
+  tweetUrl: z.string().describe("The url for the X(formerly twitter) post"),
+});
 
-export type firecrawlScrapeTweetDataWithNitterParamsType = z.infer<typeof firecrawlScrapeTweetDataWithNitterParamsSchema>;
+export type firecrawlScrapeTweetDataWithNitterParamsType = z.infer<
+  typeof firecrawlScrapeTweetDataWithNitterParamsSchema
+>;
 
-export const firecrawlScrapeTweetDataWithNitterOutputSchema = z.object({ "text": z.string().describe("The text in the tweet URL") });
+export const firecrawlScrapeTweetDataWithNitterOutputSchema = z.object({
+  text: z.string().describe("The text in the tweet URL"),
+});
 
-export type firecrawlScrapeTweetDataWithNitterOutputType = z.infer<typeof firecrawlScrapeTweetDataWithNitterOutputSchema>;
-export type firecrawlScrapeTweetDataWithNitterFunction = ActionFunction<firecrawlScrapeTweetDataWithNitterParamsType, AuthParamsType, firecrawlScrapeTweetDataWithNitterOutputType>;
+export type firecrawlScrapeTweetDataWithNitterOutputType = z.infer<
+  typeof firecrawlScrapeTweetDataWithNitterOutputSchema
+>;
+export type firecrawlScrapeTweetDataWithNitterFunction = ActionFunction<
+  firecrawlScrapeTweetDataWithNitterParamsType,
+  AuthParamsType,
+  firecrawlScrapeTweetDataWithNitterOutputType
+>;
 
-export const resendSendEmailParamsSchema = z.object({ "to": z.string().describe("The email address to send the email to"), "subject": z.string().describe("The subject of the email"), "content": z.string().describe("The content of the email") });
+export const resendSendEmailParamsSchema = z.object({
+  to: z.string().describe("The email address to send the email to"),
+  subject: z.string().describe("The subject of the email"),
+  content: z.string().describe("The content of the email"),
+});
 
 export type resendSendEmailParamsType = z.infer<typeof resendSendEmailParamsSchema>;
 
-export const resendSendEmailOutputSchema = z.object({ "success": z.boolean().describe("Whether the email was sent successfully"), "error": z.string().describe("The error that occurred if the email was not sent successfully").optional() });
+export const resendSendEmailOutputSchema = z.object({
+  success: z.boolean().describe("Whether the email was sent successfully"),
+  error: z.string().describe("The error that occurred if the email was not sent successfully").optional(),
+});
 
 export type resendSendEmailOutputType = z.infer<typeof resendSendEmailOutputSchema>;
-export type resendSendEmailFunction = ActionFunction<resendSendEmailParamsType, AuthParamsType, resendSendEmailOutputType>;
+export type resendSendEmailFunction = ActionFunction<
+  resendSendEmailParamsType,
+  AuthParamsType,
+  resendSendEmailOutputType
+>;
 
-export const googleOauthCreateNewGoogleDocParamsSchema = z.object({ "title": z.string().describe("The title of the new Google Doc"), "content": z.string().describe("The content to add to the new Google Doc").optional() });
+export const googleOauthCreateNewGoogleDocParamsSchema = z.object({
+  title: z.string().describe("The title of the new Google Doc"),
+  content: z.string().describe("The content to add to the new Google Doc").optional(),
+});
 
 export type googleOauthCreateNewGoogleDocParamsType = z.infer<typeof googleOauthCreateNewGoogleDocParamsSchema>;
 
-export const googleOauthCreateNewGoogleDocOutputSchema = z.object({ "documentId": z.string().describe("The ID of the created Google Doc"), "documentUrl": z.string().describe("The URL to access the created Google Doc").optional() });
+export const googleOauthCreateNewGoogleDocOutputSchema = z.object({
+  documentId: z.string().describe("The ID of the created Google Doc"),
+  documentUrl: z.string().describe("The URL to access the created Google Doc").optional(),
+});
 
 export type googleOauthCreateNewGoogleDocOutputType = z.infer<typeof googleOauthCreateNewGoogleDocOutputSchema>;
-export type googleOauthCreateNewGoogleDocFunction = ActionFunction<googleOauthCreateNewGoogleDocParamsType, AuthParamsType, googleOauthCreateNewGoogleDocOutputType>;
+export type googleOauthCreateNewGoogleDocFunction = ActionFunction<
+  googleOauthCreateNewGoogleDocParamsType,
+  AuthParamsType,
+  googleOauthCreateNewGoogleDocOutputType
+>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1,470 +1,189 @@
 import { z } from "zod";
 
-export type ActionFunction<P, A, O> = (input: { params: P; authParams: A }) => Promise<O>;
+export type ActionFunction<P, A, O> = (input: {params: P, authParams: A}) => Promise<O>;
 
-export const AuthParamsSchema = z.object({
-  authToken: z.string().optional(),
-  baseUrl: z.string().optional(),
-  apiKey: z.string().optional(),
-  username: z.string().optional(),
-  userAgent: z.string().optional(),
-  emailFrom: z.string().optional(),
-  emailReplyTo: z.string().optional(),
-  emailBcc: z.string().optional(),
-});
+export const AuthParamsSchema = 
+    z.object({
+        authToken: z.string().optional(),
+        baseUrl: z.string().optional(),
+        apiKey: z.string().optional(),
+        username: z.string().optional(),
+        userAgent: z.string().optional(),
+        emailFrom: z.string().optional(),
+        emailReplyTo: z.string().optional(),
+        emailBcc: z.string().optional(),
+    })
+;
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;
 
-export const slackSendMessageParamsSchema = z.object({
-  channelName: z.string().describe("The name of the Slack channel to send the message to (e.g. general, alerts)"),
-  message: z.string().describe("The message content to send to Slack. Can include markdown formatting."),
-});
+export const slackSendMessageParamsSchema = z.object({ "channelName": z.string().describe("The name of the Slack channel to send the message to (e.g. general, alerts)"), "message": z.string().describe("The message content to send to Slack. Can include markdown formatting.") });
 
 export type slackSendMessageParamsType = z.infer<typeof slackSendMessageParamsSchema>;
 
 export const slackSendMessageOutputSchema = z.void();
 
 export type slackSendMessageOutputType = z.infer<typeof slackSendMessageOutputSchema>;
-export type slackSendMessageFunction = ActionFunction<
-  slackSendMessageParamsType,
-  AuthParamsType,
-  slackSendMessageOutputType
->;
+export type slackSendMessageFunction = ActionFunction<slackSendMessageParamsType, AuthParamsType, slackSendMessageOutputType>;
 
 export const slackListConversationsParamsSchema = z.object({});
 
 export type slackListConversationsParamsType = z.infer<typeof slackListConversationsParamsSchema>;
 
-export const slackListConversationsOutputSchema = z.object({
-  channels: z
-    .array(
-      z
-        .object({
-          id: z.string().describe("The ID of the channel"),
-          name: z.string().describe("The name of the channel"),
-          topic: z.string().describe("The topic of the channel"),
-          purpose: z.string().describe("The purpose of the channel"),
-        })
-        .describe("A channel in Slack"),
-    )
-    .describe("A list of channels in Slack"),
-});
+export const slackListConversationsOutputSchema = z.object({ "channels": z.array(z.object({ "id": z.string().describe("The ID of the channel"), "name": z.string().describe("The name of the channel"), "topic": z.string().describe("The topic of the channel"), "purpose": z.string().describe("The purpose of the channel") }).describe("A channel in Slack")).describe("A list of channels in Slack") });
 
 export type slackListConversationsOutputType = z.infer<typeof slackListConversationsOutputSchema>;
-export type slackListConversationsFunction = ActionFunction<
-  slackListConversationsParamsType,
-  AuthParamsType,
-  slackListConversationsOutputType
->;
+export type slackListConversationsFunction = ActionFunction<slackListConversationsParamsType, AuthParamsType, slackListConversationsOutputType>;
 
-export const mathAddParamsSchema = z.object({
-  a: z.number().describe("The first number to add"),
-  b: z.number().describe("The second number to add"),
-});
+export const mathAddParamsSchema = z.object({ "a": z.number().describe("The first number to add"), "b": z.number().describe("The second number to add") });
 
 export type mathAddParamsType = z.infer<typeof mathAddParamsSchema>;
 
-export const mathAddOutputSchema = z.object({ result: z.number().describe("The sum of the two numbers") });
+export const mathAddOutputSchema = z.object({ "result": z.number().describe("The sum of the two numbers") });
 
 export type mathAddOutputType = z.infer<typeof mathAddOutputSchema>;
 export type mathAddFunction = ActionFunction<mathAddParamsType, AuthParamsType, mathAddOutputType>;
 
-export const confluenceUpdatePageParamsSchema = z.object({
-  pageId: z.string().describe("The page id that should be updated"),
-  title: z.string().describe("The title of the page that should be updated"),
-  username: z.string().describe("The username of the person updating the page"),
-  content: z.string().describe("The new content for the page"),
-});
+export const confluenceUpdatePageParamsSchema = z.object({ "pageId": z.string().describe("The page id that should be updated"), "title": z.string().describe("The title of the page that should be updated"), "username": z.string().describe("The username of the person updating the page"), "content": z.string().describe("The new content for the page") });
 
 export type confluenceUpdatePageParamsType = z.infer<typeof confluenceUpdatePageParamsSchema>;
 
 export const confluenceUpdatePageOutputSchema = z.void();
 
 export type confluenceUpdatePageOutputType = z.infer<typeof confluenceUpdatePageOutputSchema>;
-export type confluenceUpdatePageFunction = ActionFunction<
-  confluenceUpdatePageParamsType,
-  AuthParamsType,
-  confluenceUpdatePageOutputType
->;
+export type confluenceUpdatePageFunction = ActionFunction<confluenceUpdatePageParamsType, AuthParamsType, confluenceUpdatePageOutputType>;
 
-export const jiraCreateJiraTicketParamsSchema = z.object({
-  projectKey: z.string().describe("The key for the project you want to add it to"),
-  summary: z.string().describe("The summary of the new ticket"),
-  description: z.string().describe("The description for the new ticket"),
-  issueType: z.string().describe("The issue type of the new ticket"),
-  reporter: z.string().describe("The reporter for the new ticket creation").optional(),
-  assignee: z.string().describe("The assignee for the new ticket creation").optional(),
-});
+export const jiraCreateJiraTicketParamsSchema = z.object({ "projectKey": z.string().describe("The key for the project you want to add it to"), "summary": z.string().describe("The summary of the new ticket"), "description": z.string().describe("The description for the new ticket"), "issueType": z.string().describe("The issue type of the new ticket"), "reporter": z.string().describe("The reporter for the new ticket creation").optional(), "assignee": z.string().describe("The assignee for the new ticket creation").optional() });
 
 export type jiraCreateJiraTicketParamsType = z.infer<typeof jiraCreateJiraTicketParamsSchema>;
 
-export const jiraCreateJiraTicketOutputSchema = z.object({
-  ticketUrl: z.string().describe("The url to the created Jira Ticket"),
-});
+export const jiraCreateJiraTicketOutputSchema = z.object({ "ticketUrl": z.string().describe("The url to the created Jira Ticket") });
 
 export type jiraCreateJiraTicketOutputType = z.infer<typeof jiraCreateJiraTicketOutputSchema>;
-export type jiraCreateJiraTicketFunction = ActionFunction<
-  jiraCreateJiraTicketParamsType,
-  AuthParamsType,
-  jiraCreateJiraTicketOutputType
->;
+export type jiraCreateJiraTicketFunction = ActionFunction<jiraCreateJiraTicketParamsType, AuthParamsType, jiraCreateJiraTicketOutputType>;
 
-export const googlemapsValidateAddressParamsSchema = z.object({
-  regionCode: z.string().describe("The country of the address being verified."),
-  locality: z.string().describe("The locality of the address being verified. This is likely a city."),
-  postalCode: z.string().describe("The postal code of the address being verified."),
-  addressLines: z
-    .array(z.string())
-    .describe("A list of lines of the address. These should be in order as they would appear on an envelope."),
-  addressType: z.enum(["residential", "business", "poBox"]).describe("The type of address being validated.").optional(),
-  allowFuzzyMatches: z
-    .boolean()
-    .describe("Whether to allow fuzzy matches in the address validation by inferring components.")
-    .optional(),
-});
+export const googlemapsValidateAddressParamsSchema = z.object({ "regionCode": z.string().describe("The country of the address being verified."), "locality": z.string().describe("The locality of the address being verified. This is likely a city."), "postalCode": z.string().describe("The postal code of the address being verified."), "addressLines": z.array(z.string()).describe("A list of lines of the address. These should be in order as they would appear on an envelope."), "addressType": z.enum(["residential","business","poBox"]).describe("The type of address being validated.").optional(), "allowFuzzyMatches": z.boolean().describe("Whether to allow fuzzy matches in the address validation by inferring components.").optional() });
 
 export type googlemapsValidateAddressParamsType = z.infer<typeof googlemapsValidateAddressParamsSchema>;
 
-export const googlemapsValidateAddressOutputSchema = z.object({
-  valid: z.boolean().describe("Whether the address is valid."),
-  formattedAddress: z.string().describe("The standardized formatted address.").optional(),
-  addressComponents: z
-    .array(
-      z.object({
-        componentName: z.string().describe("The name of the address component.").optional(),
-        componentType: z
-          .array(z.string())
-          .describe("The types associated with this component (e.g., street_number, route).")
-          .optional(),
-      }),
-    )
-    .describe("Components of the address, such as street number and route.")
-    .optional(),
-  missingComponentTypes: z.array(z.string()).describe("List of components missing in the input address.").optional(),
-  unresolvedTokens: z.array(z.string()).describe("Unrecognized parts of the address.").optional(),
-  geocode: z
-    .object({
-      location: z
-        .object({
-          latitude: z.number().describe("The latitude of the address.").optional(),
-          longitude: z.number().describe("The longitude of the address.").optional(),
-        })
-        .optional(),
-      plusCode: z
-        .object({
-          globalCode: z.string().describe("The global Plus Code.").optional(),
-          compoundCode: z.string().describe("The compound Plus Code.").optional(),
-        })
-        .describe("The Plus Code for the address.")
-        .optional(),
-      bounds: z
-        .object({
-          northeast: z.object({ latitude: z.number().optional(), longitude: z.number().optional() }).optional(),
-          southwest: z.object({ latitude: z.number().optional(), longitude: z.number().optional() }).optional(),
-        })
-        .describe("The viewport bounds for the address.")
-        .optional(),
-    })
-    .describe("Geocode data for the address.")
-    .optional(),
-  uspsData: z
-    .object({
-      standardizedAddress: z.object({}).catchall(z.any()).describe("The standardized USPS address.").optional(),
-      deliveryPointValidation: z.string().describe("The USPS delivery point validation status.").optional(),
-      uspsAddressPrecision: z.string().describe("The level of precision for the USPS address.").optional(),
-    })
-    .describe("USPS-specific validation details.")
-    .optional(),
-});
+export const googlemapsValidateAddressOutputSchema = z.object({ "valid": z.boolean().describe("Whether the address is valid."), "formattedAddress": z.string().describe("The standardized formatted address.").optional(), "addressComponents": z.array(z.object({ "componentName": z.string().describe("The name of the address component.").optional(), "componentType": z.array(z.string()).describe("The types associated with this component (e.g., street_number, route).").optional() })).describe("Components of the address, such as street number and route.").optional(), "missingComponentTypes": z.array(z.string()).describe("List of components missing in the input address.").optional(), "unresolvedTokens": z.array(z.string()).describe("Unrecognized parts of the address.").optional(), "geocode": z.object({ "location": z.object({ "latitude": z.number().describe("The latitude of the address.").optional(), "longitude": z.number().describe("The longitude of the address.").optional() }).optional(), "plusCode": z.object({ "globalCode": z.string().describe("The global Plus Code.").optional(), "compoundCode": z.string().describe("The compound Plus Code.").optional() }).describe("The Plus Code for the address.").optional(), "bounds": z.object({ "northeast": z.object({ "latitude": z.number().optional(), "longitude": z.number().optional() }).optional(), "southwest": z.object({ "latitude": z.number().optional(), "longitude": z.number().optional() }).optional() }).describe("The viewport bounds for the address.").optional() }).describe("Geocode data for the address.").optional(), "uspsData": z.object({ "standardizedAddress": z.object({}).catchall(z.any()).describe("The standardized USPS address.").optional(), "deliveryPointValidation": z.string().describe("The USPS delivery point validation status.").optional(), "uspsAddressPrecision": z.string().describe("The level of precision for the USPS address.").optional() }).describe("USPS-specific validation details.").optional() });
 
 export type googlemapsValidateAddressOutputType = z.infer<typeof googlemapsValidateAddressOutputSchema>;
-export type googlemapsValidateAddressFunction = ActionFunction<
-  googlemapsValidateAddressParamsType,
-  AuthParamsType,
-  googlemapsValidateAddressOutputType
->;
+export type googlemapsValidateAddressFunction = ActionFunction<googlemapsValidateAddressParamsType, AuthParamsType, googlemapsValidateAddressOutputType>;
 
-export const googlemapsNearbysearchRestaurantsParamsSchema = z.object({
-  latitude: z.number().describe("The latitude of the location to search nearby"),
-  longitude: z.number().describe("The longitude of the location to search nearby"),
-});
+export const googlemapsNearbysearchRestaurantsParamsSchema = z.object({ "latitude": z.number().describe("The latitude of the location to search nearby"), "longitude": z.number().describe("The longitude of the location to search nearby") });
 
 export type googlemapsNearbysearchRestaurantsParamsType = z.infer<typeof googlemapsNearbysearchRestaurantsParamsSchema>;
 
-export const googlemapsNearbysearchRestaurantsOutputSchema = z.object({
-  results: z
-    .array(
-      z.object({
-        name: z.string().describe("The name of the place").optional(),
-        address: z.string().describe("The address of the place").optional(),
-        rating: z.number().describe("The rating of the place").optional(),
-        priceLevel: z.string().describe("The price level of the place").optional(),
-        openingHours: z.string().describe("The opening hours of the place").optional(),
-        primaryType: z.string().describe("The primary type of the place").optional(),
-        editorialSummary: z.string().describe("The editorial summary of the place").optional(),
-        websiteUri: z.string().describe("The website URI of the place").optional(),
-      }),
-    )
-    .describe("The results of the nearby search"),
-});
+export const googlemapsNearbysearchRestaurantsOutputSchema = z.object({ "results": z.array(z.object({ "name": z.string().describe("The name of the place").optional(), "address": z.string().describe("The address of the place").optional(), "rating": z.number().describe("The rating of the place").optional(), "priceLevel": z.string().describe("The price level of the place").optional(), "openingHours": z.string().describe("The opening hours of the place").optional(), "primaryType": z.string().describe("The primary type of the place").optional(), "editorialSummary": z.string().describe("The editorial summary of the place").optional(), "websiteUri": z.string().describe("The website URI of the place").optional() })).describe("The results of the nearby search") });
 
 export type googlemapsNearbysearchRestaurantsOutputType = z.infer<typeof googlemapsNearbysearchRestaurantsOutputSchema>;
-export type googlemapsNearbysearchRestaurantsFunction = ActionFunction<
-  googlemapsNearbysearchRestaurantsParamsType,
-  AuthParamsType,
-  googlemapsNearbysearchRestaurantsOutputType
->;
+export type googlemapsNearbysearchRestaurantsFunction = ActionFunction<googlemapsNearbysearchRestaurantsParamsType, AuthParamsType, googlemapsNearbysearchRestaurantsOutputType>;
 
-export const credalCallCopilotParamsSchema = z.object({
-  agentId: z.string().describe("The ID of the copilot to call"),
-  query: z.string().describe("The query to ask Credal Copilot"),
-  userEmail: z.string().describe("The email of the user sending or authorizing the query"),
-});
+export const credalCallCopilotParamsSchema = z.object({ "agentId": z.string().describe("The ID of the copilot to call"), "query": z.string().describe("The query to ask Credal Copilot"), "userEmail": z.string().describe("The email of the user sending or authorizing the query") });
 
 export type credalCallCopilotParamsType = z.infer<typeof credalCallCopilotParamsSchema>;
 
-export const credalCallCopilotOutputSchema = z.object({
-  response: z.string().describe("The response from the Credal Copilot"),
-});
+export const credalCallCopilotOutputSchema = z.object({ "response": z.string().describe("The response from the Credal Copilot") });
 
 export type credalCallCopilotOutputType = z.infer<typeof credalCallCopilotOutputSchema>;
-export type credalCallCopilotFunction = ActionFunction<
-  credalCallCopilotParamsType,
-  AuthParamsType,
-  credalCallCopilotOutputType
->;
+export type credalCallCopilotFunction = ActionFunction<credalCallCopilotParamsType, AuthParamsType, credalCallCopilotOutputType>;
 
-export const zendeskCreateZendeskTicketParamsSchema = z.object({
-  subject: z.string().describe("The subject of the ticket"),
-  body: z.string().describe("The body of the ticket").optional(),
-  requesterEmail: z.string().describe("The email of the requester"),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
-});
+export const zendeskCreateZendeskTicketParamsSchema = z.object({ "subject": z.string().describe("The subject of the ticket"), "body": z.string().describe("The body of the ticket").optional(), "requesterEmail": z.string().describe("The email of the requester"), "subdomain": z.string().describe("The subdomain of the Zendesk account") });
 
 export type zendeskCreateZendeskTicketParamsType = z.infer<typeof zendeskCreateZendeskTicketParamsSchema>;
 
-export const zendeskCreateZendeskTicketOutputSchema = z.object({
-  ticketId: z.string().describe("The ID of the ticket created"),
-  ticketUrl: z.string().describe("The URL of the ticket created").optional(),
-});
+export const zendeskCreateZendeskTicketOutputSchema = z.object({ "ticketId": z.string().describe("The ID of the ticket created"), "ticketUrl": z.string().describe("The URL of the ticket created").optional() });
 
 export type zendeskCreateZendeskTicketOutputType = z.infer<typeof zendeskCreateZendeskTicketOutputSchema>;
-export type zendeskCreateZendeskTicketFunction = ActionFunction<
-  zendeskCreateZendeskTicketParamsType,
-  AuthParamsType,
-  zendeskCreateZendeskTicketOutputType
->;
+export type zendeskCreateZendeskTicketFunction = ActionFunction<zendeskCreateZendeskTicketParamsType, AuthParamsType, zendeskCreateZendeskTicketOutputType>;
 
-export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({
-  text: z.string().describe("The text for the linkedin post").optional(),
-  url: z.string().describe("The url for the linkedin post").optional(),
-});
+export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({ "text": z.string().describe("The text for the linkedin post").optional(), "url": z.string().describe("The url for the linkedin post").optional() });
 
-export type linkedinCreateShareLinkedinPostUrlParamsType = z.infer<
-  typeof linkedinCreateShareLinkedinPostUrlParamsSchema
->;
+export type linkedinCreateShareLinkedinPostUrlParamsType = z.infer<typeof linkedinCreateShareLinkedinPostUrlParamsSchema>;
 
-export const linkedinCreateShareLinkedinPostUrlOutputSchema = z.object({
-  linkedinUrl: z.string().describe("The share post linkedin URL"),
-});
+export const linkedinCreateShareLinkedinPostUrlOutputSchema = z.object({ "linkedinUrl": z.string().describe("The share post linkedin URL") });
 
-export type linkedinCreateShareLinkedinPostUrlOutputType = z.infer<
-  typeof linkedinCreateShareLinkedinPostUrlOutputSchema
->;
-export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<
-  linkedinCreateShareLinkedinPostUrlParamsType,
-  AuthParamsType,
-  linkedinCreateShareLinkedinPostUrlOutputType
->;
+export type linkedinCreateShareLinkedinPostUrlOutputType = z.infer<typeof linkedinCreateShareLinkedinPostUrlOutputSchema>;
+export type linkedinCreateShareLinkedinPostUrlFunction = ActionFunction<linkedinCreateShareLinkedinPostUrlParamsType, AuthParamsType, linkedinCreateShareLinkedinPostUrlOutputType>;
 
-export const xCreateShareXPostUrlParamsSchema = z.object({
-  text: z.string().describe("The text for the X(formerly twitter) post"),
-  url: z.string().describe("The url for the X(formerly twitter) post").optional(),
-  hashtag: z.array(z.string()).describe("List of hashtags to include in the X post").optional(),
-  via: z.string().describe("The twitter username to associate with the tweet").optional(),
-  inReplyTo: z.string().describe("The tweet ID to reply to").optional(),
-});
+export const xCreateShareXPostUrlParamsSchema = z.object({ "text": z.string().describe("The text for the X(formerly twitter) post"), "url": z.string().describe("The url for the X(formerly twitter) post").optional(), "hashtag": z.array(z.string()).describe("List of hashtags to include in the X post").optional(), "via": z.string().describe("The twitter username to associate with the tweet").optional(), "inReplyTo": z.string().describe("The tweet ID to reply to").optional() });
 
 export type xCreateShareXPostUrlParamsType = z.infer<typeof xCreateShareXPostUrlParamsSchema>;
 
-export const xCreateShareXPostUrlOutputSchema = z.object({
-  xUrl: z.string().describe("The share post X(formerly twitter) URL"),
-});
+export const xCreateShareXPostUrlOutputSchema = z.object({ "xUrl": z.string().describe("The share post X(formerly twitter) URL") });
 
 export type xCreateShareXPostUrlOutputType = z.infer<typeof xCreateShareXPostUrlOutputSchema>;
-export type xCreateShareXPostUrlFunction = ActionFunction<
-  xCreateShareXPostUrlParamsType,
-  AuthParamsType,
-  xCreateShareXPostUrlOutputType
->;
+export type xCreateShareXPostUrlFunction = ActionFunction<xCreateShareXPostUrlParamsType, AuthParamsType, xCreateShareXPostUrlOutputType>;
 
-export const xScrapePostDataWithNitterParamsSchema = z.object({
-  tweetUrl: z.string().describe("The url for the X(formerly twitter) post"),
-});
-
-export type xScrapePostDataWithNitterParamsType = z.infer<typeof xScrapePostDataWithNitterParamsSchema>;
-
-export const xScrapePostDataWithNitterOutputSchema = z.object({
-  text: z.string().describe("The text in the tweet URL"),
-});
-
-export type xScrapePostDataWithNitterOutputType = z.infer<typeof xScrapePostDataWithNitterOutputSchema>;
-export type xScrapePostDataWithNitterFunction = ActionFunction<
-  xScrapePostDataWithNitterParamsType,
-  AuthParamsType,
-  xScrapePostDataWithNitterOutputType
->;
-
-export const mongoInsertMongoDocParamsSchema = z.object({
-  databaseName: z.string().describe("Database to connect to"),
-  collectionName: z.string().describe("Collection to insert the document into"),
-  document: z.object({}).catchall(z.any()).describe("The document to insert"),
-});
+export const mongoInsertMongoDocParamsSchema = z.object({ "databaseName": z.string().describe("Database to connect to"), "collectionName": z.string().describe("Collection to insert the document into"), "document": z.object({}).catchall(z.any()).describe("The document to insert") });
 
 export type mongoInsertMongoDocParamsType = z.infer<typeof mongoInsertMongoDocParamsSchema>;
 
-export const mongoInsertMongoDocOutputSchema = z.object({
-  objectId: z.string().describe("The new ID of the document inserted"),
-});
+export const mongoInsertMongoDocOutputSchema = z.object({ "objectId": z.string().describe("The new ID of the document inserted") });
 
 export type mongoInsertMongoDocOutputType = z.infer<typeof mongoInsertMongoDocOutputSchema>;
-export type mongoInsertMongoDocFunction = ActionFunction<
-  mongoInsertMongoDocParamsType,
-  AuthParamsType,
-  mongoInsertMongoDocOutputType
->;
+export type mongoInsertMongoDocFunction = ActionFunction<mongoInsertMongoDocParamsType, AuthParamsType, mongoInsertMongoDocOutputType>;
 
-export const snowflakeGetRowByFieldValueParamsSchema = z.object({
-  databaseName: z.string().describe("The name of the database to query").optional(),
-  tableName: z.string().describe("The name of the table to query"),
-  fieldName: z.string().describe("The name of the field to query"),
-  fieldValue: z.string().describe("The value of the field to query"),
-  accountName: z.string().describe("The name of the Snowflake account").optional(),
-  user: z.string().describe("The user to authenticate with").optional(),
-  warehouse: z.string().describe("The warehouse to use").optional(),
-});
+export const snowflakeGetRowByFieldValueParamsSchema = z.object({ "databaseName": z.string().describe("The name of the database to query").optional(), "tableName": z.string().describe("The name of the table to query"), "fieldName": z.string().describe("The name of the field to query"), "fieldValue": z.string().describe("The value of the field to query"), "accountName": z.string().describe("The name of the Snowflake account").optional(), "user": z.string().describe("The user to authenticate with").optional(), "warehouse": z.string().describe("The warehouse to use").optional() });
 
 export type snowflakeGetRowByFieldValueParamsType = z.infer<typeof snowflakeGetRowByFieldValueParamsSchema>;
 
-export const snowflakeGetRowByFieldValueOutputSchema = z.object({
-  row: z
-    .object({
-      id: z.string().describe("The ID of the row").optional(),
-      rowContents: z.object({}).catchall(z.any()).describe("The contents of the row").optional(),
-    })
-    .describe("The row from the Snowflake table"),
-});
+export const snowflakeGetRowByFieldValueOutputSchema = z.object({ "row": z.object({ "id": z.string().describe("The ID of the row").optional(), "rowContents": z.object({}).catchall(z.any()).describe("The contents of the row").optional() }).describe("The row from the Snowflake table") });
 
 export type snowflakeGetRowByFieldValueOutputType = z.infer<typeof snowflakeGetRowByFieldValueOutputSchema>;
-export type snowflakeGetRowByFieldValueFunction = ActionFunction<
-  snowflakeGetRowByFieldValueParamsType,
-  AuthParamsType,
-  snowflakeGetRowByFieldValueOutputType
->;
+export type snowflakeGetRowByFieldValueFunction = ActionFunction<snowflakeGetRowByFieldValueParamsType, AuthParamsType, snowflakeGetRowByFieldValueOutputType>;
 
-export const openstreetmapGetLatitudeLongitudeFromLocationParamsSchema = z.object({
-  location: z.string().describe("The location to get the latitude and longitude of"),
-});
+export const openstreetmapGetLatitudeLongitudeFromLocationParamsSchema = z.object({ "location": z.string().describe("The location to get the latitude and longitude of") });
 
-export type openstreetmapGetLatitudeLongitudeFromLocationParamsType = z.infer<
-  typeof openstreetmapGetLatitudeLongitudeFromLocationParamsSchema
->;
+export type openstreetmapGetLatitudeLongitudeFromLocationParamsType = z.infer<typeof openstreetmapGetLatitudeLongitudeFromLocationParamsSchema>;
 
-export const openstreetmapGetLatitudeLongitudeFromLocationOutputSchema = z.object({
-  results: z
-    .array(
-      z.object({
-        latitude: z.number().describe("The latitude of the location"),
-        longitude: z.number().describe("The longitude of the location"),
-        display_name: z.string().describe("The display name of the location"),
-      }),
-    )
-    .describe("The results of the query")
-    .optional(),
-});
+export const openstreetmapGetLatitudeLongitudeFromLocationOutputSchema = z.object({ "results": z.array(z.object({ "latitude": z.number().describe("The latitude of the location"), "longitude": z.number().describe("The longitude of the location"), "display_name": z.string().describe("The display name of the location") })).describe("The results of the query").optional() });
 
-export type openstreetmapGetLatitudeLongitudeFromLocationOutputType = z.infer<
-  typeof openstreetmapGetLatitudeLongitudeFromLocationOutputSchema
->;
-export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFunction<
-  openstreetmapGetLatitudeLongitudeFromLocationParamsType,
-  AuthParamsType,
-  openstreetmapGetLatitudeLongitudeFromLocationOutputType
->;
+export type openstreetmapGetLatitudeLongitudeFromLocationOutputType = z.infer<typeof openstreetmapGetLatitudeLongitudeFromLocationOutputSchema>;
+export type openstreetmapGetLatitudeLongitudeFromLocationFunction = ActionFunction<openstreetmapGetLatitudeLongitudeFromLocationParamsType, AuthParamsType, openstreetmapGetLatitudeLongitudeFromLocationOutputType>;
 
-export const nwsGetForecastForLocationParamsSchema = z.object({
-  latitude: z.number().describe("The latitude of the location"),
-  longitude: z.number().describe("The longitude of the location"),
-  isoDate: z.string().describe("The date to get the forecast for, in ISO datetime format"),
-});
+export const nwsGetForecastForLocationParamsSchema = z.object({ "latitude": z.number().describe("The latitude of the location"), "longitude": z.number().describe("The longitude of the location"), "isoDate": z.string().describe("The date to get the forecast for, in ISO datetime format") });
 
 export type nwsGetForecastForLocationParamsType = z.infer<typeof nwsGetForecastForLocationParamsSchema>;
 
-export const nwsGetForecastForLocationOutputSchema = z.object({
-  result: z
-    .object({
-      temperature: z.number().describe("The temperature at the location"),
-      temperatureUnit: z.string().describe("The unit of temperature"),
-      forecast: z.string().describe("The forecast for the location"),
-    })
-    .optional(),
-});
+export const nwsGetForecastForLocationOutputSchema = z.object({ "result": z.object({ "temperature": z.number().describe("The temperature at the location"), "temperatureUnit": z.string().describe("The unit of temperature"), "forecast": z.string().describe("The forecast for the location") }).optional() });
 
 export type nwsGetForecastForLocationOutputType = z.infer<typeof nwsGetForecastForLocationOutputSchema>;
-export type nwsGetForecastForLocationFunction = ActionFunction<
-  nwsGetForecastForLocationParamsType,
-  AuthParamsType,
-  nwsGetForecastForLocationOutputType
->;
+export type nwsGetForecastForLocationFunction = ActionFunction<nwsGetForecastForLocationParamsType, AuthParamsType, nwsGetForecastForLocationOutputType>;
 
-export const firecrawlScrapeUrlParamsSchema = z.object({ url: z.string().describe("The URL to scrape") });
+export const firecrawlScrapeUrlParamsSchema = z.object({ "url": z.string().describe("The URL to scrape") });
 
 export type firecrawlScrapeUrlParamsType = z.infer<typeof firecrawlScrapeUrlParamsSchema>;
 
-export const firecrawlScrapeUrlOutputSchema = z.object({ content: z.string().describe("The content of the URL") });
+export const firecrawlScrapeUrlOutputSchema = z.object({ "content": z.string().describe("The content of the URL") });
 
 export type firecrawlScrapeUrlOutputType = z.infer<typeof firecrawlScrapeUrlOutputSchema>;
-export type firecrawlScrapeUrlFunction = ActionFunction<
-  firecrawlScrapeUrlParamsType,
-  AuthParamsType,
-  firecrawlScrapeUrlOutputType
->;
+export type firecrawlScrapeUrlFunction = ActionFunction<firecrawlScrapeUrlParamsType, AuthParamsType, firecrawlScrapeUrlOutputType>;
 
-export const resendSendEmailParamsSchema = z.object({
-  to: z.string().describe("The email address to send the email to"),
-  subject: z.string().describe("The subject of the email"),
-  content: z.string().describe("The content of the email"),
-});
+export const firecrawlScrapeTweetDataWithNitterParamsSchema = z.object({ "tweetUrl": z.string().describe("The url for the X(formerly twitter) post") });
+
+export type firecrawlScrapeTweetDataWithNitterParamsType = z.infer<typeof firecrawlScrapeTweetDataWithNitterParamsSchema>;
+
+export const firecrawlScrapeTweetDataWithNitterOutputSchema = z.object({ "text": z.string().describe("The text in the tweet URL") });
+
+export type firecrawlScrapeTweetDataWithNitterOutputType = z.infer<typeof firecrawlScrapeTweetDataWithNitterOutputSchema>;
+export type firecrawlScrapeTweetDataWithNitterFunction = ActionFunction<firecrawlScrapeTweetDataWithNitterParamsType, AuthParamsType, firecrawlScrapeTweetDataWithNitterOutputType>;
+
+export const resendSendEmailParamsSchema = z.object({ "to": z.string().describe("The email address to send the email to"), "subject": z.string().describe("The subject of the email"), "content": z.string().describe("The content of the email") });
 
 export type resendSendEmailParamsType = z.infer<typeof resendSendEmailParamsSchema>;
 
-export const resendSendEmailOutputSchema = z.object({
-  success: z.boolean().describe("Whether the email was sent successfully"),
-  error: z.string().describe("The error that occurred if the email was not sent successfully").optional(),
-});
+export const resendSendEmailOutputSchema = z.object({ "success": z.boolean().describe("Whether the email was sent successfully"), "error": z.string().describe("The error that occurred if the email was not sent successfully").optional() });
 
 export type resendSendEmailOutputType = z.infer<typeof resendSendEmailOutputSchema>;
-export type resendSendEmailFunction = ActionFunction<
-  resendSendEmailParamsType,
-  AuthParamsType,
-  resendSendEmailOutputType
->;
+export type resendSendEmailFunction = ActionFunction<resendSendEmailParamsType, AuthParamsType, resendSendEmailOutputType>;
 
-export const googleOauthCreateNewGoogleDocParamsSchema = z.object({
-  title: z.string().describe("The title of the new Google Doc"),
-  content: z.string().describe("The content to add to the new Google Doc").optional(),
-});
+export const googleOauthCreateNewGoogleDocParamsSchema = z.object({ "title": z.string().describe("The title of the new Google Doc"), "content": z.string().describe("The content to add to the new Google Doc").optional() });
 
 export type googleOauthCreateNewGoogleDocParamsType = z.infer<typeof googleOauthCreateNewGoogleDocParamsSchema>;
 
-export const googleOauthCreateNewGoogleDocOutputSchema = z.object({
-  documentId: z.string().describe("The ID of the created Google Doc"),
-  documentUrl: z.string().describe("The URL to access the created Google Doc").optional(),
-});
+export const googleOauthCreateNewGoogleDocOutputSchema = z.object({ "documentId": z.string().describe("The ID of the created Google Doc"), "documentUrl": z.string().describe("The URL to access the created Google Doc").optional() });
 
 export type googleOauthCreateNewGoogleDocOutputType = z.infer<typeof googleOauthCreateNewGoogleDocOutputSchema>;
-export type googleOauthCreateNewGoogleDocFunction = ActionFunction<
-  googleOauthCreateNewGoogleDocParamsType,
-  AuthParamsType,
-  googleOauthCreateNewGoogleDocOutputType
->;
+export type googleOauthCreateNewGoogleDocFunction = ActionFunction<googleOauthCreateNewGoogleDocParamsType, AuthParamsType, googleOauthCreateNewGoogleDocOutputType>;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -17,7 +17,7 @@ import {
   linkedinCreateShareLinkedinPostUrlDefinition,
   googleOauthCreateNewGoogleDocDefinition,
   xCreateShareXPostUrlDefinition,
-  xScrapePostDataWithNitterDefinition,
+  firecrawlScrapeTweetDataWithNitterDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -78,7 +78,7 @@ export const ACTION_GROUPS: ActionGroups = {
   },
   FIRECRAWL: {
     description: "Actions for interacting with Firecrawl",
-    actions: [firecrawlScrapeUrlDefinition],
+    actions: [firecrawlScrapeUrlDefinition, firecrawlScrapeTweetDataWithNitterDefinition],
   },
   RESEND: {
     description: "Action for sending an email",
@@ -86,6 +86,6 @@ export const ACTION_GROUPS: ActionGroups = {
   },
   X: {
     description: "Actions for interacting with X(formerly twitter)",
-    actions: [xCreateShareXPostUrlDefinition, xScrapePostDataWithNitterDefinition],
+    actions: [xCreateShareXPostUrlDefinition],
   },
 };

--- a/src/actions/providers/firecrawl/scrapeTweetDataWithNitter.ts
+++ b/src/actions/providers/firecrawl/scrapeTweetDataWithNitter.ts
@@ -1,18 +1,18 @@
 import FirecrawlApp from "@mendable/firecrawl-js";
 import {
   AuthParamsType,
-  xScrapePostDataWithNitterFunction,
-  xScrapePostDataWithNitterParamsType,
-  xScrapePostDataWithNitterOutputType,
+  firecrawlScrapeTweetDataWithNitterFunction,
+  firecrawlScrapeTweetDataWithNitterParamsType,
+  firecrawlScrapeTweetDataWithNitterOutputType,
 } from "../../autogen/types";
 
-const scrapeTweetDataWithNitter: xScrapePostDataWithNitterFunction = async ({
+const scrapeTweetDataWithNitter: firecrawlScrapeTweetDataWithNitterFunction = async ({
   params,
   authParams,
 }: {
-  params: xScrapePostDataWithNitterParamsType;
+  params: firecrawlScrapeTweetDataWithNitterParamsType;
   authParams: AuthParamsType;
-}): Promise<xScrapePostDataWithNitterOutputType> => {
+}): Promise<firecrawlScrapeTweetDataWithNitterOutputType> => {
   const tweetUrlRegex = /^(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/([a-zA-Z0-9_]+)\/status\/(\d+)(?:\?.*)?$/;
 
   if (!tweetUrlRegex.test(params.tweetUrl)) {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -400,24 +400,6 @@ actions:
             type: string
             description: The share post X(formerly twitter) URL
 
-    scrapePostDataWithNitter:
-      description: Given A tweet URL scrape the tweet data with nitter+firecrawl
-      scopes: []
-      parameters:
-        type: object
-        required: [tweetUrl]
-        properties:
-          tweetUrl:
-            type: string
-            description: The url for the X(formerly twitter) post
-      output:
-        type: object
-        required: [text]
-        properties:
-          text:
-            type: string
-            description: The text in the tweet URL
-
   mongo:
     insertMongoDoc:
       description: Insert a document into a MongoDB collection
@@ -569,6 +551,24 @@ actions:
           content:
             type: string
             description: The content of the URL
+          
+    scrapeTweetDataWithNitter:
+      description: Given A tweet URL scrape the tweet data with nitter+firecrawl
+      scopes: []
+      parameters:
+        type: object
+        required: [tweetUrl]
+        properties:
+          tweetUrl:
+            type: string
+            description: The url for the X(formerly twitter) post
+      output:
+        type: object
+        required: [text]
+        properties:
+          text:
+            type: string
+            description: The text in the tweet URL
   resend:
     sendEmail:
       description: Send an email using Resend

--- a/tests/testScrapeXTweetWithNitter.ts
+++ b/tests/testScrapeXTweetWithNitter.ts
@@ -11,8 +11,8 @@ async function runTest() {
     const tweetUrl = "https://twitter.com/elonmusk/status/1899583456050598202";
     
     const result = await runAction(
-        "scrapePostDataWithNitter",
-        "x",
+        "scrapeTweetDataWithNitter",
+        "firecrawl",
         {
             apiKey: process.env.FIRECRAWL_API_KEY
         }, 
@@ -30,8 +30,8 @@ async function runTest() {
     const xUrl = "https://x.com/elonmusk/status/1899583456050598202";
     
     const xResult = await runAction(
-        "scrapePostDataWithNitter",
-        "x",
+        "scrapeTweetDataWithNitter",
+        "firecrawl",
         {
             apiKey: process.env.FIRECRAWL_API_KEY
         }, 


### PR DESCRIPTION

- Incorrectly had a scrape route in twitter instead of firecrawl (parent)
- Items should be grouped by the permissions they require (auth token, api key, etc)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change tweet scraping provider from `x` to `firecrawl`, updating related schemas, functions, and tests.
> 
>   - **Behavior**:
>     - Change provider for `scrapeTweetDataWithNitter` from `x` to `firecrawl` in `actionMapper.ts` and `groups.ts`.
>     - Update `schema.yaml` and `templates.ts` to reflect the provider change to `firecrawl`.
>     - Rename test file `testScrapeXWithNitter.ts` to `testScrapeXTweetWithNitter.ts` and update test cases to use `firecrawl`.
>   - **Code Structure**:
>     - Move `scrapeTweetDataWithNitter.ts` from `providers/x` to `providers/firecrawl`.
>     - Update imports and exports in `actionMapper.ts`, `types.ts`, and `templates.ts` to use `firecrawl` schemas and functions.
>   - **Misc**:
>     - Increment version in `package.json` from `0.1.16` to `0.1.17`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 3fb22770c15842bc0ddd19e5fb0728832ce38d35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->