### PR TITLE
[Actions] - small clean up PR

### DIFF
--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -26,7 +26,13 @@ const createXSharePostUrl: xCreateShareXPostUrlFunction = ({
 
   // Add hashtags parameter if it exists
   if (params.hashtag && params.hashtag.length > 0) {
-    queryParams.append("hashtags", params.hashtag.join(","));
+    const cleanedHashtags = params.hashtag
+      .map(tag => tag.replace(/^#+/, '').trim())
+      .filter(tag => tag.length > 0);
+    
+    if (cleanedHashtags.length > 0) {
+      queryParams.append("hashtags", cleanedHashtags.join(","));
+    }
   }
 
   // Add via parameter if it exists


### PR DESCRIPTION

- When the LLM sees a field called hashtags it'll try to insert then with the # symbol - we'd like to avoid this as the X query params don't expect them to have # symbols includeded
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Cleans `hashtags` in `createXSharePostUrl.ts` by removing leading `#` symbols and trimming whitespace before appending to query parameters.
> 
>   - **Behavior**:
>     - In `createXSharePostUrl.ts`, `hashtags` are cleaned by removing leading `#` symbols and trimming whitespace before appending to query parameters.
>     - Only non-empty `hashtags` are appended to the query parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 44f4bff8fad269efce8eda4ab6e9254b649cbcca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->