### PR TITLE
[Actions] Jira - Error cleanup - avoid long axios error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.17",
+  "version": "0.1.20",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/jira/createJiraTicket.ts
+++ b/src/actions/providers/jira/createJiraTicket.ts
@@ -117,11 +117,13 @@ const createJiraTicket: jiraCreateJiraTicketFunction = async ({
     };
   } catch (error) {
     const axiosError = error as AxiosError;
-    
+
     if (axiosError.response) {
       // The server responded with a status code outside of 2xx range
       console.error("Jira API error:", axiosError.response.status, axiosError.response.data);
-      throw new Error(`Failed to create Jira ticket: ${axiosError.response.status} - ${JSON.stringify(axiosError.response.data)}`);
+      throw new Error(
+        `Failed to create Jira ticket: ${axiosError.response.status} - ${JSON.stringify(axiosError.response.data)}`,
+      );
     } else if (axiosError.request) {
       // Request was made but no response received
       console.error("No response from Jira API:", axiosError.request);


### PR DESCRIPTION

- Should switch to an axios request manager util file that will throw these errors for us
- Then we should use this for all axious requests to avoid any weird error messages being sent back
- `Cirucular json .. blah blah blah`
- 
<img width="996" alt="Screenshot 2025-03-12 at 6 31 02 PM" src="https://github.com/user-attachments/assets/f5534797-36fb-4ef2-bbe9-16d018d2a64b" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves Axios error handling in `createJiraTicket.ts` and updates package version to `0.1.20`.
> 
>   - **Error Handling**:
>     - Adds try-catch block in `createJiraTicket.ts` to handle Axios errors.
>     - Differentiates between server response errors, no response errors, and request setup errors.
>     - Logs specific error messages for each case and throws descriptive errors.
>   - **Version Update**:
>     - Updates version in `package.json` from `0.1.17` to `0.1.20`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 6634cf433ccd11d35810aa7d1b08ec65c332f697. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->