### PR TITLE
Expose references and source data context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -426,6 +426,82 @@ export const credalCallCopilotDefinition: ActionTemplate = {
         type: "string",
         description: "The response from the Credal Copilot",
       },
+      referencedSources: {
+        type: "array",
+        description: "The sources referenced in the response",
+        items: {
+          type: "object",
+          description: "The source referenced in the response",
+          required: ["id", "externalResourceId", "name"],
+          properties: {
+            id: {
+              type: "string",
+              description: "The id of the source",
+            },
+            externalResourceId: {
+              type: "object",
+              required: ["externalResourceId", "resourceType"],
+              description: "The external resource id of the source",
+              properties: {
+                externalResourceId: {
+                  type: "string",
+                  description: "The external resource id of the source",
+                },
+                resourceType: {
+                  type: "string",
+                  description: "The type of the resource",
+                },
+              },
+            },
+            name: {
+              type: "string",
+              description: "The name of the source",
+            },
+            url: {
+              type: "string",
+              description: "The url of the source",
+            },
+          },
+        },
+      },
+      sourcesInDataContext: {
+        type: "array",
+        description: "The sources in the data context of the response",
+        items: {
+          type: "object",
+          description: "The source in the data context of the response",
+          required: ["id", "externalResourceId", "name"],
+          properties: {
+            id: {
+              type: "string",
+              description: "The id of the source",
+            },
+            externalResourceId: {
+              type: "object",
+              description: "The external resource id of the source",
+              required: ["externalResourceId", "resourceType"],
+              properties: {
+                externalResourceId: {
+                  type: "string",
+                  description: "The external resource id of the source",
+                },
+                resourceType: {
+                  type: "string",
+                  description: "The type of the resource",
+                },
+              },
+            },
+            name: {
+              type: "string",
+              description: "The name of the source",
+            },
+            url: {
+              type: "string",
+              description: "The url of the source",
+            },
+          },
+        },
+      },
     },
   },
   name: "callCopilot",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -225,6 +225,42 @@ export type credalCallCopilotParamsType = z.infer<typeof credalCallCopilotParams
 
 export const credalCallCopilotOutputSchema = z.object({
   response: z.string().describe("The response from the Credal Copilot"),
+  referencedSources: z
+    .array(
+      z
+        .object({
+          id: z.string().describe("The id of the source"),
+          externalResourceId: z
+            .object({
+              externalResourceId: z.string().describe("The external resource id of the source"),
+              resourceType: z.string().describe("The type of the resource"),
+            })
+            .describe("The external resource id of the source"),
+          name: z.string().describe("The name of the source"),
+          url: z.string().describe("The url of the source").optional(),
+        })
+        .describe("The source referenced in the response"),
+    )
+    .describe("The sources referenced in the response")
+    .optional(),
+  sourcesInDataContext: z
+    .array(
+      z
+        .object({
+          id: z.string().describe("The id of the source"),
+          externalResourceId: z
+            .object({
+              externalResourceId: z.string().describe("The external resource id of the source"),
+              resourceType: z.string().describe("The type of the resource"),
+            })
+            .describe("The external resource id of the source"),
+          name: z.string().describe("The name of the source"),
+          url: z.string().describe("The url of the source").optional(),
+        })
+        .describe("The source in the data context of the response"),
+    )
+    .describe("The sources in the data context of the response")
+    .optional(),
 });
 
 export type credalCallCopilotOutputType = z.infer<typeof credalCallCopilotOutputSchema>;

--- a/src/actions/providers/credal/callCopilot.ts
+++ b/src/actions/providers/credal/callCopilot.ts
@@ -34,6 +34,9 @@ const callCopilot: credalCallCopilotFunction = async ({
       response.sendChatResult.type === "ai_response_result"
         ? response.sendChatResult.response.message
         : "Error getting response",
+    referencedSources:
+      response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.referencedSources : [],
+    sourcesInDataContext: response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.sourcesInDataContext : [],
   };
 };
 

--- a/src/actions/providers/credal/callCopilot.ts
+++ b/src/actions/providers/credal/callCopilot.ts
@@ -36,7 +36,8 @@ const callCopilot: credalCallCopilotFunction = async ({
         : "Error getting response",
     referencedSources:
       response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.referencedSources : [],
-    sourcesInDataContext: response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.sourcesInDataContext : [],
+    sourcesInDataContext:
+      response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.sourcesInDataContext : [],
   };
 };
 

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -313,6 +313,63 @@ actions:
           response:
             type: string
             description: The response from the Credal Copilot
+          referencedSources:
+            type: array
+            description: The sources referenced in the response
+            items:
+              type: object
+              description: The source referenced in the response
+              required: [id, externalResourceId, name]
+              properties:
+                id:
+                  type: string
+                  description: The id of the source
+                externalResourceId:
+                  type: object
+                  required: [externalResourceId, resourceType]
+                  description: The external resource id of the source
+                  properties:
+                    externalResourceId:
+                      type: string
+                      description: The external resource id of the source
+                    resourceType:
+                      type: string
+                      description: The type of the resource
+                name:
+                  type: string
+                  description: The name of the source
+                url:
+                  type: string
+                  description: The url of the source
+          sourcesInDataContext:
+            type: array
+            description: The sources in the data context of the response
+            items:
+              type: object
+              description: The source in the data context of the response
+              required: [id, externalResourceId, name]
+              properties:
+                id:
+                  type: string
+                  description: The id of the source
+                externalResourceId:
+                  type: object
+                  description: The external resource id of the source
+                  required: [externalResourceId, resourceType]
+                  properties:
+                    externalResourceId:
+                      type: string
+                      description: The external resource id of the source
+                    resourceType:
+                      type: string
+                      description: The type of the resource
+                name:
+                  type: string
+                  description: The name of the source
+                url:
+                  type: string
+                  description: The url of the source
+        
 
   zendesk:
     createZendeskTicket:


### PR DESCRIPTION
When copilots are called as an action, we want to be able to see which sources they reference.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `referencedSources` and `sourcesInDataContext` to Credal Copilot action output.
> 
>   - **Behavior**:
>     - Adds `referencedSources` and `sourcesInDataContext` to `credalCallCopilotOutputSchema` in `types.ts`.
>     - Updates `callCopilot` in `callCopilot.ts` to include `referencedSources` and `sourcesInDataContext` in the response.
>   - **Schema**:
>     - Updates `credalCallCopilotDefinition` in `templates.ts` to include `referencedSources` and `sourcesInDataContext`.
>     - Updates `schema.yaml` to reflect new output properties for `callCopilot`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for ddd10357e435aee8ad961675669a105dd51a4efe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->