### PR TITLE
Jira to use oauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -148,6 +148,10 @@ export const jiraCreateJiraTicketDefinition: ActionTemplate = {
         type: "string",
         description: "The assignee for the new ticket creation",
       },
+      customFieldsJson: {
+        type: "string",
+        description: "A JSON String of custom fields to be set on the create ticket request",
+      },
     },
   },
   output: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -148,9 +148,10 @@ export const jiraCreateJiraTicketDefinition: ActionTemplate = {
         type: "string",
         description: "The assignee for the new ticket creation",
       },
-      customFieldsJson: {
-        type: "string",
-        description: "A JSON String of custom fields to be set on the create ticket request",
+      customFields: {
+        type: "object",
+        description: "Custom fields to be set on the create ticket request",
+        additionalProperties: true,
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -95,9 +95,10 @@ export const jiraCreateJiraTicketParamsSchema = z.object({
   issueType: z.string().describe("The issue type of the new ticket"),
   reporter: z.string().describe("The reporter for the new ticket creation").optional(),
   assignee: z.string().describe("The assignee for the new ticket creation").optional(),
-  customFieldsJson: z
-    .string()
-    .describe("A JSON String of custom fields to be set on the create ticket request")
+  customFields: z
+    .object({})
+    .catchall(z.any())
+    .describe("Custom fields to be set on the create ticket request")
     .optional(),
 });
 

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -11,6 +11,7 @@ export const AuthParamsSchema = z.object({
   emailFrom: z.string().optional(),
   emailReplyTo: z.string().optional(),
   emailBcc: z.string().optional(),
+  cloudId: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -95,6 +95,10 @@ export const jiraCreateJiraTicketParamsSchema = z.object({
   issueType: z.string().describe("The issue type of the new ticket"),
   reporter: z.string().describe("The reporter for the new ticket creation").optional(),
   assignee: z.string().describe("The assignee for the new ticket creation").optional(),
+  customFieldsJson: z
+    .string()
+    .describe("A JSON String of custom fields to be set on the create ticket request")
+    .optional(),
 });
 
 export type jiraCreateJiraTicketParamsType = z.infer<typeof jiraCreateJiraTicketParamsSchema>;

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -46,6 +46,7 @@ z.object({
     emailFrom: z.string().optional(),
     emailReplyTo: z.string().optional(),
     emailBcc: z.string().optional(),
+    cloudId: z.string().optional(),
 })
 `;
 

--- a/src/actions/providers/jira/createJiraTicket.ts
+++ b/src/actions/providers/jira/createJiraTicket.ts
@@ -7,19 +7,14 @@ import {
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
-async function getUserAccountId(
-  email: string,
-  baseUrl: string,
-  authToken: string,
-  username: string,
-): Promise<string | null> {
+async function getUserAccountId(email: string, apiUrl: string, authToken: string): Promise<string | null> {
   try {
     const response = await axiosClient.get<Array<{ accountId: string; displayName: string; emailAddress: string }>>(
-      `${baseUrl}/rest/api/3/user/search?query=${encodeURIComponent(email)}`,
+      `${apiUrl}/user/search?query=${encodeURIComponent(email)}`,
       {
         headers: {
-          Authorization: `Basic ${Buffer.from(`${username}:${authToken}`).toString("base64")}`,
-          "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
+          Accept: "application/json",
         },
       },
     );
@@ -43,53 +38,41 @@ const createJiraTicket: jiraCreateJiraTicketFunction = async ({
   params: jiraCreateJiraTicketParamsType;
   authParams: AuthParamsType;
 }): Promise<jiraCreateJiraTicketOutputType> => {
-  const { authToken, baseUrl, username } = authParams;
-  const url = `${baseUrl}/rest/api/3/issue`;
+  const { authToken, cloudId, baseUrl } = authParams;
+
+  const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/`;
+
+  if (!cloudId) {
+    throw new Error("Cloud ID is required to create a Jira ticket");
+  }
 
   // If assignee is an email, look up the account ID
   let reporterId: string | null = null;
-  if (
-    params.reporter &&
-    typeof params.reporter === "string" &&
-    params.reporter.includes("@") &&
-    baseUrl &&
-    authToken &&
-    username
-  ) {
-    reporterId = await getUserAccountId(params.reporter, baseUrl, authToken, username);
+  if (params.reporter && typeof params.reporter === "string" && params.reporter.includes("@") && authToken) {
+    reporterId = await getUserAccountId(params.reporter, apiUrl, authToken);
   }
 
   // If assignee is an email, look up the account ID
   let assigneeId: string | null = null;
-  if (
-    params.assignee &&
-    typeof params.assignee === "string" &&
-    params.assignee.includes("@") &&
-    baseUrl &&
-    authToken &&
-    username
-  ) {
-    assigneeId = await getUserAccountId(params.assignee, baseUrl, authToken, username);
+  if (params.assignee && typeof params.assignee === "string" && params.assignee.includes("@") && authToken) {
+    assigneeId = await getUserAccountId(params.assignee, apiUrl, authToken);
   }
 
-  const description =
-    typeof params.description === "string"
-      ? {
-          type: "doc",
-          version: 1,
-          content: [
-            {
-              type: "paragraph",
-              content: [
-                {
-                  type: "text",
-                  text: params.description,
-                },
-              ],
-            },
-          ],
-        }
-      : params.description;
+  const description = {
+    type: "doc",
+    version: 1,
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: params.description,
+          },
+        ],
+      },
+    ],
+  };
 
   const payload = {
     fields: {
@@ -106,10 +89,10 @@ const createJiraTicket: jiraCreateJiraTicketFunction = async ({
     },
   };
 
-  const response = await axiosClient.post(url, payload, {
+  const response = await axiosClient.post(`${apiUrl}/issue`, payload, {
     headers: {
-      Authorization: `Basic ${Buffer.from(`${username}:${authToken}`).toString("base64")}`,
-      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+      Accept: "application/json",
     },
   });
 

--- a/src/actions/providers/jira/createJiraTicket.ts
+++ b/src/actions/providers/jira/createJiraTicket.ts
@@ -86,7 +86,7 @@ const createJiraTicket: jiraCreateJiraTicketFunction = async ({
       },
       ...(reporterId ? { reporter: { id: reporterId } } : {}),
       ...(assigneeId ? { assignee: { id: assigneeId } } : {}),
-      ...(params.customFieldsJson ? JSON.parse(params.customFieldsJson) : {}),
+      ...(params.customFields ? params.customFields : {}),
     },
   };
 

--- a/src/actions/providers/jira/createJiraTicket.ts
+++ b/src/actions/providers/jira/createJiraTicket.ts
@@ -86,6 +86,7 @@ const createJiraTicket: jiraCreateJiraTicketFunction = async ({
       },
       ...(reporterId ? { reporter: { id: reporterId } } : {}),
       ...(assigneeId ? { assignee: { id: assigneeId } } : {}),
+      ...(params.customFieldsJson ? JSON.parse(params.customFieldsJson) : {}),
     },
   };
 

--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -26,7 +26,11 @@ const createXSharePostUrl: xCreateShareXPostUrlFunction = ({
 
   // Add hashtags parameter if it exists
   if (params.hashtag && params.hashtag.length > 0) {
-    queryParams.append("hashtags", params.hashtag.join(","));
+    const cleanedHashtags = params.hashtag.map(tag => tag.replace(/^#+/, "").trim()).filter(tag => tag.length > 0);
+
+    if (cleanedHashtags.length > 0) {
+      queryParams.append("hashtags", cleanedHashtags.join(","));
+    }
   }
 
   // Add via parameter if it exists

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -115,9 +115,10 @@ actions:
           assignee:
             type: string
             description: The assignee for the new ticket creation
-          customFieldsJson: 
-            type: string
-            description: A JSON String of custom fields to be set on the create ticket request
+          customFields:
+            type: object
+            description: Custom fields to be set on the create ticket request
+            additionalProperties: true
       output:
         type: object
         required: [ticketUrl]

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -115,6 +115,9 @@ actions:
           assignee:
             type: string
             description: The assignee for the new ticket creation
+          customFieldsJson: 
+            type: string
+            description: A JSON String of custom fields to be set on the create ticket request
       output:
         type: object
         required: [ticketUrl]

--- a/tests/testCreateJiraTicket.ts
+++ b/tests/testCreateJiraTicket.ts
@@ -20,11 +20,12 @@ async function runTest() {
         },
         {
             projectKey,
-            summary: `CR - Test Ticket ${new Date().toISOString()}`,
-            description: `CR - Test Ticket ${new Date().toISOString()}`,
+            summary: `Credal - Test Ticket ${new Date().toISOString()}`,
+            description: `Credal - Test Ticket ${new Date().toISOString()}`,
             issueType: "Task", // Adjust based on available issue types in your Jira
             reporter: "", // Optional - (defaults to the authenticated user related to the oauth token)
             assignee: "", // Optional
+            customFieldsJson: JSON.stringify({ customfield_10100: 'High' }), // Example of custom fields setting
         }
     );
     

--- a/tests/testCreateJiraTicket.ts
+++ b/tests/testCreateJiraTicket.ts
@@ -3,27 +3,28 @@ import { runAction } from "../src/app";
 
 async function runTest() {
 
-    const authToken = "insert-during-test"; // Get API Token from: https://id.atlassian.com/manage-profile/security/api-tokens
-    const baseUrl = "insert-during-test" // Base URL of your confluence account
-    const username = "insert-during-test"; // The email associated with the API token
-    const projectKey = "insert-during-test"; // Project Key of your Jira project
+    // For OAuth Credentials with Jira: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+    const authToken =  "insert-your-auth-token-here"
+    const cloudId = "insert-your-cloud-id-here"
+    const baseUrl = "insert-your-base-url-here"
+    const projectKey = "insert-your-project-key-here";
+
 
     const result = await runAction(
         "createJiraTicket",
         "jira",
         { 
-            authToken,
+            authToken,        
+            cloudId,
             baseUrl,
-            username,
         },
         {
             projectKey,
             summary: `CR - Test Ticket ${new Date().toISOString()}`,
             description: `CR - Test Ticket ${new Date().toISOString()}`,
             issueType: "Task", // Adjust based on available issue types in your Jira
-            reporter: "", // Optional - (defaults to the authenticated user related to the auth token)
+            reporter: "", // Optional - (defaults to the authenticated user related to the oauth token)
             assignee: "", // Optional
-            username,
         }
     );
     
@@ -32,7 +33,6 @@ async function runTest() {
     // Validate response
     assert(result, "Response should not be null");
     assert(result.ticketUrl, "Response should contain a url to the created ticket");
-    
     console.log(`Successfully created Jira ticket: ${result.ticketUrl}`);
 }
 

--- a/tests/testCreateJiraTicket.ts
+++ b/tests/testCreateJiraTicket.ts
@@ -25,7 +25,7 @@ async function runTest() {
             issueType: "Task", // Adjust based on available issue types in your Jira
             reporter: "", // Optional - (defaults to the authenticated user related to the oauth token)
             assignee: "", // Optional
-            customFieldsJson: JSON.stringify({ customfield_10100: 'High' }), // Example of custom fields setting
+            customFields: { customfield_10100: 'High' }, // Example of custom fields setting
         }
     );
     

--- a/tests/testCreateXSharePostUrl.ts
+++ b/tests/testCreateXSharePostUrl.ts
@@ -9,7 +9,7 @@ async function runTest() {
     This should properly encode spaces and special characters!
     `;
     const url = "https://app.credal.ai/";
-    const hashtag = ["AI", "DevTools", "Productivity"];
+    const hashtag = ["#AI", "#DevTools", "Productivity"];
     const via = "credalai";
     const inReplyTo = "1899674121098957217";
     


### PR DESCRIPTION
## Jira Action Change
- Previous Jira action was using basic auth - moving over to oauth
- Documentation: https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/

Will need a change in credal app to pull the oauth credentials instead of the basic/legacy jira/confluence credentials

### Minor X Action Change
 - small fix as the LLM would add # to hashtag fields when it's not supposed to - simple filtering out to match X schema
 - Visual fix for sharing

## Custom required fields JIRA:
<img width="840" alt="Screenshot 2025-03-14 at 12 12 19 PM" src="https://github.com/user-attachments/assets/e10b4400-e2a5-47a3-846c-be81de99f082" />



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch Jira actions to OAuth and fix hashtag handling in X actions, updating schemas and tests accordingly.
> 
>   - **Jira Action Change**:
>     - Switch from basic auth to OAuth in `createJiraTicket.ts`.
>     - Add `cloudId` to `AuthParamsSchema` in `types.ts`.
>     - Update `jiraCreateJiraTicketParamsSchema` to include `customFields`.
>     - Modify `testCreateJiraTicket.ts` to use OAuth credentials.
>   - **X Action Change**:
>     - Fix hashtag handling in `createXSharePostUrl.ts` to remove leading `#` and trim spaces.
>     - Update `testCreateXSharePostUrl.ts` to test hashtag handling.
>   - **Misc**:
>     - Update `package.json` version to `0.1.20`.
>     - Add `customFields` to `jiraCreateJiraTicketDefinition` in `templates.ts` and `schema.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e98ad96e95d736adf2e97966eb2e4e0ac1ed68cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->