### PR TITLE
[Looker] Action to enable users by email

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -47,6 +47,8 @@ import {
   confluenceFetchPageContentOutputSchema,
   snowflakeRunSnowflakeQueryParamsSchema,
   snowflakeRunSnowflakeQueryOutputSchema,
+  lookerEnableUserByEmailParamsSchema,
+  lookerEnableUserByEmailOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -71,6 +73,7 @@ import getBasicFinancials from "./providers/finnhub/getBasicFinancials";
 import confluenceOverwritePage from "./providers/confluence/overwritePage";
 import confluenceFetchPageContent from "./providers/confluence/fetchPageContent";
 import runSnowflakeQuery from "./providers/snowflake/runSnowflakeQuery";
+import enableUserByEmail from "./providers/looker/enableUserByEmail";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -227,6 +230,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: getBasicFinancials,
       paramsSchema: finnhubGetBasicFinancialsParamsSchema,
       outputSchema: finnhubGetBasicFinancialsOutputSchema,
+    },
+  },
+  looker: {
+    enableUserByEmail: {
+      fn: enableUserByEmail,
+      paramsSchema: lookerEnableUserByEmailParamsSchema,
+      outputSchema: lookerEnableUserByEmailOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1171,3 +1171,71 @@ export const finnhubGetBasicFinancialsDefinition: ActionTemplate = {
   name: "getBasicFinancials",
   provider: "finnhub",
 };
+export const lookerEnableUserByEmailDefinition: ActionTemplate = {
+  description: "Search for a Looker user by email and enable them if disabled",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["userEmail"],
+    properties: {
+      userEmail: {
+        type: "string",
+        description: "The email address of the user to search for",
+      },
+      clientId: {
+        type: "string",
+        description: "The client ID for Looker API authentication",
+      },
+      clientSecret: {
+        type: "string",
+        description: "The client secret for Looker API authentication",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success", "message"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the operation was successful",
+      },
+      message: {
+        type: "string",
+        description: "Status message about the operation",
+      },
+      userId: {
+        type: "string",
+        description: "The ID of the user that was found",
+      },
+      userDetails: {
+        type: "object",
+        description: "Details about the user",
+        properties: {
+          id: {
+            type: "string",
+            description: "The ID of the user",
+          },
+          firstName: {
+            type: "string",
+            description: "The first name of the user",
+          },
+          lastName: {
+            type: "string",
+            description: "The last name of the user",
+          },
+          email: {
+            type: "string",
+            description: "The email of the user",
+          },
+          isDisabled: {
+            type: "boolean",
+            description: "Whether the user is disabled",
+          },
+        },
+      },
+    },
+  },
+  name: "enableUserByEmail",
+  provider: "looker",
+};

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1182,14 +1182,6 @@ export const lookerEnableUserByEmailDefinition: ActionTemplate = {
         type: "string",
         description: "The email address of the user to search for",
       },
-      clientId: {
-        type: "string",
-        description: "The client ID for Looker API authentication",
-      },
-      clientSecret: {
-        type: "string",
-        description: "The client secret for Looker API authentication",
-      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -660,3 +660,36 @@ export type finnhubGetBasicFinancialsFunction = ActionFunction<
   AuthParamsType,
   finnhubGetBasicFinancialsOutputType
 >;
+
+// Looker enableUserByEmail types
+export const lookerEnableUserByEmailParamsSchema = z.object({
+  userEmail: z.string().describe("The email address of the user to search for"),
+  clientId: z.string().describe("The client ID for Looker API authentication").optional(),
+  clientSecret: z.string().describe("The client secret for Looker API authentication").optional(),
+});
+
+export type lookerEnableUserByEmailParamsType = z.infer<typeof lookerEnableUserByEmailParamsSchema>;
+
+export const lookerEnableUserByEmailOutputSchema = z.object({
+  success: z.boolean().describe("Whether the operation was successful"),
+  message: z.string().describe("Status message about the operation"),
+  userId: z.string().describe("The ID of the user that was found").optional(),
+  userDetails: z
+    .object({
+      id: z.string().describe("The ID of the user"),
+      firstName: z.string().describe("The first name of the user"),
+      lastName: z.string().describe("The last name of the user"),
+      email: z.string().describe("The email of the user"),
+      isDisabled: z.boolean().describe("Whether the user is disabled"),
+    })
+    .describe("Details about the user")
+    .optional(),
+});
+
+export type lookerEnableUserByEmailOutputType = z.infer<typeof lookerEnableUserByEmailOutputSchema>;
+
+export type lookerEnableUserByEmailFunction = ActionFunction<
+  lookerEnableUserByEmailParamsType,
+  AuthParamsType,
+  lookerEnableUserByEmailOutputType
+>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -664,8 +664,6 @@ export type finnhubGetBasicFinancialsFunction = ActionFunction<
 // Looker enableUserByEmail types
 export const lookerEnableUserByEmailParamsSchema = z.object({
   userEmail: z.string().describe("The email address of the user to search for"),
-  clientId: z.string().describe("The client ID for Looker API authentication").optional(),
-  clientSecret: z.string().describe("The client secret for Looker API authentication").optional(),
 });
 
 export type lookerEnableUserByEmailParamsType = z.infer<typeof lookerEnableUserByEmailParamsSchema>;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -22,6 +22,7 @@ import {
   finnhubGetBasicFinancialsDefinition,
   confluenceFetchPageContentDefinition,
   snowflakeRunSnowflakeQueryDefinition,
+  lookerEnableUserByEmailDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -95,5 +96,9 @@ export const ACTION_GROUPS: ActionGroups = {
   FINNHUB: {
     description: "Action for interacting with Finnhub for stock market data",
     actions: [finnhubSymbolLookupDefinition, finnhubGetBasicFinancialsDefinition],
+  },
+  LOOKER: {
+    description: "Actions for interacting with Looker",
+    actions: [lookerEnableUserByEmailDefinition],
   },
 };

--- a/src/actions/providers/looker/enableUserByEmail.ts
+++ b/src/actions/providers/looker/enableUserByEmail.ts
@@ -33,11 +33,11 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     try {
       // Use client_id and client_secret as URL query parameters
       const loginUrl = `${baseUrl}/api/4.0/login?client_id=${encodeURIComponent(clientId)}&client_secret=${encodeURIComponent(clientSecret)}`;
-      
+
       const loginResponse = await axiosClient.post(loginUrl, {});
 
       accessToken = loginResponse.data.access_token;
-      
+
       if (!accessToken) {
         throw new Error("Failed to obtain authentication token from Looker API");
       }
@@ -59,12 +59,12 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     // Step 2: Search for the user by email
     const searchUrl = `${baseUrl}/api/4.0/users/search?email=${encodeURIComponent(userEmail)}`;
     console.log("Searching for user:", searchUrl);
-    
+
     const searchResponse = await axiosClient.get(searchUrl, { headers });
     console.log("Search response:", searchResponse.data);
 
     const users = searchResponse.data;
-    
+
     if (!users || users.length === 0) {
       return {
         success: false,
@@ -73,7 +73,7 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     }
 
     const user = users[0]; // Take the first matching user
-    
+
     // Step 3: Check if user is disabled
     if (!user.is_disabled) {
       return {
@@ -93,15 +93,15 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     // Step 4: Enable the user (no confirmation check, automatically enable)
     const updateUrl = `${baseUrl}/api/4.0/users/${user.id}`;
     console.log("Enabling user:", updateUrl);
-    
+
     const updateResponse = await axiosClient.patch(
       updateUrl,
       {
-        is_disabled: false
+        is_disabled: false,
       },
-      { headers }
+      { headers },
     );
-    
+
     console.log("Update response:", updateResponse.data);
 
     const updatedUser = updateResponse.data;
@@ -120,7 +120,7 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     };
   } catch (error) {
     console.error("Error in Looker enableUserByEmail action:", error);
-    
+
     return {
       success: false,
       message: error instanceof Error ? error.message : "Unknown error occurred",
@@ -128,4 +128,4 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
   }
 };
 
-export default enableUserByEmail; 
+export default enableUserByEmail;

--- a/src/actions/providers/looker/enableUserByEmail.ts
+++ b/src/actions/providers/looker/enableUserByEmail.ts
@@ -1,0 +1,128 @@
+import {
+  AuthParamsType,
+  lookerEnableUserByEmailFunction,
+  lookerEnableUserByEmailParamsType,
+  lookerEnableUserByEmailOutputType,
+} from "../../autogen/types";
+import { axiosClient } from "../../util/axiosClient";
+
+const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
+  params,
+  authParams,
+}: {
+  params: lookerEnableUserByEmailParamsType;
+  authParams: AuthParamsType;
+}): Promise<lookerEnableUserByEmailOutputType> => {
+  const { userEmail, clientId, clientSecret } = params;
+  const { baseUrl } = authParams;
+
+  if (!baseUrl) {
+    throw new Error("Base URL is required for Looker API");
+  }
+
+  // Check for authentication params
+  const authClientId = clientId || authParams.clientId;
+  const authClientSecret = clientSecret || authParams.clientSecret;
+  let authToken = authParams.authToken;
+
+  if (!authToken && (!authClientId || !authClientSecret)) {
+    throw new Error("Either authToken or both clientId and clientSecret are required for Looker API");
+  }
+
+  // Step 1: If no auth token is provided, authenticate using client_id and client_secret
+  if (!authToken) {
+    try {
+      const loginResponse = await axiosClient.post(
+        `${baseUrl}/login`,
+        {
+          client_id: authClientId,
+          client_secret: authClientSecret,
+        }
+      );
+
+      authToken = loginResponse.data.access_token;
+      
+      if (!authToken) {
+        throw new Error("Failed to obtain authentication token from Looker API");
+      }
+    } catch (error) {
+      console.error("Error authenticating with Looker:", error);
+      return {
+        success: false,
+        message: "Failed to authenticate with Looker API",
+      };
+    }
+  }
+
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+    "Content-Type": "application/json",
+  };
+
+  try {
+    // Step 2: Search for the user by email
+    const searchResponse = await axiosClient.get(
+      `${baseUrl}/api/4.0/users/search?email=${encodeURIComponent(userEmail)}`,
+      { headers }
+    );
+
+    const users = searchResponse.data;
+    
+    if (!users || users.length === 0) {
+      return {
+        success: false,
+        message: `No user found with email: ${userEmail}`,
+      };
+    }
+
+    const user = users[0]; // Take the first matching user
+    
+    // Step 3: Check if user is disabled
+    if (!user.is_disabled) {
+      return {
+        success: true,
+        message: `User ${userEmail} is already enabled`,
+        userId: user.id,
+        userDetails: {
+          id: user.id,
+          firstName: user.first_name,
+          lastName: user.last_name,
+          email: user.email,
+          isDisabled: user.is_disabled,
+        },
+      };
+    }
+
+    // Step 4: Enable the user (no confirmation check, automatically enable)
+    const updateResponse = await axiosClient.patch(
+      `${baseUrl}/api/4.0/users/${user.id}`,
+      {
+        is_disabled: false
+      },
+      { headers }
+    );
+
+    const updatedUser = updateResponse.data;
+
+    return {
+      success: true,
+      message: `Successfully enabled user ${userEmail}`,
+      userId: updatedUser.id,
+      userDetails: {
+        id: updatedUser.id,
+        firstName: updatedUser.first_name,
+        lastName: updatedUser.last_name,
+        email: updatedUser.email,
+        isDisabled: updatedUser.is_disabled,
+      },
+    };
+  } catch (error) {
+    console.error("Error in Looker enableUserByEmail action:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+};
+
+export default enableUserByEmail; 

--- a/src/actions/providers/looker/enableUserByEmail.ts
+++ b/src/actions/providers/looker/enableUserByEmail.ts
@@ -29,14 +29,14 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
 
   // Step 1: If no auth token is provided, authenticate using client_id and client_secret
   if (!accessToken && clientId && clientSecret) {
+    console.log("Authenticating with Looker API:", baseUrl);
     try {
-      const loginResponse = await axiosClient.post(
-        `${baseUrl}/login`,
-        {
-          client_id: clientId,
-          client_secret: clientSecret,
-        }
-      );
+      // Use client_id and client_secret as URL query parameters
+      const loginUrl = `${baseUrl}/api/4.0/login?client_id=${encodeURIComponent(clientId)}&client_secret=${encodeURIComponent(clientSecret)}`;
+      console.log("Login URL:", loginUrl);
+      
+      const loginResponse = await axiosClient.post(loginUrl, {});
+      console.log("Login response:", loginResponse.data);
 
       accessToken = loginResponse.data.access_token;
       
@@ -59,10 +59,11 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
 
   try {
     // Step 2: Search for the user by email
-    const searchResponse = await axiosClient.get(
-      `${baseUrl}/api/4.0/users/search?email=${encodeURIComponent(userEmail)}`,
-      { headers }
-    );
+    const searchUrl = `${baseUrl}/api/4.0/users/search?email=${encodeURIComponent(userEmail)}`;
+    console.log("Searching for user:", searchUrl);
+    
+    const searchResponse = await axiosClient.get(searchUrl, { headers });
+    console.log("Search response:", searchResponse.data);
 
     const users = searchResponse.data;
     
@@ -92,13 +93,18 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     }
 
     // Step 4: Enable the user (no confirmation check, automatically enable)
+    const updateUrl = `${baseUrl}/api/4.0/users/${user.id}`;
+    console.log("Enabling user:", updateUrl);
+    
     const updateResponse = await axiosClient.patch(
-      `${baseUrl}/api/4.0/users/${user.id}`,
+      updateUrl,
       {
         is_disabled: false
       },
       { headers }
     );
+    
+    console.log("Update response:", updateResponse.data);
 
     const updatedUser = updateResponse.data;
 
@@ -116,6 +122,7 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     };
   } catch (error) {
     console.error("Error in Looker enableUserByEmail action:", error);
+    
     return {
       success: false,
       message: error instanceof Error ? error.message : "Unknown error occurred",

--- a/src/actions/providers/looker/enableUserByEmail.ts
+++ b/src/actions/providers/looker/enableUserByEmail.ts
@@ -33,10 +33,8 @@ const enableUserByEmail: lookerEnableUserByEmailFunction = async ({
     try {
       // Use client_id and client_secret as URL query parameters
       const loginUrl = `${baseUrl}/api/4.0/login?client_id=${encodeURIComponent(clientId)}&client_secret=${encodeURIComponent(clientSecret)}`;
-      console.log("Login URL:", loginUrl);
       
       const loginResponse = await axiosClient.post(loginUrl, {});
-      console.log("Login response:", loginResponse.data);
 
       accessToken = loginResponse.data.access_token;
       

--- a/tests/testLookerEnableUser.ts
+++ b/tests/testLookerEnableUser.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert";
+import { runAction } from "../src/app";
+
+async function runTest() {
+  console.log("Running test for Looker enableUserByEmail");
+
+  // Run test to find and potentially enable user
+  const result = await runAction(
+    "enableUserByEmail",
+    "looker",
+    {
+      baseUrl: "https://your-looker-instance.cloud.looker.com",
+    },
+    {
+      userEmail: "user@example.com",
+      clientId: "your-client-id", 
+      clientSecret: "your-client-secret"
+    }
+  );
+
+  console.log("Result:", result);
+  
+  if (result.success) {
+    console.log(`User ${result.userDetails?.email} status: ${result.userDetails?.isDisabled ? "disabled" : "enabled"}`);
+    assert(!result.userDetails?.isDisabled, "User should be enabled");
+  }
+}
+
+export default runTest; 

--- a/tests/testLookerEnableUser.ts
+++ b/tests/testLookerEnableUser.ts
@@ -10,11 +10,11 @@ async function runTest() {
     "looker",
     {
       baseUrl: "https://your-looker-instance.cloud.looker.com",
-    },
-    {
-      userEmail: "user@example.com",
       clientId: "your-client-id", 
       clientSecret: "your-client-secret"
+    },
+    {
+      userEmail: "user@example.com"
     }
   );
 

--- a/tests/testLookerEnableUser.ts
+++ b/tests/testLookerEnableUser.ts
@@ -4,17 +4,29 @@ import { runAction } from "../src/app";
 async function runTest() {
   console.log("Running test for Looker enableUserByEmail");
 
+  // Get authentication details from environment variables
+  const baseUrl = process.env.LOOKER_BASE_URL;
+  const clientId = process.env.LOOKER_CLIENT_ID;
+  const clientSecret = process.env.LOOKER_CLIENT_SECRET;
+  const userEmail = process.env.LOOKER_TEST_USER_EMAIL;
+
+  if (!baseUrl || !clientId || !clientSecret || !userEmail) {
+    console.error("Missing required environment variables for Looker test:");
+    console.error("Required: LOOKER_BASE_URL, LOOKER_CLIENT_ID, LOOKER_CLIENT_SECRET, LOOKER_TEST_USER_EMAIL");
+    process.exit(1);
+  }
+
   // Run test to find and potentially enable user
   const result = await runAction(
     "enableUserByEmail",
     "looker",
     {
-      baseUrl: "https://your-looker-instance.cloud.looker.com",
-      clientId: "your-client-id", 
-      clientSecret: "your-client-secret"
+      baseUrl,
+      clientId,
+      clientSecret
     },
     {
-      userEmail: "user@example.com"
+      userEmail
     }
   );
 
@@ -26,4 +38,4 @@ async function runTest() {
   }
 }
 
-export default runTest; 
+runTest().catch(console.error);


### PR DESCRIPTION
* takes email as input
* expands authParams to include client_id, client_secret (could probably use username / secret params, open to changing)
* requires baseUrl, client_id, client_secret to be given as authParams

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `enableUserByEmail` action for Looker to enable users by email, with authentication and testing support.
> 
>   - **Behavior**:
>     - Adds `enableUserByEmail` action for Looker in `enableUserByEmail.ts` to enable users by email.
>     - Requires `baseUrl`, `clientId`, `clientSecret` in `authParams`.
>     - Authenticates using `client_id` and `client_secret` if `authToken` is not provided.
>     - Searches for user by email and enables if disabled.
>   - **Schemas**:
>     - Adds `lookerEnableUserByEmailParamsSchema` and `lookerEnableUserByEmailOutputSchema` in `types.ts`.
>     - Updates `AuthParamsSchema` to include `clientId` and `clientSecret`.
>   - **Action Mapping**:
>     - Maps `enableUserByEmail` action in `actionMapper.ts`.
>     - Adds `lookerEnableUserByEmailDefinition` to `templates.ts`.
>     - Includes Looker action in `groups.ts` under `LOOKER` group.
>   - **Testing**:
>     - Adds `testLookerEnableUser.ts` to test enabling Looker users by email using environment variables for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for ab6efdae9bb9711e79d31c0e051aa96af181b3b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->