### PR TITLE
Bubble up web search results from Copilot calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -537,6 +537,29 @@ export const credalCallCopilotDefinition: ActionTemplate = {
           },
         },
       },
+      webSearchResults: {
+        type: "array",
+        description: "The web search results in the response",
+        items: {
+          type: "object",
+          description: "The web search result in the response",
+          required: ["title", "url"],
+          properties: {
+            title: {
+              type: "string",
+              description: "The title of the web search result",
+            },
+            url: {
+              type: "string",
+              description: "The url of the web search result",
+            },
+            contents: {
+              type: "string",
+              description: "The contents of the web search result",
+            },
+          },
+        },
+      },
     },
   },
   name: "callCopilot",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -285,6 +285,18 @@ export const credalCallCopilotOutputSchema = z.object({
     )
     .describe("The sources in the data context of the response")
     .optional(),
+  webSearchResults: z
+    .array(
+      z
+        .object({
+          title: z.string().describe("The title of the web search result"),
+          url: z.string().describe("The url of the web search result"),
+          contents: z.string().describe("The contents of the web search result").optional(),
+        })
+        .describe("The web search result in the response"),
+    )
+    .describe("The web search results in the response")
+    .optional(),
 });
 
 export type credalCallCopilotOutputType = z.infer<typeof credalCallCopilotOutputSchema>;

--- a/src/actions/providers/credal/callCopilot.ts
+++ b/src/actions/providers/credal/callCopilot.ts
@@ -38,6 +38,8 @@ const callCopilot: credalCallCopilotFunction = async ({
       response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.referencedSources : [],
     sourcesInDataContext:
       response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.sourcesInDataContext : [],
+    webSearchResults:
+      response.sendChatResult.type === "ai_response_result" ? response.sendChatResult.webSearchResults : [],
   };
 };
 

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -392,6 +392,23 @@ actions:
                 url:
                   type: string
                   description: The url of the source
+          webSearchResults:
+            type: array
+            description: The web search results in the response
+            items:
+              type: object
+              description: The web search result in the response
+              required: [title, url]
+              properties:
+                title:
+                  type: string
+                  description: The title of the web search result
+                url:
+                  type: string
+                  description: The url of the web search result
+                contents:
+                  type: string
+                  description: The contents of the web search result
         
 
   zendesk:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for web search results in Credal Copilot calls, updating schemas, types, and function implementation.
> 
>   - **Behavior**:
>     - Adds `webSearchResults` to `credalCallCopilotDefinition` in `templates.ts` to include web search results in the response.
>     - Updates `callCopilot` in `callCopilot.ts` to handle `webSearchResults` in the response.
>   - **Schema and Types**:
>     - Updates `credalCallCopilotOutputSchema` in `types.ts` to include `webSearchResults`.
>     - Updates `schema.yaml` to define `webSearchResults` in the `callCopilot` action.
>   - **Misc**:
>     - Bumps version in `package.json` from `0.1.23` to `0.1.24`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e733bb482ea93401ac86190627ac8cd87c550fa1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->