### PR TITLE
[Snowflake] - Return result in context instead of outputting to S3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.23",
+      "version": "0.1.25",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/s3-request-presigner": "^3.758.0",
         "@credal/sdk": "^0.0.21",
         "@mendable/firecrawl-js": "^1.19.0",
         "@slack/web-api": "^7.8.0",
@@ -21,7 +20,6 @@
         "resend": "^4.1.2",
         "snowflake-sdk": "^2.0.2",
         "ts-node": "^10.9.2",
-        "uuid": "^11.1.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -778,111 +776,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.758.0.tgz",
-      "integrity": "sha512-dVyItwu/J1InfJBbCPpHRV9jrsBfI7L0RlDGyS3x/xqBwnm5qpvgNZQasQiyqIl+WJB4f5rZRZHgHuwftqINbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-format-url": "3.734.0",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-      "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.5",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.758.0.tgz",
-      "integrity": "sha512-6mJ2zyyHPYSV6bAcaFpsdoXZJeQlR1QgBnZZ6juY/+dcYiuyWCdyLUbGzSZSE7GTfx6i+9+QWFeoIMlWKgU63A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/core": "^3.1.5",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.1.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.758.0.tgz",
-      "integrity": "sha512-0RPCo8fYJcrenJ6bRtiUbFOSgQ1CX/GpvwtLU2Fam1tS9h2klKK8d74caeV6A1mIUvBU7bhyQ0wMGlwMtn3EYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/s3-request-presigner/node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.740.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.740.0.tgz",
@@ -951,21 +844,6 @@
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
         "@smithy/util-endpoints": "^3.0.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.734.0.tgz",
-      "integrity": "sha512-TxZMVm8V4aR/QkW9/NhujvYpPZjUYqzLwSge5imKZbWFR806NP7RMwc5ilVuHF/bMOln/cVHkl42kATElWBvNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6982,19 +6860,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +38,6 @@
     "typescript-eslint": "^8.18.0"
   },
   "dependencies": {
-    "@aws-sdk/s3-request-presigner": "^3.758.0",
     "@credal/sdk": "^0.0.21",
     "@mendable/firecrawl-js": "^1.19.0",
     "@slack/web-api": "^7.8.0",
@@ -50,7 +49,6 @@
     "resend": "^4.1.2",
     "snowflake-sdk": "^2.0.2",
     "ts-node": "^10.9.2",
-    "uuid": "^11.1.0",
     "zod": "^3.24.1"
   }
 }

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -45,8 +45,8 @@ import {
   finnhubGetBasicFinancialsOutputSchema,
   confluenceFetchPageContentParamsSchema,
   confluenceFetchPageContentOutputSchema,
-  snowflakeRunSnowflakeQueryWriteResultsToS3ParamsSchema,
-  snowflakeRunSnowflakeQueryWriteResultsToS3OutputSchema,
+  snowflakeRunSnowflakeQueryParamsSchema,
+  snowflakeRunSnowflakeQueryOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -70,7 +70,7 @@ import symbolLookup from "./providers/finnhub/symbolLookup";
 import getBasicFinancials from "./providers/finnhub/getBasicFinancials";
 import confluenceOverwritePage from "./providers/confluence/overwritePage";
 import confluenceFetchPageContent from "./providers/confluence/fetchPageContent";
-import runSnowflakeQueryWriteResultsToS3 from "./providers/snowflake/runSnowflakeQueryWriteResultsToS3";
+import runSnowflakeQuery from "./providers/snowflake/runSnowflakeQuery";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -150,10 +150,10 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       paramsSchema: snowflakeGetRowByFieldValueParamsSchema,
       outputSchema: snowflakeGetRowByFieldValueOutputSchema,
     },
-    runSnowflakeQueryWriteResultsToS3: {
-      fn: runSnowflakeQueryWriteResultsToS3,
-      paramsSchema: snowflakeRunSnowflakeQueryWriteResultsToS3ParamsSchema,
-      outputSchema: snowflakeRunSnowflakeQueryWriteResultsToS3OutputSchema,
+    runSnowflakeQuery: {
+      fn: runSnowflakeQuery,
+      paramsSchema: snowflakeRunSnowflakeQueryParamsSchema,
+      outputSchema: snowflakeRunSnowflakeQueryOutputSchema,
     },
   },
   linkedin: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -772,12 +772,12 @@ export const snowflakeGetRowByFieldValueDefinition: ActionTemplate = {
   name: "getRowByFieldValue",
   provider: "snowflake",
 };
-export const snowflakeRunSnowflakeQueryWriteResultsToS3Definition: ActionTemplate = {
-  description: "Execute a Snowflake query and write results to an S3 bucket",
+export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
+  description: "Execute a Snowflake query and return output.",
   scopes: [],
   parameters: {
     type: "object",
-    required: ["databaseName", "warehouse", "query", "user", "accountName", "s3BucketName", "s3Region"],
+    required: ["databaseName", "warehouse", "query", "user", "accountName"],
     properties: {
       databaseName: {
         type: "string",
@@ -799,32 +799,20 @@ export const snowflakeRunSnowflakeQueryWriteResultsToS3Definition: ActionTemplat
         type: "string",
         description: "The name of the Snowflake account",
       },
-      s3BucketName: {
-        type: "string",
-        description: "The name of the S3 bucket to write results to",
-      },
-      s3Region: {
-        type: "string",
-        description: "The AWS region where the S3 bucket is located",
-      },
       outputFormat: {
         type: "string",
-        description: "Format for the output file (json or csv, defaults to json)",
+        description: "The format of the output",
         enum: ["json", "csv"],
       },
     },
   },
   output: {
     type: "object",
-    required: ["bucketUrl", "message", "rowCount"],
+    required: ["content", "rowCount"],
     properties: {
-      bucketUrl: {
+      content: {
         type: "string",
-        description: "The URL of the S3 bucket where the results are stored",
-      },
-      message: {
-        type: "string",
-        description: "A message describing the result or error",
+        description: "The content of the query result (json)",
       },
       rowCount: {
         type: "number",
@@ -832,7 +820,7 @@ export const snowflakeRunSnowflakeQueryWriteResultsToS3Definition: ActionTemplat
       },
     },
   },
-  name: "runSnowflakeQueryWriteResultsToS3",
+  name: "runSnowflakeQuery",
   provider: "snowflake",
 };
 export const openstreetmapGetLatitudeLongitudeFromLocationDefinition: ActionTemplate = {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -418,37 +418,27 @@ export type snowflakeGetRowByFieldValueFunction = ActionFunction<
   snowflakeGetRowByFieldValueOutputType
 >;
 
-export const snowflakeRunSnowflakeQueryWriteResultsToS3ParamsSchema = z.object({
+export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
   databaseName: z.string().describe("The name of the database to query"),
   warehouse: z.string().describe("The warehouse to use for executing the query"),
   query: z.string().describe("The SQL query to execute"),
   user: z.string().describe("The username to authenticate with"),
   accountName: z.string().describe("The name of the Snowflake account"),
-  s3BucketName: z.string().describe("The name of the S3 bucket to write results to"),
-  s3Region: z.string().describe("The AWS region where the S3 bucket is located"),
-  outputFormat: z
-    .enum(["json", "csv"])
-    .describe("Format for the output file (json or csv, defaults to json)")
-    .optional(),
+  outputFormat: z.enum(["json", "csv"]).describe("The format of the output").optional(),
 });
 
-export type snowflakeRunSnowflakeQueryWriteResultsToS3ParamsType = z.infer<
-  typeof snowflakeRunSnowflakeQueryWriteResultsToS3ParamsSchema
->;
+export type snowflakeRunSnowflakeQueryParamsType = z.infer<typeof snowflakeRunSnowflakeQueryParamsSchema>;
 
-export const snowflakeRunSnowflakeQueryWriteResultsToS3OutputSchema = z.object({
-  bucketUrl: z.string().describe("The URL of the S3 bucket where the results are stored"),
-  message: z.string().describe("A message describing the result or error"),
+export const snowflakeRunSnowflakeQueryOutputSchema = z.object({
+  content: z.string().describe("The content of the query result (json)"),
   rowCount: z.number().describe("The number of rows returned by the query"),
 });
 
-export type snowflakeRunSnowflakeQueryWriteResultsToS3OutputType = z.infer<
-  typeof snowflakeRunSnowflakeQueryWriteResultsToS3OutputSchema
->;
-export type snowflakeRunSnowflakeQueryWriteResultsToS3Function = ActionFunction<
-  snowflakeRunSnowflakeQueryWriteResultsToS3ParamsType,
+export type snowflakeRunSnowflakeQueryOutputType = z.infer<typeof snowflakeRunSnowflakeQueryOutputSchema>;
+export type snowflakeRunSnowflakeQueryFunction = ActionFunction<
+  snowflakeRunSnowflakeQueryParamsType,
   AuthParamsType,
-  snowflakeRunSnowflakeQueryWriteResultsToS3OutputType
+  snowflakeRunSnowflakeQueryOutputType
 >;
 
 export const openstreetmapGetLatitudeLongitudeFromLocationParamsSchema = z.object({

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -21,7 +21,7 @@ import {
   finnhubSymbolLookupDefinition,
   finnhubGetBasicFinancialsDefinition,
   confluenceFetchPageContentDefinition,
-  snowflakeRunSnowflakeQueryWriteResultsToS3Definition,
+  snowflakeRunSnowflakeQueryDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -66,7 +66,7 @@ export const ACTION_GROUPS: ActionGroups = {
   },
   SNOWFLAKE_ACTIONS: {
     description: "Action for getting content from a Snowflake table",
-    actions: [snowflakeGetRowByFieldValueDefinition, snowflakeRunSnowflakeQueryWriteResultsToS3Definition],
+    actions: [snowflakeGetRowByFieldValueDefinition, snowflakeRunSnowflakeQueryDefinition],
   },
   JIRA_CREATE_TICKET: {
     description: "Action for creating a Jira ticket",

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -1,37 +1,30 @@
 import snowflake from "snowflake-sdk";
 import {
   AuthParamsType,
-  snowflakeRunSnowflakeQueryWriteResultsToS3Function,
-  snowflakeRunSnowflakeQueryWriteResultsToS3OutputType,
-  snowflakeRunSnowflakeQueryWriteResultsToS3ParamsType,
+  snowflakeRunSnowflakeQueryFunction,
+  snowflakeRunSnowflakeQueryOutputType,
+  snowflakeRunSnowflakeQueryParamsType,
 } from "../../autogen/types";
 import crypto from "crypto";
-import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { v4 as uuidv4 } from "uuid";
-
 // Only log errors.
 snowflake.configure({ logLevel: "ERROR" });
 
-const runSnowflakeQueryWriteResultsToS3: snowflakeRunSnowflakeQueryWriteResultsToS3Function = async ({
+const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
   params,
   authParams,
 }: {
-  params: snowflakeRunSnowflakeQueryWriteResultsToS3ParamsType;
+  params: snowflakeRunSnowflakeQueryParamsType;
   authParams: AuthParamsType;
-}): Promise<snowflakeRunSnowflakeQueryWriteResultsToS3OutputType> => {
-  const { databaseName, warehouse, query, user, accountName, s3BucketName, s3Region, outputFormat = "json" } = params;
+}): Promise<snowflakeRunSnowflakeQueryOutputType> => {
+  const { databaseName, warehouse, query, user, accountName, outputFormat = "json" } = params;
 
-  const { apiKey: privateKey, awsAccessKeyId, awsSecretAccessKey } = authParams;
+  const { apiKey: privateKey } = authParams;
 
   if (!privateKey) {
     throw new Error("Snowflake private key is required");
   }
-  if (!awsAccessKeyId || !awsSecretAccessKey) {
-    throw new Error("AWS credentials are required");
-  }
-  if (!accountName || !user || !databaseName || !warehouse || !query || !s3BucketName) {
-    throw new Error("Missing required parameters for Snowflake query or S3 destination");
+  if (!accountName || !user || !databaseName || !warehouse || !query) {
+    throw new Error("Missing required parameters for Snowflake query");
   }
 
   const getPrivateKeyCorrectFormat = (privateKey: string): string => {
@@ -77,42 +70,9 @@ const runSnowflakeQueryWriteResultsToS3: snowflakeRunSnowflakeQueryWriteResultsT
       }
     } else {
       // Default to JSON
-      formattedData = JSON.stringify(queryResults, null, 2);
+      formattedData = JSON.stringify(queryResults).replace(/\s+/g, "");
     }
     return { formattedData, resultsLength: queryResults.length };
-  };
-  const uploadToS3AndGetURL = async (formattedData: string): Promise<string> => {
-    // Create S3 client
-    const s3Client = new S3Client({
-      region: s3Region,
-      credentials: {
-        accessKeyId: awsAccessKeyId,
-        secretAccessKey: awsSecretAccessKey,
-      },
-    });
-
-    const contentType = outputFormat.toLowerCase() === "csv" ? "text/csv" : "application/json";
-    const fileExtension = outputFormat.toLowerCase() === "csv" ? "csv" : "json";
-    const finalKey = `${databaseName}/${uuidv4()}.${fileExtension}`;
-
-    // Upload to S3 without ACL
-    const uploadCommand = new PutObjectCommand({
-      Bucket: s3BucketName,
-      Key: finalKey,
-      Body: formattedData,
-      ContentType: contentType,
-    });
-
-    await s3Client.send(uploadCommand);
-
-    // Generate a presigned URL (valid for an hour)
-    const getObjectCommand = new GetObjectCommand({
-      Bucket: s3BucketName,
-      Key: finalKey,
-    });
-
-    const presignedUrl = await getSignedUrl(s3Client, getObjectCommand, { expiresIn: 3600 });
-    return presignedUrl;
   };
 
   // Process the private key
@@ -142,7 +102,6 @@ const runSnowflakeQueryWriteResultsToS3: snowflakeRunSnowflakeQueryWriteResultsT
     });
 
     const { formattedData, resultsLength } = await executeQueryAndFormatData();
-    const presignedUrl = await uploadToS3AndGetURL(formattedData);
 
     // Return fields to match schema definition
     connection.destroy(err => {
@@ -151,9 +110,8 @@ const runSnowflakeQueryWriteResultsToS3: snowflakeRunSnowflakeQueryWriteResultsT
       }
     });
     return {
-      bucketUrl: presignedUrl,
-      message: `Query results successfully written to S3. URL valid for 1 hour.`,
       rowCount: resultsLength,
+      content: formattedData,
     };
   } catch (error: unknown) {
     connection.destroy(err => {
@@ -165,4 +123,4 @@ const runSnowflakeQueryWriteResultsToS3: snowflakeRunSnowflakeQueryWriteResultsT
   }
 };
 
-export default runSnowflakeQueryWriteResultsToS3;
+export default runSnowflakeQuery;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -562,12 +562,12 @@ actions:
               rowContents:
                 type: object
                 description: The contents of the row
-    runSnowflakeQueryWriteResultsToS3:
-      description: Execute a Snowflake query and write results to an S3 bucket
+    runSnowflakeQuery:
+      description: Execute a Snowflake query and return output.
       scopes: []
       parameters:
         type: object
-        required: [databaseName, warehouse, query, user, accountName, s3BucketName, s3Region]
+        required: [databaseName, warehouse, query, user, accountName]
         properties:
           databaseName:
             type: string
@@ -584,26 +584,17 @@ actions:
           accountName:
             type: string
             description: The name of the Snowflake account
-          s3BucketName:
-            type: string
-            description: The name of the S3 bucket to write results to
-          s3Region:
-            type: string
-            description: The AWS region where the S3 bucket is located
           outputFormat:
             type: string
-            description: Format for the output file (json or csv, defaults to json)
+            description: The format of the output
             enum: [json, csv]
       output:
         type: object
-        required: [bucketUrl, message, rowCount]
+        required: [content, rowCount]
         properties:
-          bucketUrl: 
+          content:
             type: string
-            description: The URL of the S3 bucket where the results are stored
-          message:
-            type: string
-            description: A message describing the result or error
+            description: The content of the query result (json)
           rowCount:
             type: number
             description: The number of rows returned by the query

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -4,30 +4,24 @@ import { runAction } from "../src/app";
 async function runTest() {
     // Set up test parameters
     const params = {
-        // Snowflake database connection params:
+        // Snowflake database connection params (hard set by user):
         databaseName: "insert-database-name",
         warehouse: "insert-compute-warehouse",
         user: "insert-user-name",
         accountName: "insert-account-name",
         // Query param:
         query: "insert-query-here",
-        // S3 bucket params:
-        s3BucketName: "insert-s3-bucket-name",
-        s3Region: "insert-s3-region",
-        // Optional parameters:
         outputFormat: "json" // or "csv"
     };
 
     const authParams = {
         apiKey: "insert-snowflake-private-key", // Private key in PEM format
-        awsAccessKeyId: "insert-aws-access-key-id",
-        awsSecretAccessKey: "insert-aws-secret-access-key"
     };
     
     try {
         // Run the action
         const result = await runAction(
-            "runSnowflakeQueryWriteResultsToS3",
+            "runSnowflakeQuery",
             "snowflake",
             authParams, 
             params
@@ -35,14 +29,9 @@ async function runTest() {
             
         // Validate the response
         assert(result, "Response should not be null");
-        assert(result.bucketUrl, "Response should contain the S3 bucket URL");
-        assert(result.message, "Response should contain a result message");
-        assert(typeof result.rowCount === 'number', "Response should contain a row count");
-        
-        console.log(`Successfully executed Snowflake query and wrote results to S3`);
-        console.log(`- Bucket URL: ${result.bucketUrl}`);
-        console.log(`- Row count: ${result.rowCount}`);
-        console.log(`- Message: ${result.message}`);
+        assert(result.rowCount, "Response should contain a row count");
+        assert(result.content, "Response should contain a result content");
+        console.log("Test passed! with content: " + result.content);
     } catch (error) {
         console.error("Test failed:", error);
         process.exit(1);


### PR DESCRIPTION

- Wanted to test if queries ran successfully via output to S3
- Can verify via action invocation output - and then use in context for chats.
- Simplifies this action so it doesn't do too many things at once.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies Snowflake query execution by returning results directly, removing S3 output functionality, and updating related schemas and tests.
> 
>   - **Behavior**:
>     - `runSnowflakeQuery` now returns query results directly instead of writing to S3.
>     - Removes S3-related parameters and logic from `runSnowflakeQuery`.
>   - **Schemas and Types**:
>     - Renames `snowflakeRunSnowflakeQueryWriteResultsToS3ParamsSchema` to `snowflakeRunSnowflakeQueryParamsSchema` in `types.ts`.
>     - Updates `snowflakeRunSnowflakeQueryOutputSchema` to include `content` instead of `bucketUrl` and `message`.
>   - **Files and Functions**:
>     - Renames `runSnowflakeQueryWriteResultsToS3.ts` to `runSnowflakeQuery.ts`.
>     - Updates `actionMapper.ts` and `groups.ts` to use `runSnowflakeQuery`.
>     - Removes `@aws-sdk/s3-request-presigner` and `uuid` from `package.json` dependencies.
>   - **Tests**:
>     - Updates `testSnowflakeQuery.ts` to reflect changes in `runSnowflakeQuery` behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for c4c42959f52516c942cf9a398dbfd859e7dee7cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->