### PR TITLE
[Snowflake] Move snowflake actions to use oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+.env.tests/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/src/actions/providers/snowflake/getRowByFieldValue.ts
+++ b/src/actions/providers/snowflake/getRowByFieldValue.ts
@@ -28,8 +28,8 @@ const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
     username: user,
     authenticator: "OAUTH",
     token: authToken,
-    role: "CREDAL_READ", // If you have specific role requirements
-    warehouse: warehouse, // Similarly for warehouse
+    role: "CREDAL_READ",
+    warehouse: warehouse,
     database: databaseName,
     schema: "PUBLIC",
   });
@@ -46,7 +46,7 @@ const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
       });
     });
 
-    const query = `SELECT * FROM ${databaseName}.PUBLIC.${tableName} WHERE ${fieldName} = '${fieldValue}'`;
+    const query = `SELECT * FROM ${databaseName}.PUBLIC.${tableName} WHERE ${fieldName} = ?`;
     const binds = [fieldValue];
 
     return await new Promise<snowflakeGetRowByFieldValueOutputType>((resolve, reject) => {

--- a/tests/testSnowflakeGetRowByFieldValue.ts
+++ b/tests/testSnowflakeGetRowByFieldValue.ts
@@ -1,21 +1,22 @@
-import { assert } from "node:console";
 import { runAction } from "../src/app";
 
 async function runTest() {
+
     const result = await runAction(
         "getRowByFieldValue",
         "snowflake",
-        { apiKey: "" }, // authParams
+        { authToken: "insert-oauth-access-token" },
         {
-            databaseName: "RAMP_DEMO",
-            accountName: "LYBHROH-NDB34197.us-west-2",
-            user: "RIABALLI",
-            tableName: "EXAMPLE_USERS",
-            fieldName: "COMPANY",
-            fieldValue: "Ramp.com",
+            databaseName: "insert-database-name",
+            accountName: "insert-account-name",
+            warehouse: "insert-warehouse-name",
+            user: "insert-user-name",
+            tableName: "insert-table-name",
+            fieldName: "insert-field-name",
+            fieldValue: "insert-field-value",
         }
     );
-
+    console.log(result);
 }
 
 runTest().catch(console.error);

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -2,48 +2,48 @@ import assert from "node:assert";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    // Set up test parameters
-    const params = {
-        // Snowflake database connection params (hard set by user):
-        databaseName: "insert-database-name",
-        warehouse: "insert-compute-warehouse",
-        user: "insert-user-name",
-        accountName: "insert-account-name",
-        // Query param:
-        query: "insert-query-here",
-        outputFormat: "json" // or "csv"
-    };
+  // Set up test parameters
+  const params = {
+    // Database connection params
+    databaseName: "insert-database-name",
+    warehouse: "insert-warehouse-name",
+    user: "insert-user-name",
+    accountName: "insert-account-name",
+    // Query param
+    query: "insert-query",
+    outputFormat: "json", // or "csv"
+  };
 
-    const authParams = {
-        apiKey: "insert-snowflake-private-key", // Private key in PEM format
-    };
-    
-    try {
-        // Run the action
-        const result = await runAction(
-            "runSnowflakeQuery",
-            "snowflake",
-            authParams, 
-            params
-        );
-            
-        // Validate the response
-        assert(result, "Response should not be null");
-        assert(result.rowCount, "Response should contain a row count");
-        assert(result.content, "Response should contain a result content");
-        console.log("Test passed! with content: " + result.content);
-    } catch (error) {
-        console.error("Test failed:", error);
-        process.exit(1);
-    }
+  const authParams = {
+    authToken: "insert-oauth-access-token",
+  }; 
+
+  try {
+    // Run the action
+    const result = await runAction(
+      "runSnowflakeQuery",
+      "snowflake",
+      authParams,
+      params
+    );
+
+    // Validate the response
+    assert(result, "Response should not be null");
+    assert(result.rowCount >= 0, "Response should contain a row count");
+    assert(result.content, "Response should contain a result content");
+    console.log("Test passed! with content: " + result.content);
+  } catch (error) {
+    console.error("Test failed:", error);
+    process.exit(1);
+  }
 }
 
 // Uncomment the test you want to run
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });


### PR DESCRIPTION
- Move from private key for auth to use oauth (more secure)
- Instead of using `ACCOUNTADMIN` move to a new role to be setup by users `CREDAL_USER`
- This way when users have more control on what the action should/shouldn't be able to access on snowflake 

- Working on a doc for creating this Role in a snowflake account + granting access to the appropriate databases/tables/schemas - the benefit of this is a action like (run snowflake query) can't do any destructive behavior like dropping tables.

- Ideally users will configure this to be a action that only has READ access - by default there's no role setup like this in snowflake which is why the custom role is required. 

Example:
<img width="506" alt="Screenshot 2025-03-20 at 6 37 11 PM" src="https://github.com/user-attachments/assets/dc16dc8e-3baa-408e-baa3-9758c4f60dcd" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch Snowflake actions from private key to OAuth authentication, updating roles and tests accordingly.
> 
>   - **Authentication**:
>     - Switch from private key to OAuth for Snowflake actions in `getRowByFieldValue.ts` and `runSnowflakeQuery.ts`.
>     - Replace `privateKey` with `authToken` for authentication.
>     - Change role from `ACCOUNTADMIN` to `CREDAL_READ`.
>   - **Error Handling**:
>     - Update error messages to reflect OAuth token requirement.
>   - **Tests**:
>     - Update `testSnowflakeGetRowByFieldValue.ts` and `testSnowflakeQuery.ts` to use `authToken` instead of `apiKey`.
>     - Modify test parameters to be placeholders for OAuth setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 15b6b0645d6fee4091775ee4e2b4db59cb2296ee. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->