### PR TITLE
[zendesk] add comment to ticket action

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -27,6 +27,8 @@ import {
   jiraAssignJiraTicketOutputSchema,
   zendeskUpdateTicketStatusOutputSchema,
   zendeskUpdateTicketStatusParamsSchema,
+  zendeskAddCommentToTicketOutputSchema,
+  zendeskAddCommentToTicketParamsSchema,
   jiraCreateJiraTicketParamsSchema,
   jiraCreateJiraTicketOutputSchema,
   openstreetmapGetLatitudeLongitudeFromLocationParamsSchema,
@@ -69,6 +71,7 @@ import createZendeskTicket from "./providers/zendesk/createZendeskTicket";
 import getZendeskTicketDetails from "./providers/zendesk/getTicketDetails";
 import assignJiraTicket from "./providers/jira/assignJiraTicket";
 import updateTicketStatus from "./providers/zendesk/updateTicketStatus";
+import addCommentToTicket from "./providers/zendesk/addCommentToTicket";
 import createJiraTicket from "./providers/jira/createJiraTicket";
 import getLatitudeLongitudeFromLocation from "./providers/openstreetmap/getLatitudeLongitudeFromLocation";
 import getForecastForLocation from "./providers/nws/getForecastForLocation";
@@ -160,6 +163,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: updateTicketStatus,
       paramsSchema: zendeskUpdateTicketStatusParamsSchema,
       outputSchema: zendeskUpdateTicketStatusOutputSchema,
+    },
+    addCommentToTicket: {
+      fn: addCommentToTicket,
+      paramsSchema: zendeskAddCommentToTicketParamsSchema,
+      outputSchema: zendeskAddCommentToTicketOutputSchema,
     },
   },
   mongo: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -700,6 +700,41 @@ export const zendeskUpdateTicketStatusDefinition: ActionTemplate = {
   name: "updateTicketStatus",
   provider: "zendesk",
 };
+export const zendeskAddCommentToTicketDefinition: ActionTemplate = {
+  description: "Add a comment to a ticket in Zendesk",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["ticketId", "subdomain", "comment"],
+    properties: {
+      ticketId: {
+        type: "string",
+        description: "The ID of the ticket to update",
+      },
+      subdomain: {
+        type: "string",
+        description: "The subdomain of the Zendesk account",
+      },
+      comment: {
+        type: "object",
+        description: "The comment to add to the ticket",
+        required: ["body"],
+        properties: {
+          body: {
+            type: "string",
+            description: "The body of the comment",
+          },
+          public: {
+            type: "boolean",
+            description: "Whether the comment should be public",
+          },
+        },
+      },
+    },
+  },
+  name: "addCommentToTicket",
+  provider: "zendesk",
+};
 export const linkedinCreateShareLinkedinPostUrlDefinition: ActionTemplate = {
   description: "Create a share linkedin post link",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -395,6 +395,28 @@ export type zendeskUpdateTicketStatusFunction = ActionFunction<
   zendeskUpdateTicketStatusOutputType
 >;
 
+export const zendeskAddCommentToTicketParamsSchema = z.object({
+  ticketId: z.string().describe("The ID of the ticket to update"),
+  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  comment: z
+    .object({
+      body: z.string().describe("The body of the comment"),
+      public: z.boolean().describe("Whether the comment should be public").optional(),
+    })
+    .describe("The comment to add to the ticket"),
+});
+
+export type zendeskAddCommentToTicketParamsType = z.infer<typeof zendeskAddCommentToTicketParamsSchema>;
+
+export const zendeskAddCommentToTicketOutputSchema = z.void();
+
+export type zendeskAddCommentToTicketOutputType = z.infer<typeof zendeskAddCommentToTicketOutputSchema>;
+export type zendeskAddCommentToTicketFunction = ActionFunction<
+  zendeskAddCommentToTicketParamsType,
+  AuthParamsType,
+  zendeskAddCommentToTicketOutputType
+>;
+
 export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({
   text: z.string().describe("The text for the linkedin post").optional(),
   url: z.string().describe("The url for the linkedin post").optional(),

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -1,0 +1,42 @@
+import {
+  AuthParamsType,
+  zendeskAddCommentToTicketFunction,
+  zendeskAddCommentToTicketOutputType,
+  zendeskAddCommentToTicketParamsType,
+} from "../../autogen/types";
+import { axiosClient } from "../../util/axiosClient";
+
+const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
+  params,
+  authParams,
+}: {
+  params: zendeskAddCommentToTicketParamsType;
+  authParams: AuthParamsType;
+}): Promise<zendeskAddCommentToTicketOutputType> => {
+  const { authToken, username } = authParams;
+  const { subdomain, ticketId, comment } = params;
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
+
+  if (!authToken) {
+    throw new Error("authToken is required");
+  }
+
+  await axiosClient.request({
+    url: url,
+    method: "PUT",
+    auth: {
+      username: `${username}/token`,
+      password: authToken,
+    },
+    headers: {
+      "Content-Type": "application/json",
+    },
+    data: {
+      ticket: {
+        comment: comment,
+      },
+    },
+  });
+};
+
+export default addCommentToTicket;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -504,6 +504,30 @@ actions:
           status:
             type: string
             description: The state of the ticket. If your account has activated custom ticket statuses, this is the ticket's status category. Allowed values are "new", "open", "pending", "hold", "solved", or "closed".
+    addCommentToTicket:
+      description: Add a comment to a ticket in Zendesk
+      scopes: []
+      parameters:
+        type: object
+        required: [ticketId, subdomain, comment]
+        properties:
+          ticketId:
+            type: string
+            description: The ID of the ticket to update
+          subdomain:
+            type: string
+            description: The subdomain of the Zendesk account
+          comment:
+            type: object
+            description: The comment to add to the ticket
+            required: [body]
+            properties:
+              body:
+                type: string
+                description: The body of the comment
+              public:
+                type: boolean
+                description: Whether the comment should be public
   linkedin:
     createShareLinkedinPostUrl:
       description: Create a share linkedin post link

--- a/tests/testZendeskAddCommentToTicket.ts
+++ b/tests/testZendeskAddCommentToTicket.ts
@@ -1,0 +1,22 @@
+import { runAction } from "../src/app";
+
+async function runTest() {
+  await runAction(
+    "addCommentToTicket",
+    "zendesk",
+    {
+      authToken: "insert-your-auth-token",
+      username: "insert-your-username",
+    }, // authParams
+    {
+      ticketId: "62",
+      subdomain: "credalai",
+      comment: {
+        body: "This is a test private comment",
+        public: true,
+      }
+    }
+  );
+}
+
+runTest().catch(console.error);


### PR DESCRIPTION
Ran `npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/testZendeskAddCommentToTicket.ts`

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `addCommentToTicket` action for Zendesk to allow adding comments to existing tickets, including new schemas, function, and test.
> 
>   - **Behavior**:
>     - Adds `addCommentToTicket` action to `actionMapper.ts` for Zendesk, allowing comments to be added to existing tickets.
>     - Implements `addCommentToTicket` function in `addCommentToTicket.ts` to send PUT requests to Zendesk API.
>   - **Schemas and Types**:
>     - Adds `zendeskAddCommentToTicketParamsSchema` and `zendeskAddCommentToTicketOutputSchema` in `types.ts`.
>     - Defines `zendeskAddCommentToTicketDefinition` in `templates.ts`.
>   - **Testing**:
>     - Adds `testZendeskAddCommentToTicket.ts` to test the new action using `runAction`.
>   - **Misc**:
>     - Updates `schema.yaml` to include `addCommentToTicket` action under Zendesk.
>     - Bumps version in `package.json` from `0.1.30` to `0.1.31`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 08ccf16734c8c6dfa16e7bf2a8e603462cf727d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->