### PR TITLE
[google] create google spreadsheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -49,6 +49,8 @@ import {
   snowflakeRunSnowflakeQueryOutputSchema,
   lookerEnableUserByEmailParamsSchema,
   lookerEnableUserByEmailOutputSchema,
+  googleOauthCreateSpreadsheetParamsSchema,
+  googleOauthCreateSpreadsheetOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -74,6 +76,7 @@ import confluenceOverwritePage from "./providers/confluence/overwritePage";
 import confluenceFetchPageContent from "./providers/confluence/fetchPageContent";
 import runSnowflakeQuery from "./providers/snowflake/runSnowflakeQuery";
 import enableUserByEmail from "./providers/looker/enableUserByEmail";
+import { createSpreadsheet } from "./providers/google-oauth/createSpreadsheet";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -211,6 +214,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: createNewGoogleDoc,
       paramsSchema: googleOauthCreateNewGoogleDocParamsSchema,
       outputSchema: googleOauthCreateNewGoogleDocOutputSchema,
+    },
+    createSpreadsheet: {
+      fn: createSpreadsheet,
+      paramsSchema: googleOauthCreateSpreadsheetParamsSchema,
+      outputSchema: googleOauthCreateSpreadsheetOutputSchema,
     },
   },
   x: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1039,6 +1039,118 @@ export const googleOauthCreateNewGoogleDocDefinition: ActionTemplate = {
   name: "createNewGoogleDoc",
   provider: "googleOauth",
 };
+export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {
+  description: "Create a new Google Spreadsheet using OAuth authentication",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["title"],
+    properties: {
+      title: {
+        type: "string",
+        description: "The title of the new spreadsheet",
+      },
+      sheets: {
+        type: "array",
+        description: "The initial sheets to create in the spreadsheet",
+        items: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              description: "The title of the sheet",
+            },
+            gridProperties: {
+              type: "object",
+              properties: {
+                rowCount: {
+                  type: "integer",
+                  description: "The number of rows in the sheet",
+                },
+                columnCount: {
+                  type: "integer",
+                  description: "The number of columns in the sheet",
+                },
+                frozenRowCount: {
+                  type: "integer",
+                  description: "The number of frozen rows",
+                },
+                frozenColumnCount: {
+                  type: "integer",
+                  description: "The number of frozen columns",
+                },
+              },
+            },
+          },
+        },
+      },
+      properties: {
+        type: "object",
+        description: "Properties for the spreadsheet",
+        properties: {
+          locale: {
+            type: "string",
+            description: "The locale of the spreadsheet (e.g., en_US)",
+          },
+          timeZone: {
+            type: "string",
+            description: "The time zone of the spreadsheet (e.g., America/New_York)",
+          },
+          autoRecalc: {
+            type: "string",
+            enum: ["ON_CHANGE", "MINUTE", "HOUR"],
+            description: "When to recalculate the spreadsheet",
+          },
+        },
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the spreadsheet was created successfully",
+      },
+      spreadsheetId: {
+        type: "string",
+        description: "The ID of the created spreadsheet",
+      },
+      spreadsheetUrl: {
+        type: "string",
+        description: "The URL to access the created spreadsheet",
+      },
+      sheets: {
+        type: "array",
+        description: "Information about the created sheets",
+        items: {
+          type: "object",
+          properties: {
+            sheetId: {
+              type: "integer",
+              description: "The ID of the sheet",
+            },
+            title: {
+              type: "string",
+              description: "The title of the sheet",
+            },
+            index: {
+              type: "integer",
+              description: "The index of the sheet",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the spreadsheet was not created successfully",
+      },
+    },
+  },
+  name: "createSpreadsheet",
+  provider: "googleOauth",
+};
 export const finnhubSymbolLookupDefinition: ActionTemplate = {
   description: "Look up a stock symbol by name",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -573,6 +573,60 @@ export type googleOauthCreateNewGoogleDocFunction = ActionFunction<
   googleOauthCreateNewGoogleDocOutputType
 >;
 
+export const googleOauthCreateSpreadsheetParamsSchema = z.object({
+  title: z.string().describe("The title of the new spreadsheet"),
+  sheets: z
+    .array(
+      z.object({
+        title: z.string().describe("The title of the sheet").optional(),
+        gridProperties: z
+          .object({
+            rowCount: z.number().int().describe("The number of rows in the sheet").optional(),
+            columnCount: z.number().int().describe("The number of columns in the sheet").optional(),
+            frozenRowCount: z.number().int().describe("The number of frozen rows").optional(),
+            frozenColumnCount: z.number().int().describe("The number of frozen columns").optional(),
+          })
+          .optional(),
+      }),
+    )
+    .describe("The initial sheets to create in the spreadsheet")
+    .optional(),
+  properties: z
+    .object({
+      locale: z.string().describe("The locale of the spreadsheet (e.g., en_US)").optional(),
+      timeZone: z.string().describe("The time zone of the spreadsheet (e.g., America/New_York)").optional(),
+      autoRecalc: z.enum(["ON_CHANGE", "MINUTE", "HOUR"]).describe("When to recalculate the spreadsheet").optional(),
+    })
+    .describe("Properties for the spreadsheet")
+    .optional(),
+});
+
+export type googleOauthCreateSpreadsheetParamsType = z.infer<typeof googleOauthCreateSpreadsheetParamsSchema>;
+
+export const googleOauthCreateSpreadsheetOutputSchema = z.object({
+  success: z.boolean().describe("Whether the spreadsheet was created successfully"),
+  spreadsheetId: z.string().describe("The ID of the created spreadsheet").optional(),
+  spreadsheetUrl: z.string().describe("The URL to access the created spreadsheet").optional(),
+  sheets: z
+    .array(
+      z.object({
+        sheetId: z.number().int().describe("The ID of the sheet").optional(),
+        title: z.string().describe("The title of the sheet").optional(),
+        index: z.number().int().describe("The index of the sheet").optional(),
+      }),
+    )
+    .describe("Information about the created sheets")
+    .optional(),
+  error: z.string().describe("The error that occurred if the spreadsheet was not created successfully").optional(),
+});
+
+export type googleOauthCreateSpreadsheetOutputType = z.infer<typeof googleOauthCreateSpreadsheetOutputSchema>;
+export type googleOauthCreateSpreadsheetFunction = ActionFunction<
+  googleOauthCreateSpreadsheetParamsType,
+  AuthParamsType,
+  googleOauthCreateSpreadsheetOutputType
+>;
+
 export const finnhubSymbolLookupParamsSchema = z.object({
   query: z.string().describe("The symbol or colloquial name of the company to look up"),
 });

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -23,6 +23,7 @@ import {
   confluenceFetchPageContentDefinition,
   snowflakeRunSnowflakeQueryDefinition,
   lookerEnableUserByEmailDefinition,
+  googleOauthCreateSpreadsheetDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -47,7 +48,7 @@ export const ACTION_GROUPS: ActionGroups = {
   },
   GOOGLE_DRIVE: {
     description: "Action for interacting with Google Drive",
-    actions: [googleOauthCreateNewGoogleDocDefinition],
+    actions: [googleOauthCreateNewGoogleDocDefinition, googleOauthCreateSpreadsheetDefinition],
   },
   CREDAL_CALL_COPILOT: {
     description: "Action for calling a Credal Copilot",

--- a/src/actions/providers/google-oauth/createSpreadsheet.ts
+++ b/src/actions/providers/google-oauth/createSpreadsheet.ts
@@ -17,7 +17,7 @@ export const createSpreadsheet: googleOauthCreateSpreadsheetFunction = async ({
   authParams: AuthParamsType;
 }): Promise<googleOauthCreateSpreadsheetOutputType> => {
   if (!authParams.authToken) {
-    throw new Error("authToken is required for Google Docs API");
+    throw new Error("authToken is required for Google Sheets API");
   }
 
   const { title, sheets = [], properties = {} } = params;

--- a/src/actions/providers/google-oauth/createSpreadsheet.ts
+++ b/src/actions/providers/google-oauth/createSpreadsheet.ts
@@ -28,7 +28,7 @@ export const createSpreadsheet: googleOauthCreateSpreadsheetFunction = async ({
       title,
       ...properties,
     },
-    sheets,
+    sheets: sheets.map(sheet => ({ properties: sheet })),
   };
 
   try {
@@ -52,10 +52,10 @@ export const createSpreadsheet: googleOauthCreateSpreadsheetFunction = async ({
       success: true,
       spreadsheetId,
       spreadsheetUrl,
-      sheets: createdSheets.map((sheet: { sheetId: number; title: string; index: number }) => ({
-        sheetId: sheet.sheetId,
-        title: sheet.title,
-        index: sheet.index,
+      sheets: createdSheets.map((sheet: { properties: { sheetId: number; title: string; index: number } }) => ({
+        sheetId: sheet.properties.sheetId,
+        title: sheet.properties.title,
+        index: sheet.properties.index,
       })),
     };
   } catch (error) {

--- a/src/actions/providers/google-oauth/createSpreadsheet.ts
+++ b/src/actions/providers/google-oauth/createSpreadsheet.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+import {
+  AuthParamsType,
+  googleOauthCreateSpreadsheetFunction,
+  googleOauthCreateSpreadsheetParamsType,
+  googleOauthCreateSpreadsheetOutputType,
+} from "../../autogen/types";
+
+/**
+ * Creates a new Google Spreadsheet using OAuth authentication
+ */
+export const createSpreadsheet: googleOauthCreateSpreadsheetFunction = async ({
+  params,
+  authParams,
+}: {
+  params: googleOauthCreateSpreadsheetParamsType;
+  authParams: AuthParamsType;
+}): Promise<googleOauthCreateSpreadsheetOutputType> => {
+  if (!authParams.authToken) {
+    throw new Error("authToken is required for Google Docs API");
+  }
+
+  const { title, sheets = [], properties = {} } = params;
+  const baseApiUrl = "https://sheets.googleapis.com/v4/spreadsheets";
+
+  const requestBody = {
+    properties: {
+      title,
+      ...properties,
+    },
+    sheets,
+  };
+
+  try {
+    const response = await axios.post(baseApiUrl, requestBody, {
+      headers: {
+        Authorization: `Bearer ${authParams.authToken}`,
+      },
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      return {
+        success: false,
+        error: response.statusText,
+      };
+    }
+
+    const { spreadsheetId, sheets: createdSheets } = response.data;
+    const spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
+
+    return {
+      success: true,
+      spreadsheetId,
+      spreadsheetUrl,
+      sheets: createdSheets.map((sheet: { sheetId: number; title: string; index: number }) => ({
+        sheetId: sheet.sheetId,
+        title: sheet.title,
+        index: sheet.index,
+      })),
+    };
+  } catch (error) {
+    console.error("Error creating spreadsheet:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -751,6 +751,85 @@ actions:
           documentUrl:
             type: string
             description: The URL to access the created Google Doc
+    createSpreadsheet:
+      description: Create a new Google Spreadsheet using OAuth authentication
+      scopes: []
+      parameters:
+        type: object
+        required: [title]
+        properties:
+          title:
+            type: string
+            description: The title of the new spreadsheet
+          sheets:
+            type: array
+            description: The initial sheets to create in the spreadsheet
+            items:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: The title of the sheet
+                gridProperties:
+                  type: object
+                  properties:
+                    rowCount:
+                      type: integer
+                      description: The number of rows in the sheet
+                    columnCount:
+                      type: integer
+                      description: The number of columns in the sheet
+                    frozenRowCount:
+                      type: integer
+                      description: The number of frozen rows
+                    frozenColumnCount:
+                      type: integer
+                      description: The number of frozen columns
+          properties:
+            type: object
+            description: Properties for the spreadsheet
+            properties:
+              locale:
+                type: string
+                description: The locale of the spreadsheet (e.g., en_US)
+              timeZone:
+                type: string
+                description: The time zone of the spreadsheet (e.g., America/New_York)
+              autoRecalc:
+                type: string
+                enum: ["ON_CHANGE", "MINUTE", "HOUR"]
+                description: When to recalculate the spreadsheet
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the spreadsheet was created successfully
+          spreadsheetId:
+            type: string
+            description: The ID of the created spreadsheet
+          spreadsheetUrl:
+            type: string
+            description: The URL to access the created spreadsheet
+          sheets:
+            type: array
+            description: Information about the created sheets
+            items:
+              type: object
+              properties:
+                sheetId:
+                  type: integer
+                  description: The ID of the sheet
+                title:
+                  type: string
+                  description: The title of the sheet
+                index:
+                  type: integer
+                  description: The index of the sheet
+          error:
+            type: string
+            description: The error that occurred if the spreadsheet was not created successfully
   finnhub:
     symbolLookup:
       description: Look up a stock symbol by name

--- a/tests/testGoogleCreateSpreadsheet.ts
+++ b/tests/testGoogleCreateSpreadsheet.ts
@@ -1,0 +1,70 @@
+import { runAction } from "../src/app";
+import assert from "node:assert";
+
+/**
+ * Test for the Google OAuth createSpreadsheet action
+ */
+async function runTest() {
+  console.log("Running test for Google OAuth createSpreadsheet");
+
+  const authToken = "insert-access-token"; // Test with token from: https://developers.google.com/oauthplayground/
+
+  // Create a new spreadsheet with two sheets
+  const result = await runAction(
+    "createSpreadsheet",
+    "googleOauth",
+    {
+      authToken,
+    },
+    {
+      title: "Test Spreadsheet",
+      sheets: [
+        {
+          title: "Data",
+          gridProperties: {
+            rowCount: 100,
+            columnCount: 26,
+            frozenRowCount: 1,
+          },
+        },
+        {
+          title: "Summary",
+          gridProperties: {
+            rowCount: 50,
+            columnCount: 10,
+          },
+        },
+      ],
+      properties: {
+        locale: "en_US",
+        timeZone: "America/New_York",
+        autoRecalc: "ON_CHANGE",
+      },
+    }
+  );
+
+  console.log("Result:", result);
+
+  // Validate the result
+  assert(result.spreadsheetId, "Result should contain a spreadsheetId");
+  assert(result.spreadsheetUrl, "Result should contain a spreadsheetUrl");
+  assert(result.sheets.length === 2, "Should have created 2 sheets");
+  assert(
+    result.sheets[0].title === "Data",
+    "First sheet should be named 'Data'"
+  );
+  assert(
+    result.sheets[1].title === "Summary",
+    "Second sheet should be named 'Summary'"
+  );
+
+  console.log("Link to Google Spreadsheet: ", result.spreadsheetUrl);
+
+  return result;
+}
+
+// Run the test
+runTest().catch((error) => {
+  console.error("Test execution failed:", error);
+  process.exit(1);
+});

--- a/tests/testGoogleCreateSpreadsheet.ts
+++ b/tests/testGoogleCreateSpreadsheet.ts
@@ -1,3 +1,4 @@
+import { googleOauthCreateSpreadsheetParamsType } from "../src/actions/autogen/types";
 import { runAction } from "../src/app";
 import assert from "node:assert";
 
@@ -40,7 +41,7 @@ async function runTest() {
         timeZone: "America/New_York",
         autoRecalc: "ON_CHANGE",
       },
-    }
+    } as googleOauthCreateSpreadsheetParamsType
   );
 
   console.log("Result:", result);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `createSpreadsheet` action to create Google Spreadsheets using OAuth, with updated schemas and tests.
> 
>   - **Behavior**:
>     - Adds `createSpreadsheet` function in `createSpreadsheet.ts` to create Google Spreadsheets using OAuth.
>     - Updates `actionMapper.ts` to include `createSpreadsheet` in `googleOauth` actions.
>     - Updates `schema.yaml` and `templates.ts` with `createSpreadsheet` action definition.
>   - **Schemas**:
>     - Adds `googleOauthCreateSpreadsheetParamsSchema` and `googleOauthCreateSpreadsheetOutputSchema` in `types.ts`.
>   - **Tests**:
>     - Adds `testGoogleCreateSpreadsheet.ts` to test the `createSpreadsheet` action.
>   - **Misc**:
>     - Bumps version in `package.json` from `0.1.30` to `0.1.31`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for c21693dfacab84f9fe75c517aaad701b247ce891. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->