### PR TITLE
Actions - small fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -808,8 +808,13 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["content", "rowCount"],
+    required: ["format", "content", "rowCount"],
     properties: {
+      format: {
+        type: "string",
+        description: "The format of the output",
+        enum: ["json", "csv"],
+      },
       content: {
         type: "string",
         description: "The content of the query result (json)",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -434,6 +434,7 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
 export type snowflakeRunSnowflakeQueryParamsType = z.infer<typeof snowflakeRunSnowflakeQueryParamsSchema>;
 
 export const snowflakeRunSnowflakeQueryOutputSchema = z.object({
+  format: z.enum(["json", "csv"]).describe("The format of the output"),
   content: z.string().describe("The content of the query result (json)"),
   rowCount: z.number().describe("The number of rows returned by the query"),
 });

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -94,6 +94,7 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
     return {
       rowCount: resultsLength,
       content: formattedData,
+      format: outputFormat,
     };
   } catch (error: unknown) {
     connection.destroy(err => {

--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -24,9 +24,15 @@ const createXSharePostUrl: xCreateShareXPostUrlFunction = ({
     queryParams.append("url", params.url);
   }
 
+  let hashtags: string[] = [];
+  if (typeof params.hashtag == "string") {
+    hashtags = [params.hashtag];
+  } else if (Array.isArray(params.hashtag)) {
+    hashtags = params.hashtag;
+  }
   // Add hashtags parameter if it exists
-  if (params.hashtag && params.hashtag.length > 0) {
-    const cleanedHashtags = params.hashtag.map(tag => tag.replace(/^#+/, "").trim()).filter(tag => tag.length > 0);
+  if (hashtags.length > 0) {
+    const cleanedHashtags = hashtags.map(tag => tag.replace(/^#+/, "").trim()).filter(tag => tag.length > 0);
 
     if (cleanedHashtags.length > 0) {
       queryParams.append("hashtags", cleanedHashtags.join(","));

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -590,8 +590,12 @@ actions:
             enum: [json, csv]
       output:
         type: object
-        required: [content, rowCount]
+        required: [format, content, rowCount]
         properties:
+          format:
+            type: string
+            description: The format of the output
+            enum: [json, csv]
           content:
             type: string
             description: The content of the query result (json)

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -31,6 +31,7 @@ async function runTest() {
     assert(result, "Response should not be null");
     assert(result.rowCount >= 0, "Response should contain a row count");
     assert(result.content, "Response should contain a result content");
+    assert((result.format == "csv" || result.format == "json"), "Response should contain a result format");
     console.log("Test passed! with content: " + result.content);
   } catch (error) {
     console.error("Test failed:", error);


### PR DESCRIPTION

1. Add output type to the snowflake obj (used in processing later)
2. Update X share link action to accept string (default usually show up as strings)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add output format to Snowflake query and update X share link action to accept string hashtags.
> 
>   - **Behavior**:
>     - Add `format` to `snowflakeRunSnowflakeQueryOutputSchema` in `types.ts` and `runSnowflakeQuery.ts` to specify output format (json/csv).
>     - Update `createXSharePostUrl` in `createXSharePostUrl.ts` to accept `hashtag` as a string or array.
>   - **Schema**:
>     - Update `snowflakeRunSnowflakeQueryDefinition` in `templates.ts` and `schema.yaml` to include `format` in output.
>     - Update `xCreateShareXPostUrlDefinition` in `templates.ts` to handle `hashtag` as string or array.
>   - **Tests**:
>     - Add assertion for `format` in `testSnowflakeQuery.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 158f912ecf289ae7f35b6f105cc287467cebcba3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->