### PR TITLE
[new Jira action] Assign/Reassign Jira ticket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -21,6 +21,8 @@ import {
   snowflakeGetRowByFieldValueParamsSchema,
   zendeskCreateZendeskTicketOutputSchema,
   zendeskCreateZendeskTicketParamsSchema,
+  jiraAssignJiraTicketParamsSchema,
+  jiraAssignJiraTicketOutputSchema,
   jiraCommentJiraTicketParamsSchema,
   jiraCommentJiraTicketOutputSchema,
   jiraCreateJiraTicketParamsSchema,
@@ -60,6 +62,7 @@ import listConversations from "./providers/slack/listConversations";
 import sendMessage from "./providers/slack/sendMessage";
 import getRowByFieldValue from "./providers/snowflake/getRowByFieldValue";
 import createZendeskTicket from "./providers/zendesk/createZendeskTicket";
+import assignJiraTicket from "./providers/jira/assignJiraTicket";
 import commentJiraTicket from "./providers/jira/commentJiraTicket";
 import createJiraTicket from "./providers/jira/createJiraTicket";
 import getLatitudeLongitudeFromLocation from "./providers/openstreetmap/getLatitudeLongitudeFromLocation";
@@ -170,6 +173,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
     },
   },
   jira: {
+    assignJiraTicket: {
+      fn: assignJiraTicket,
+      paramsSchema: jiraAssignJiraTicketParamsSchema,
+      outputSchema: jiraAssignJiraTicketOutputSchema,
+    },
     commentJiraTicket: {
       fn: commentJiraTicket,
       paramsSchema: jiraCommentJiraTicketParamsSchema,

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -21,6 +21,8 @@ import {
   snowflakeGetRowByFieldValueParamsSchema,
   zendeskCreateZendeskTicketOutputSchema,
   zendeskCreateZendeskTicketParamsSchema,
+  jiraCommentJiraTicketParamsSchema,
+  jiraCommentJiraTicketOutputSchema,
   jiraCreateJiraTicketParamsSchema,
   jiraCreateJiraTicketOutputSchema,
   openstreetmapGetLatitudeLongitudeFromLocationParamsSchema,
@@ -58,6 +60,7 @@ import listConversations from "./providers/slack/listConversations";
 import sendMessage from "./providers/slack/sendMessage";
 import getRowByFieldValue from "./providers/snowflake/getRowByFieldValue";
 import createZendeskTicket from "./providers/zendesk/createZendeskTicket";
+import commentJiraTicket from "./providers/jira/commentJiraTicket";
 import createJiraTicket from "./providers/jira/createJiraTicket";
 import getLatitudeLongitudeFromLocation from "./providers/openstreetmap/getLatitudeLongitudeFromLocation";
 import getForecastForLocation from "./providers/nws/getForecastForLocation";
@@ -167,6 +170,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
     },
   },
   jira: {
+    commentJiraTicket: {
+      fn: commentJiraTicket,
+      paramsSchema: jiraCommentJiraTicketParamsSchema,
+      outputSchema: jiraCommentJiraTicketOutputSchema,
+    },
     createJiraTicket: {
       fn: createJiraTicket,
       paramsSchema: jiraCreateJiraTicketParamsSchema,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -149,7 +149,7 @@ export const confluenceFetchPageContentDefinition: ActionTemplate = {
 };
 export const jiraCommentJiraTicketDefinition: ActionTemplate = {
   description: "Comments on a Jira ticket with specified content",
-  scopes: [],
+  scopes: ["write:comment:jira"],
   parameters: {
     type: "object",
     required: ["projectKey", "issueId", "comment"],
@@ -170,8 +170,16 @@ export const jiraCommentJiraTicketDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["commentUrl"],
+    required: ["success"],
     properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the comment was sent successfully",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the comment was not sent successfully",
+      },
       commentUrl: {
         type: "string",
         description: "The url to the created Jira comment",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -147,6 +147,48 @@ export const confluenceFetchPageContentDefinition: ActionTemplate = {
   name: "fetchPageContent",
   provider: "confluence",
 };
+export const jiraAssignJiraTicketDefinition: ActionTemplate = {
+  description: "Assigns/Re-assignes a Jira ticket to a specified user",
+  scopes: ["write:jira-work", "read:jira-user"],
+  parameters: {
+    type: "object",
+    required: ["projectKey", "issueId", "assignee"],
+    properties: {
+      projectKey: {
+        type: "string",
+        description: "The key for the project you want to add it to",
+      },
+      assignee: {
+        type: "string",
+        description: "The assignee for the ticket, userID or email",
+      },
+      issueId: {
+        type: "string",
+        description: "The issue ID associated with the ticket to be assigned/re-assigned",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the ticket was successfully assigned/reassigned",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the ticket was not successfully assigned/reassigned",
+      },
+      ticketUrl: {
+        type: "string",
+        description: "The url to the newly assigned/reassigned Jira ticket",
+      },
+    },
+  },
+  name: "assignJiraTicket",
+  provider: "jira",
+};
 export const jiraCommentJiraTicketDefinition: ActionTemplate = {
   description: "Comments on a Jira ticket with specified content",
   scopes: ["write:comment:jira"],

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -147,6 +147,40 @@ export const confluenceFetchPageContentDefinition: ActionTemplate = {
   name: "fetchPageContent",
   provider: "confluence",
 };
+export const jiraCommentJiraTicketDefinition: ActionTemplate = {
+  description: "Comments on a Jira ticket with specified content",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["projectKey", "issueId", "comment"],
+    properties: {
+      projectKey: {
+        type: "string",
+        description: "The key for the project you want to add it to",
+      },
+      issueId: {
+        type: "string",
+        description: "The issue ID associated with the ticket to be commented on",
+      },
+      comment: {
+        type: "string",
+        description: "The text to be commented on the ticket",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["commentUrl"],
+    properties: {
+      commentUrl: {
+        type: "string",
+        description: "The url to the created Jira comment",
+      },
+    },
+  },
+  name: "commentJiraTicket",
+  provider: "jira",
+};
 export const jiraCreateJiraTicketDefinition: ActionTemplate = {
   description: "Create a jira ticket with new content specified",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -121,7 +121,9 @@ export const jiraCommentJiraTicketParamsSchema = z.object({
 export type jiraCommentJiraTicketParamsType = z.infer<typeof jiraCommentJiraTicketParamsSchema>;
 
 export const jiraCommentJiraTicketOutputSchema = z.object({
-  commentUrl: z.string().describe("The url to the created Jira comment"),
+  success: z.boolean().describe("Whether the comment was sent successfully"),
+  error: z.string().describe("The error that occurred if the comment was not sent successfully").optional(),
+  commentUrl: z.string().describe("The url to the created Jira comment").optional(),
 });
 
 export type jiraCommentJiraTicketOutputType = z.infer<typeof jiraCommentJiraTicketOutputSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -112,6 +112,30 @@ export type confluenceFetchPageContentFunction = ActionFunction<
   confluenceFetchPageContentOutputType
 >;
 
+export const jiraAssignJiraTicketParamsSchema = z.object({
+  projectKey: z.string().describe("The key for the project you want to add it to"),
+  assignee: z.string().describe("The assignee for the ticket, userID or email"),
+  issueId: z.string().describe("The issue ID associated with the ticket to be assigned/re-assigned"),
+});
+
+export type jiraAssignJiraTicketParamsType = z.infer<typeof jiraAssignJiraTicketParamsSchema>;
+
+export const jiraAssignJiraTicketOutputSchema = z.object({
+  success: z.boolean().describe("Whether the ticket was successfully assigned/reassigned"),
+  error: z
+    .string()
+    .describe("The error that occurred if the ticket was not successfully assigned/reassigned")
+    .optional(),
+  ticketUrl: z.string().describe("The url to the newly assigned/reassigned Jira ticket").optional(),
+});
+
+export type jiraAssignJiraTicketOutputType = z.infer<typeof jiraAssignJiraTicketOutputSchema>;
+export type jiraAssignJiraTicketFunction = ActionFunction<
+  jiraAssignJiraTicketParamsType,
+  AuthParamsType,
+  jiraAssignJiraTicketOutputType
+>;
+
 export const jiraCommentJiraTicketParamsSchema = z.object({
   projectKey: z.string().describe("The key for the project you want to add it to"),
   issueId: z.string().describe("The issue ID associated with the ticket to be commented on"),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -112,6 +112,25 @@ export type confluenceFetchPageContentFunction = ActionFunction<
   confluenceFetchPageContentOutputType
 >;
 
+export const jiraCommentJiraTicketParamsSchema = z.object({
+  projectKey: z.string().describe("The key for the project you want to add it to"),
+  issueId: z.string().describe("The issue ID associated with the ticket to be commented on"),
+  comment: z.string().describe("The text to be commented on the ticket"),
+});
+
+export type jiraCommentJiraTicketParamsType = z.infer<typeof jiraCommentJiraTicketParamsSchema>;
+
+export const jiraCommentJiraTicketOutputSchema = z.object({
+  commentUrl: z.string().describe("The url to the created Jira comment"),
+});
+
+export type jiraCommentJiraTicketOutputType = z.infer<typeof jiraCommentJiraTicketOutputSchema>;
+export type jiraCommentJiraTicketFunction = ActionFunction<
+  jiraCommentJiraTicketParamsType,
+  AuthParamsType,
+  jiraCommentJiraTicketOutputType
+>;
+
 export const jiraCreateJiraTicketParamsSchema = z.object({
   projectKey: z.string().describe("The key for the project you want to add it to"),
   summary: z.string().describe("The summary of the new ticket"),

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -10,6 +10,7 @@ import {
   zendeskCreateZendeskTicketDefinition,
   openstreetmapGetLatitudeLongitudeFromLocationDefinition,
   nwsGetForecastForLocationDefinition,
+  jiraCommentJiraTicketDefinition,
   jiraCreateJiraTicketDefinition,
   googlemapsNearbysearchRestaurantsDefinition,
   firecrawlScrapeUrlDefinition,
@@ -68,6 +69,10 @@ export const ACTION_GROUPS: ActionGroups = {
   SNOWFLAKE_ACTIONS: {
     description: "Action for getting content from a Snowflake table",
     actions: [snowflakeGetRowByFieldValueDefinition, snowflakeRunSnowflakeQueryDefinition],
+  },
+  JIRA_COMMENT_TICKET: {
+    description: "Action for commenting on a Jira ticket",
+    actions: [jiraCommentJiraTicketDefinition],
   },
   JIRA_CREATE_TICKET: {
     description: "Action for creating a Jira ticket",

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -10,6 +10,7 @@ import {
   zendeskCreateZendeskTicketDefinition,
   openstreetmapGetLatitudeLongitudeFromLocationDefinition,
   nwsGetForecastForLocationDefinition,
+  jiraAssignJiraTicketDefinition,
   jiraCommentJiraTicketDefinition,
   jiraCreateJiraTicketDefinition,
   googlemapsNearbysearchRestaurantsDefinition,
@@ -70,13 +71,9 @@ export const ACTION_GROUPS: ActionGroups = {
     description: "Action for getting content from a Snowflake table",
     actions: [snowflakeGetRowByFieldValueDefinition, snowflakeRunSnowflakeQueryDefinition],
   },
-  JIRA_COMMENT_TICKET: {
-    description: "Action for commenting on a Jira ticket",
-    actions: [jiraCommentJiraTicketDefinition],
-  },
-  JIRA_CREATE_TICKET: {
-    description: "Action for creating a Jira ticket",
-    actions: [jiraCreateJiraTicketDefinition],
+  JIRA_ACTIONS: {
+    description: "Action for interating with Jira tickets",
+    actions: [jiraCreateJiraTicketDefinition, jiraCommentJiraTicketDefinition, jiraAssignJiraTicketDefinition],
   },
   OPENSTREETMAP_GET_LATITUDE_LONGITUDE_FROM_LOCATION: {
     description: "Action for getting the latitude and longitude of a location",

--- a/src/actions/providers/jira/assignJiraTicket.ts
+++ b/src/actions/providers/jira/assignJiraTicket.ts
@@ -1,0 +1,61 @@
+import axios, { AxiosError } from "axios";
+import {
+  AuthParamsType,
+  jiraAssignJiraTicketFunction,
+  jiraAssignJiraTicketOutputType,
+  jiraAssignJiraTicketParamsType,
+} from "../../autogen/types";
+import { getUserAccountIdFromEmail } from "./utils";
+
+const assignJiraTicket: jiraAssignJiraTicketFunction = async ({
+  params,
+  authParams,
+}: {
+  params: jiraAssignJiraTicketParamsType;
+  authParams: AuthParamsType;
+}): Promise<jiraAssignJiraTicketOutputType> => {
+  const { authToken, cloudId, baseUrl } = authParams;
+
+  const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/`;
+
+  if (!cloudId || !authToken) {
+    throw new Error("Valid Cloud ID and auth token are required to assign Jira ticket");
+  }
+
+  try {
+    let assigneeId: string | null = params.assignee;
+    if (assigneeId && assigneeId.includes("@")) {
+      assigneeId = await getUserAccountIdFromEmail(assigneeId, apiUrl, authToken);
+    }
+
+    if (!assigneeId) {
+      throw new Error("Unable to get valid assignee account ID.");
+    }
+
+    const response = await axios.put(
+      `${apiUrl}issue/${params.issueId}/assignee`,
+      { accountId: assigneeId },
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    return {
+      success: true,
+      ticketUrl: `${baseUrl}/browse/${params.issueId}`,
+    };
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    console.error("Error assigning issue:", axiosError);
+    return {
+      success: false,
+      error: axiosError.message,
+    };
+  }
+};
+
+export default assignJiraTicket;

--- a/src/actions/providers/jira/commentJiraTicket.ts
+++ b/src/actions/providers/jira/commentJiraTicket.ts
@@ -1,0 +1,56 @@
+import { AxiosError } from "axios";
+import {
+  AuthParamsType,
+  jiraCommentJiraTicketFunction,
+  jiraCommentJiraTicketOutputType,
+  jiraCommentJiraTicketParamsType,
+} from "../../autogen/types";
+import { axiosClient } from "../../util/axiosClient";
+
+const CommentJiraTicket: jiraCommentJiraTicketFunction = async ({
+  params,
+  authParams,
+}: {
+  params: jiraCommentJiraTicketParamsType;
+  authParams: AuthParamsType;
+}): Promise<jiraCommentJiraTicketOutputType> => {
+  const { authToken, cloudId, baseUrl } = authParams;
+
+  if (!cloudId || !params?.issueId) {
+    throw new Error("Cloud ID and Issue ID are required to comment on a Jira ticket");
+  }
+  const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${params.issueId}/comment`;
+  const response = await axiosClient.post(
+    apiUrl,
+    {
+      body: {
+        type: "doc",
+        version: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: params.comment,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  return {
+    commentUrl: `${baseUrl}/browse/${params.issueId}?focusedCommentId=${response.data.id}`,
+  };
+};
+
+export default CommentJiraTicket;

--- a/src/actions/providers/jira/commentJiraTicket.ts
+++ b/src/actions/providers/jira/commentJiraTicket.ts
@@ -20,37 +20,47 @@ const CommentJiraTicket: jiraCommentJiraTicketFunction = async ({
     throw new Error("Cloud ID and Issue ID are required to comment on a Jira ticket");
   }
   const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${params.issueId}/comment`;
-  const response = await axiosClient.post(
-    apiUrl,
-    {
-      body: {
-        type: "doc",
-        version: 1,
-        content: [
-          {
-            type: "paragraph",
-            content: [
-              {
-                type: "text",
-                text: params.comment,
-              },
-            ],
-          },
-        ],
-      },
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-    },
-  );
 
-  return {
-    commentUrl: `${baseUrl}/browse/${params.issueId}?focusedCommentId=${response.data.id}`,
-  };
+  try {
+    const response = await axiosClient.post(
+      apiUrl,
+      {
+        body: {
+          type: "doc",
+          version: 1,
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: params.comment,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    return {
+      success: true,
+      commentUrl: `${baseUrl}/browse/${params.issueId}?focusedCommentId=${response.data.id}`,
+    };
+  } catch (error) {
+    console.error("Error commenting on Jira ticket: ", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
 };
 
 export default CommentJiraTicket;

--- a/src/actions/providers/jira/utils.ts
+++ b/src/actions/providers/jira/utils.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from "axios";
+import { axiosClient } from "../../util/axiosClient";
+
+export async function getUserAccountIdFromEmail(
+  email: string,
+  apiUrl: string,
+  authToken: string,
+): Promise<string | null> {
+  try {
+    const response = await axiosClient.get<Array<{ accountId: string; displayName: string; emailAddress: string }>>(
+      `${apiUrl}/user/search?query=${encodeURIComponent(email)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (response.data && response.data.length > 0) {
+      return response.data[0].accountId;
+    }
+    return null;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    console.error("Error finding user:", axiosError.message);
+    return null;
+  }
+}

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -111,7 +111,8 @@ actions:
   jira:
     commentJiraTicket:
       description: Comments on a Jira ticket with specified content 
-      scopes: []
+      scopes: 
+        - write:comment:jira
       parameters:
         type: object
         required: [projectKey, issueId, comment]
@@ -127,8 +128,14 @@ actions:
             description: The text to be commented on the ticket
       output:
         type: object
-        required: [commentUrl]
+        required: [success]
         properties:
+          success:
+            type: boolean
+            description: Whether the comment was sent successfully
+          error:
+            type: string
+            description: The error that occurred if the comment was not sent successfully
           commentUrl:
             type: string
             description: The url to the created Jira comment

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -109,6 +109,29 @@ actions:
             type: string
             description: The content of the page in storage format (HTML)
   jira:
+    commentJiraTicket:
+      description: Comments on a Jira ticket with specified content 
+      scopes: []
+      parameters:
+        type: object
+        required: [projectKey, issueId, comment]
+        properties:
+          projectKey:
+            type: string
+            description: The key for the project you want to add it to
+          issueId:
+            type: string
+            description: The issue ID associated with the ticket to be commented on
+          comment:
+            type: string
+            description: The text to be commented on the ticket
+      output:
+        type: object
+        required: [commentUrl]
+        properties:
+          commentUrl:
+            type: string
+            description: The url to the created Jira comment
     createJiraTicket:
       description: Create a jira ticket with new content specified
       scopes: []

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -109,6 +109,37 @@ actions:
             type: string
             description: The content of the page in storage format (HTML)
   jira:
+    assignJiraTicket:
+      description: Assigns/Re-assignes a Jira ticket to a specified user 
+      scopes: 
+        - write:jira-work
+        - read:jira-user
+      parameters:
+        type: object
+        required: [projectKey, issueId, assignee]
+        properties:
+          projectKey:
+            type: string
+            description: The key for the project you want to add it to
+          assignee:
+            type: string
+            description: The assignee for the ticket, userID or email
+          issueId:
+            type: string
+            description: The issue ID associated with the ticket to be assigned/re-assigned
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the ticket was successfully assigned/reassigned
+          error:
+            type: string
+            description: The error that occurred if the ticket was not successfully assigned/reassigned
+          ticketUrl:
+            type: string
+            description: The url to the newly assigned/reassigned Jira ticket
     commentJiraTicket:
       description: Comments on a Jira ticket with specified content 
       scopes: 

--- a/tests/jira/testAssignJiraTicket.ts
+++ b/tests/jira/testAssignJiraTicket.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app";
+import { jiraConfig } from "./utils";
+
+async function runTest() {
+  const { authToken, cloudId, baseUrl, issueId, assignee } = jiraConfig;
+
+  const result = await runAction(
+    "assignJiraTicket",
+    "jira",
+    {
+      authToken,
+      cloudId,
+      baseUrl,
+    },
+    {
+      issueId: issueId,
+      assignee: assignee,
+    }
+  );
+
+  assert(result, "Response should not be null");
+  assert(result.success, "Success should be true");
+  assert(result.ticketUrl, "Response should contain a ticket URL");
+  console.log(`Successfully assigned Jira ticket: ${result.ticketUrl}`);
+}
+
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
+});

--- a/tests/jira/testCommentJiraTicket.ts
+++ b/tests/jira/testCommentJiraTicket.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app";
+import { jiraConfig } from './utils'; 
+
+async function runTest() {
+  const { authToken, cloudId, baseUrl, projectKey, issueId } = jiraConfig;
+  const result = await runAction(
+    "commentJiraTicket",
+    "jira",
+    { 
+      authToken,
+      cloudId,
+      baseUrl,
+    },
+    {
+      projectKey,
+      comment: `Test comment made on ${new Date().toISOString()}`,
+      issueId: issueId,
+    }
+  );
+  
+  console.log(JSON.stringify(result, null, 2));
+  
+  // Validate response
+  assert(result, "Response should not be null");
+  assert(result.commentUrl, "Response should contain a url to the created comment");
+  console.log(`Successfully created Jira comment: ${result.commentUrl}`);
+}
+
+runTest().catch(error => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.log('sad face');
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
+});

--- a/tests/jira/testCreateJiraTicket.ts
+++ b/tests/jira/testCreateJiraTicket.ts
@@ -1,14 +1,10 @@
 import assert from "node:assert";
-import { runAction } from "../src/app";
+import { runAction } from "../../src/app";
+import { jiraConfig } from './utils'; 
 
 async function runTest() {
 
-    // For OAuth Credentials with Jira: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
-    const authToken =  "insert-your-auth-token-here"
-    const cloudId = "insert-your-cloud-id-here"
-    const baseUrl = "insert-your-base-url-here"
-    const projectKey = "insert-your-project-key-here";
-
+    const { authToken, cloudId, baseUrl, projectKey } = jiraConfig;
 
     const result = await runAction(
         "createJiraTicket",

--- a/tests/jira/testCreateJiraTicket.ts
+++ b/tests/jira/testCreateJiraTicket.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app";
-import { jiraConfig } from './utils'; 
+import { jiraConfig } from "./utils";
 
 async function runTest() {
 

--- a/tests/jira/utils.ts
+++ b/tests/jira/utils.ts
@@ -1,0 +1,8 @@
+export const jiraConfig = {
+   // For OAuth Credentials with Jira: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+  authToken: "your-auth-token-here",
+  cloudId: "your-cloud-id-here",
+  baseUrl: "your-base-url-here",
+  projectKey: "your-projectkey-here",
+  issueId: "your-issueId-here",
+};

--- a/tests/jira/utils.ts
+++ b/tests/jira/utils.ts
@@ -5,4 +5,5 @@ export const jiraConfig = {
   baseUrl: "your-base-url-here",
   projectKey: "your-projectkey-here",
   issueId: "your-issueId-here",
+  assignee: "your-assignee-here",
 };


### PR DESCRIPTION
moved some shared functions to utils. comes after https://github.com/Credal-ai/actions-sdk/pull/49

Tested assign ticket works and create ticket still works
`npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/jira/testCreateJiraTicket.ts` and 
`npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/jira/testAssignJiraTicket.ts`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new actions for assigning and commenting on Jira tickets, with tests and schema updates.
> 
>   - **New Features**:
>     - Add `assignJiraTicket` action in `assignJiraTicket.ts` to assign/reassign Jira tickets.
>     - Add `commentJiraTicket` action in `commentJiraTicket.ts` to comment on Jira tickets.
>   - **Refactoring**:
>     - Move `getUserAccountIdFromEmail` to `utils.ts` for shared use.
>   - **Schema and Template Updates**:
>     - Update `schema.yaml` and `templates.ts` to include new Jira actions.
>     - Add parameter and output schemas for new actions in `types.ts`.
>   - **Testing**:
>     - Add `testAssignJiraTicket.ts` and `testCommentJiraTicket.ts` for testing new actions.
>     - Refactor `testCreateJiraTicket.ts` to use shared `jiraConfig` from `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e0e79788d1536e000f7d9d7b02e9210d77bea466. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->