### PR TITLE
[microsoft] Add Teams messaging actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",
         "@mendable/firecrawl-js": "^1.19.0",
+        "@microsoft/microsoft-graph-client": "^3.0.7",
         "@slack/web-api": "^7.8.0",
         "@types/snowflake-sdk": "^1.6.24",
         "ajv": "^8.17.1",
@@ -1093,6 +1094,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -1524,6 +1537,33 @@
         "typescript-event-target": "^1.1.1",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.0"
+      }
+    },
+    "node_modules/@microsoft/microsoft-graph-client": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.7.tgz",
+      "integrity": "sha512-/AazAV/F+HK4LIywF9C+NYHcJo038zEnWkteilcxC1FM/uK/4NVGDKGrxx7nNq1ybspAroRKT4I1FHfxQzxkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/msal-browser": {
+          "optional": true
+        },
+        "buffer": {
+          "optional": true
+        },
+        "stream-browserify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -5904,6 +5944,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,6 +41,7 @@
   "dependencies": {
     "@credal/sdk": "^0.0.21",
     "@mendable/firecrawl-js": "^1.19.0",
+    "@microsoft/microsoft-graph-client": "^3.0.7",
     "@slack/web-api": "^7.8.0",
     "@types/snowflake-sdk": "^1.6.24",
     "ajv": "^8.17.1",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -87,6 +87,10 @@ import {
   ashbyCreateCandidateOutputSchema,
   ashbyUpdateCandidateParamsSchema,
   ashbyUpdateCandidateOutputSchema,
+  microsoftMessageTeamsChatParamsSchema,
+  microsoftMessageTeamsChatOutputSchema,
+  microsoftMessageTeamsChannelParamsSchema,
+  microsoftMessageTeamsChannelOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -132,6 +136,8 @@ import searchCandidates from "./providers/ashby/searchCandidates";
 import createCandidate from "./providers/ashby/createCandidate";
 import updateCandidate from "./providers/ashby/updateCandidate";
 import addCandidateToProject from "./providers/ashby/addCandidateToProject";
+import sendMessageToTeamsChat from "./providers/microsoft/messageTeamsChat";
+import sendMessageToTeamsChannel from "./providers/microsoft/messageTeamsChannel";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -399,6 +405,18 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: getRecord,
       paramsSchema: salesforceGetRecordParamsSchema,
       outputSchema: salesforceGetRecordOutputSchema,
+    },
+  },
+  microsoft: {
+    messageTeamsChat: {
+      fn: sendMessageToTeamsChat,
+      paramsSchema: microsoftMessageTeamsChatParamsSchema,
+      outputSchema: microsoftMessageTeamsChatOutputSchema,
+    },
+    messageTeamsChannel: {
+      fn: sendMessageToTeamsChannel,
+      paramsSchema: microsoftMessageTeamsChannelParamsSchema,
+      outputSchema: microsoftMessageTeamsChannelOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1722,7 +1722,7 @@ export const ashbyCreateCandidateDefinition: ActionTemplate = {
       },
       alternateEmailAddresses: {
         type: "array",
-        description: "Array of alternate email addresses to add to the candidate's profile.",
+        description: "Array of alternate email address to add to the candidate's profile.",
         items: {
           type: "string",
         },
@@ -2041,4 +2041,84 @@ export const salesforceGetRecordDefinition: ActionTemplate = {
   },
   name: "getRecord",
   provider: "salesforce",
+};
+export const microsoftMessageTeamsChatDefinition: ActionTemplate = {
+  description: "Sends a message to a Microsoft Teams chat",
+  scopes: ["chat:write"],
+  parameters: {
+    type: "object",
+    required: ["chatId", "message"],
+    properties: {
+      chatId: {
+        type: "string",
+        description: "The chat ID of the Microsoft Teams chat",
+      },
+      message: {
+        type: "string",
+        description: "The text to be messaged to the chat",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the message was sent successfully",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the message was not sent successfully",
+      },
+      messageId: {
+        type: "string",
+        description: "The ID of the message that was sent",
+      },
+    },
+  },
+  name: "messageTeamsChat",
+  provider: "microsoft",
+};
+export const microsoftMessageTeamsChannelDefinition: ActionTemplate = {
+  description: "Sends a message to a Microsoft Teams channel",
+  scopes: ["chat:write"],
+  parameters: {
+    type: "object",
+    required: ["teamId", "channelId", "message"],
+    properties: {
+      teamId: {
+        type: "string",
+        description: "The team ID of the Microsoft Teams channel",
+      },
+      channelId: {
+        type: "string",
+        description: "The channel ID of the Microsoft Teams channel",
+      },
+      message: {
+        type: "string",
+        description: "The text to be messaged to the channel",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the message was sent successfully",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the message was not sent successfully",
+      },
+      messageId: {
+        type: "string",
+        description: "The ID of the message that was sent",
+      },
+    },
+  },
+  name: "messageTeamsChannel",
+  provider: "microsoft",
 };

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -18,6 +18,9 @@ export const AuthParamsSchema = z.object({
   awsSecretAccessKey: z.string().optional(),
   clientId: z.string().optional(),
   clientSecret: z.string().optional(),
+  tenantId: z.string().optional(),
+  refreshToken: z.string().optional(),
+  redirectUri: z.string().optional(),
 });
 
 export type AuthParamsType = z.infer<typeof AuthParamsSchema>;
@@ -1144,4 +1147,45 @@ export type salesforceGetRecordFunction = ActionFunction<
   salesforceGetRecordParamsType,
   AuthParamsType,
   salesforceGetRecordOutputType
+>;
+
+export const microsoftMessageTeamsChatParamsSchema = z.object({
+  chatId: z.string().describe("The chat ID of the Microsoft Teams chat"),
+  message: z.string().describe("The text to be messaged to the chat"),
+});
+
+export type microsoftMessageTeamsChatParamsType = z.infer<typeof microsoftMessageTeamsChatParamsSchema>;
+
+export const microsoftMessageTeamsChatOutputSchema = z.object({
+  success: z.boolean().describe("Whether the message was sent successfully"),
+  error: z.string().describe("The error that occurred if the message was not sent successfully").optional(),
+  messageId: z.string().describe("The ID of the message that was sent").optional(),
+});
+
+export type microsoftMessageTeamsChatOutputType = z.infer<typeof microsoftMessageTeamsChatOutputSchema>;
+export type microsoftMessageTeamsChatFunction = ActionFunction<
+  microsoftMessageTeamsChatParamsType,
+  AuthParamsType,
+  microsoftMessageTeamsChatOutputType
+>;
+
+export const microsoftMessageTeamsChannelParamsSchema = z.object({
+  teamId: z.string().describe("The team ID of the Microsoft Teams channel"),
+  channelId: z.string().describe("The channel ID of the Microsoft Teams channel"),
+  message: z.string().describe("The text to be messaged to the channel"),
+});
+
+export type microsoftMessageTeamsChannelParamsType = z.infer<typeof microsoftMessageTeamsChannelParamsSchema>;
+
+export const microsoftMessageTeamsChannelOutputSchema = z.object({
+  success: z.boolean().describe("Whether the message was sent successfully"),
+  error: z.string().describe("The error that occurred if the message was not sent successfully").optional(),
+  messageId: z.string().describe("The ID of the message that was sent").optional(),
+});
+
+export type microsoftMessageTeamsChannelOutputType = z.infer<typeof microsoftMessageTeamsChannelOutputSchema>;
+export type microsoftMessageTeamsChannelFunction = ActionFunction<
+  microsoftMessageTeamsChannelParamsType,
+  AuthParamsType,
+  microsoftMessageTeamsChannelOutputType
 >;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -30,6 +30,8 @@ import {
   salesforceCreateCaseDefinition,
   salesforceGenerateSalesReportDefinition,
   salesforceGetRecordDefinition,
+  microsoftMessageTeamsChatDefinition,
+  microsoftMessageTeamsChannelDefinition,
 } from "../actions/autogen/templates";
 import { ActionTemplate } from "../actions/parse";
 
@@ -120,5 +122,9 @@ export const ACTION_GROUPS: ActionGroups = {
       salesforceGenerateSalesReportDefinition,
       salesforceGetRecordDefinition,
     ],
+  },
+  MICROSOFT: {
+    description: "Actions for interacting with Microsoft 365",
+    actions: [microsoftMessageTeamsChatDefinition, microsoftMessageTeamsChannelDefinition],
   },
 };

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -53,6 +53,9 @@ z.object({
     awsSecretAccessKey: z.string().optional(),
     clientId: z.string().optional(),
     clientSecret: z.string().optional(),
+    tenantId: z.string().optional(),
+    refreshToken: z.string().optional(),
+    redirectUri: z.string().optional(),
 })
 `;
 

--- a/src/actions/providers/microsoft/messageTeamsChannel.ts
+++ b/src/actions/providers/microsoft/messageTeamsChannel.ts
@@ -1,0 +1,52 @@
+import {
+  AuthParamsType,
+  microsoftMessageTeamsChannelFunction,
+  microsoftMessageTeamsChannelOutputType,
+  microsoftMessageTeamsChannelParamsType,
+} from "../../autogen/types";
+
+import { sendMessage } from "./utils";
+
+const sendMessageToTeamsChannel: microsoftMessageTeamsChannelFunction = async ({
+  params,
+  authParams,
+}: {
+  params: microsoftMessageTeamsChannelParamsType;
+  authParams: AuthParamsType;
+}): Promise<microsoftMessageTeamsChannelOutputType> => {
+  const { channelId, teamId, message } = params;
+
+  if (!teamId) {
+    return {
+      success: false,
+      error: "Team ID is required to send a message",
+    };
+  }
+
+  if (!channelId) {
+    return { success: false, error: "Channel ID is required to send a message" };
+  }
+
+  if (!message) {
+    return {
+      success: false,
+      error: "Message content is required to send a message",
+    };
+  }
+
+  try {
+    const messageId = await sendMessage(`/teams/${teamId}/channels/${channelId}/messages`, message, authParams);
+    return {
+      success: true,
+      messageId: messageId,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default sendMessageToTeamsChannel;

--- a/src/actions/providers/microsoft/messageTeamsChat.ts
+++ b/src/actions/providers/microsoft/messageTeamsChat.ts
@@ -1,0 +1,48 @@
+import {
+  AuthParamsType,
+  microsoftMessageTeamsChatFunction,
+  microsoftMessageTeamsChatOutputType,
+  microsoftMessageTeamsChatParamsType,
+} from "../../autogen/types";
+
+import { sendMessage } from "./utils";
+
+const sendMessageToTeamsChat: microsoftMessageTeamsChatFunction = async ({
+  params,
+  authParams,
+}: {
+  params: microsoftMessageTeamsChatParamsType;
+  authParams: AuthParamsType;
+}): Promise<microsoftMessageTeamsChatOutputType> => {
+  const { chatId, message } = params;
+
+  if (!chatId) {
+    return {
+      success: false,
+      error: "Chat ID is required to send a message",
+    };
+  }
+
+  if (!message) {
+    return {
+      success: false,
+      error: "Message content is required to send a message",
+    };
+  }
+
+  try {
+    const messageId = await sendMessage(`/chats/${chatId}/messages`, message, authParams);
+    return {
+      success: true,
+      messageId: messageId,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default sendMessageToTeamsChat;

--- a/src/actions/providers/microsoft/utils.ts
+++ b/src/actions/providers/microsoft/utils.ts
@@ -1,0 +1,47 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { axiosClient } from "../../util/axiosClient";
+import { AuthParamsType } from "../../autogen/types";
+
+export async function getGraphClientForMessageSend(authParams: AuthParamsType): Promise<Client> {
+  if (
+    !authParams.clientId ||
+    !authParams.clientSecret ||
+    !authParams.tenantId ||
+    !authParams.refreshToken ||
+    !authParams.redirectUri
+  ) {
+    throw new Error("Missing required authentication parameters");
+  }
+
+  const url = `https://login.microsoftonline.com/${authParams.tenantId}/oauth2/v2.0/token`;
+
+  const params = new URLSearchParams({
+    client_id: authParams.clientId!,
+    client_secret: authParams.clientSecret!,
+    scope: "offline_access ChannelMessage.Send ChatMessage.Send",
+    grant_type: "refresh_token",
+    refresh_token: authParams.refreshToken!,
+    redirect_uri: authParams.redirectUri!,
+  });
+
+  const response = await axiosClient.post(url, params, {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+
+  const accessToken = response.data.access_token;
+  return Client.init({
+    authProvider: done => {
+      done(null, accessToken);
+    },
+  });
+}
+
+export async function sendMessage(api_url: string, message: string, authParams: AuthParamsType): Promise<string> {
+  const client = await getGraphClientForMessageSend(authParams);
+  const response = await client.api(api_url).post({
+    body: {
+      content: message,
+    },
+  });
+  return response.id;
+}

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1446,4 +1446,61 @@ actions:
           error:
             type: string
             description: The error that occurred if the record was not successfully retrieved
-    
+  microsoft:
+    messageTeamsChat:
+      description: Sends a message to a Microsoft Teams chat
+      scopes:
+        - chat:write
+      parameters:
+        type: object
+        required: [chatId, message]
+        properties:
+          chatId:
+            type: string
+            description: The chat ID of the Microsoft Teams chat
+          message:
+            type: string
+            description: The text to be messaged to the chat
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the message was sent successfully
+          error:
+            type: string
+            description: The error that occurred if the message was not sent successfully
+          messageId:
+            type: string
+            description: The ID of the message that was sent
+    messageTeamsChannel:
+      description: Sends a message to a Microsoft Teams channel
+      scopes:
+        - chat:write
+      parameters:
+        type: object
+        required: [teamId, channelId, message]
+        properties:
+          teamId:
+            type: string
+            description: The team ID of the Microsoft Teams channel
+          channelId:
+            type: string
+            description: The channel ID of the Microsoft Teams channel
+          message:
+            type: string
+            description: The text to be messaged to the channel
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the message was sent successfully
+          error:
+            type: string
+            description: The error that occurred if the message was not sent successfully
+          messageId:
+            type: string
+            description: The ID of the message that was sent    

--- a/tests/microsoft/getTokenTool.ts
+++ b/tests/microsoft/getTokenTool.ts
@@ -1,0 +1,100 @@
+import http from 'http';
+import open from 'open';
+import axios from 'axios';
+import dotenv from 'dotenv';
+import { URL } from 'url';
+
+dotenv.config();
+
+// Ensure environment variables are set
+if (!process.env.MICROSOFT_CLIENT_ID) {
+    throw new Error('Missing required environment variable: MICROSOFT_CLIENT_ID');
+}
+if (!process.env.MICROSOFT_CLIENT_SECRET) {
+    throw new Error('Missing required environment variable: MICROSOFT_CLIENT_SECRET');
+}
+if (!process.env.MICROSOFT_TENANT_ID) {
+    throw new Error('Missing required environment variable: MICROSOFT_TENANT_ID');
+}
+if (!process.env.MICROSOFT_REDIRECT_URI) {
+    throw new Error('Missing required environment variable: MICROSOFT_REDIRECT_URI');
+}
+
+// Load environment variables
+const CLIENT_ID = process.env.MICROSOFT_CLIENT_ID;
+const CLIENT_SECRET = process.env.MICROSOFT_CLIENT_SECRET;
+const TENANT_ID = process.env.MICROSOFT_TENANT_ID;
+const REDIRECT_URI = process.env.MICROSOFT_REDIRECT_URI;
+
+// Extract the port from the redirect URI
+const parsedUrl = new URL(REDIRECT_URI);
+if (parsedUrl.hostname !== 'localhost' && parsedUrl.hostname !== '127.0.0.1') {
+    throw new Error('The redirect URI must be a localhost URL for this tool to work.');
+}
+const AUTH_PORT = parsedUrl.port ? parseInt(parsedUrl.port, 10) : 80; // Default to port 80 if not specified
+
+const scope = "offline_access ChatMessage.Send ChannelMessage.Send";  // offline_access ensures refresh token is returned
+
+// Function to generate the Microsoft OAuth2 authorization URL
+function generateAuthUrl(): string {
+    const params = new URLSearchParams({
+        client_id: CLIENT_ID,
+        response_type: 'code',
+        redirect_uri: REDIRECT_URI,
+        scope: scope,
+        response_mode: 'query',
+        state: 'randomstatevalue',
+    });
+
+    return `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/authorize?${params.toString()}`;
+}
+
+// Function to exchange authorization code for tokens
+async function getTokens(authCode: string): Promise<void> {
+    const tokenUrl = `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`;
+
+    const params = new URLSearchParams({
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        code: authCode,
+        redirect_uri: REDIRECT_URI,
+        grant_type: 'authorization_code',
+        scope: scope,
+    });
+
+    try {
+        const response = await axios.post(tokenUrl, params, {
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        });
+
+        console.log('Access Token:', response.data.access_token);
+        console.log('\nRefresh Token:', response.data.refresh_token);
+    } catch (error: any) {
+        console.error('Error fetching tokens:', error.response?.data || error.message);
+    }
+}
+
+// Start a temporary local server to capture the authorization code
+const server = http.createServer(async (req, res) => {
+    if (req.url?.startsWith('/callback')) {
+        const url = new URL(req.url, `http://localhost:${AUTH_PORT}`);
+        const authCode = url.searchParams.get('code');
+
+        if (authCode) {
+            console.log('\nAuthorization Code received:', authCode);
+            res.end('Authorization successful! You can close this window.');
+            server.close(); // Close the server after receiving the code
+            await getTokens(authCode);
+        } else {
+            res.end('Error: No authorization code received.');
+        }
+    }
+});
+
+// Start the server
+server.listen(AUTH_PORT, async () => {
+    console.log(`Server listening on port ${AUTH_PORT}`);
+    const authUrl = generateAuthUrl();
+    console.log(`\nOpening the browser for authentication...\n${authUrl}`);
+    await open(authUrl); // Open default web browser to authenticate
+});

--- a/tests/microsoft/testMessageTeamsChannel.ts
+++ b/tests/microsoft/testMessageTeamsChannel.ts
@@ -1,0 +1,28 @@
+import { runAction } from "../../src/app";
+import { assert } from "node:console"
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function runTest() {
+    const result = await runAction(
+        "messageTeamsChannel",
+        "microsoft",
+        {
+            tenantId: process.env.MICROSOFT_TENANT_ID!,
+            clientId: process.env.MICROSOFT_CLIENT_ID!,
+            clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+            refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
+            redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
+        }, // authParams
+        {
+            message: "Hello from actions-sdk testing of Microsoft365 Teams channel integration",
+            teamId: process.env.MICROSOFT_TEAM_ID!,
+            channelId: process.env.MICROSOFT_CHANNEL_ID!,
+        },
+    );
+    console.log(result);
+    assert(result.success, "Message was not sent successfully");
+}
+
+runTest().catch(console.error);

--- a/tests/microsoft/testMessageTeamsChat.ts
+++ b/tests/microsoft/testMessageTeamsChat.ts
@@ -1,0 +1,27 @@
+import { runAction } from "../../src/app";
+import { assert } from "node:console"
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function runTest() {
+    const result = await runAction(
+        "messageTeamsChat",
+        "microsoft",
+        {
+            tenantId: process.env.MICROSOFT_TENANT_ID!,
+            clientId: process.env.MICROSOFT_CLIENT_ID!,
+            clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+            refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
+            redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
+        }, // authParams
+        {
+            message: "Hello from actions-sdk testing of Microsoft365 Teams chat integration",
+            chatId: process.env.MICROSOFT_CHAT_ID!,
+        },
+    );
+    console.log(result);
+    assert(result.success, "Message was not sent successfully");
+}
+
+runTest().catch(console.error);


### PR DESCRIPTION
New `messageTeamsChat` and `messageTeamsChannel` actions to send a message on Microsoft Teams

Message sending in Microsoft Teams through Microsoft Graph requires access with authorization delegated from an actual user within the tenant (I think you can create dummy bot user but it will need to have Office365 license to access teams, for testing I guess you can use your own user if it has a license attached). This requires authenticating user with a tool getTokenTool.ts to generate refresh_token which can then be used by the service to send messages with that users identity, and shouldn't expire.

You can see that delegated permissions are required for send actions here https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http . Note there is migration option, but that doesn't work on an active team.

Test plan:

1. Set following shell env variables: MICROSOFT_TENANT_ID
MICROSOFT_CLIENT_ID
MICROSOFT_CLIENT_SECRET
MICROSOFT_TEAM_ID
MICROSOFT_CHANNEL_ID
MICROSOFT_REDIRECT_URI

2. Get refresh token $ npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/microsoft/getTokenTool.ts follow link to authorize intended microsoft user account set retrieved MICROSOFT_REFRESH_TOKEN in env
3.
$ npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/microsoft/testMessageTeamsChannel.ts

I can't actually test this as my user doesn't have the Office365 license, but messaged instructions to Richard Liu.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `messageTeamsChat` and `messageTeamsChannel` actions for sending messages to Microsoft Teams, with supporting utilities, schema, types, and tests.
> 
>   - **New Actions**:
>     - `messageTeamsChat` and `messageTeamsChannel` actions added to send messages to Microsoft Teams chats and channels.
>     - Implemented in `messageTeamsChat.ts` and `messageTeamsChannel.ts`.
>   - **Utilities**:
>     - `getGraphClientForMessageSend` and `sendMessage` functions in `utils.ts` for Microsoft Graph API authentication and message sending.
>   - **Schema and Types**:
>     - Added `microsoftMessageTeamsChatParamsSchema`, `microsoftMessageTeamsChatOutputSchema`, `microsoftMessageTeamsChannelParamsSchema`, and `microsoftMessageTeamsChannelOutputSchema` in `types.ts`.
>     - Updated `schema.yaml` and `templates.ts` with new action definitions.
>   - **Testing**:
>     - `getTokenTool.ts` for obtaining Microsoft OAuth tokens.
>     - `testMessageTeamsChat.ts` and `testMessageTeamsChannel.ts` for testing message sending actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 2cfca3add519a36acb98d4512e02b81b4c8774b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->