### PR TITLE
[lint] Remove unused import

### DIFF
--- a/src/actions/providers/jira/commentJiraTicket.ts
+++ b/src/actions/providers/jira/commentJiraTicket.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from "axios";
 import {
   AuthParamsType,
   jiraCommentJiraTicketFunction,


### PR DESCRIPTION
I keep seeing this lint error on all PRs CI.

Test plan:
npm run build
npm run lint
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused import `AxiosError` from `commentJiraTicket.ts`.
> 
>   - **Linting**:
>     - Remove unused import `AxiosError` from `commentJiraTicket.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for fb75568846e9f6102544e90dcb0de09be9b55c69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->