### PR TITLE
Bring in less in build process by enforcing type imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Adjust this to match your Node.js version
+          node-version: "22" # Adjust this to match your Node.js version
 
       # Install dependencies
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Adjust this to match your Node.js version
+          node-version: "22" # Adjust this to match your Node.js version
 
       # Install dependencies
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Credal Logo](assets/credal-logo.svg)
 
 ## Credal.ai's Open Source Actions Framework
+
 Easily add custom actions for your Credal Copilots. Read more about Credal's Agent platform [here](https://www.credal.ai/products/ai-agent-platform).
 
 ## Adding or updating actions
@@ -24,7 +25,7 @@ const result = await runAction(
   "listConversations",
   "slack",
   { authToken: "xoxb-..." },
-  {}
+  {},
 );
 ```
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,4 +9,9 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   { ignores: ["src/actions/autogen/**"] },
+  {
+    rules: {
+      "@typescript-eslint/consistent-type-imports": "error",
+    },
+  },
 ];

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import type { z } from "zod";
 import {
   type ActionFunction,
   confluenceOverwritePageParamsSchema,

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -53,7 +53,7 @@ import {
   microsoftCreateDocumentDefinition,
   microsoftGetDocumentDefinition,
 } from "../actions/autogen/templates";
-import { ActionTemplate } from "../actions/parse";
+import type { ActionTemplate } from "../actions/parse";
 
 export type ActionGroups = Record<string, { description: string; actions: ActionTemplate[] }>;
 

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -2,7 +2,7 @@ import Ajv from "ajv";
 import fs from "fs/promises";
 import yaml from "js-yaml";
 import convert from "json-schema-to-zod";
-import type { SourceFile} from "ts-morph";
+import type { SourceFile } from "ts-morph";
 import { Project, VariableDeclarationKind } from "ts-morph";
 import { z } from "zod";
 import { snakeToPascal } from "../utils/string";

--- a/src/actions/parse.ts
+++ b/src/actions/parse.ts
@@ -2,7 +2,8 @@ import Ajv from "ajv";
 import fs from "fs/promises";
 import yaml from "js-yaml";
 import convert from "json-schema-to-zod";
-import { Project, SourceFile, VariableDeclarationKind } from "ts-morph";
+import type { SourceFile} from "ts-morph";
+import { Project, VariableDeclarationKind } from "ts-morph";
 import { z } from "zod";
 import { snakeToPascal } from "../utils/string";
 

--- a/src/actions/providers/asana/commentAsanaTask.ts
+++ b/src/actions/providers/asana/commentAsanaTask.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   asanaCommentTaskFunction,
   asanaCommentTaskOutputType,

--- a/src/actions/providers/asana/createAsanaTask.ts
+++ b/src/actions/providers/asana/createAsanaTask.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   asanaCreateTaskFunction,
   asanaCreateTaskOutputType,

--- a/src/actions/providers/asana/updateAsanaTask.ts
+++ b/src/actions/providers/asana/updateAsanaTask.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   asanaUpdateTaskFunction,
   asanaUpdateTaskOutputType,

--- a/src/actions/providers/ashby/addCandidateToProject.ts
+++ b/src/actions/providers/ashby/addCandidateToProject.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyAddCandidateToProjectFunction,
   ashbyAddCandidateToProjectOutputType,
   ashbyAddCandidateToProjectParamsType,

--- a/src/actions/providers/ashby/createCandidate.ts
+++ b/src/actions/providers/ashby/createCandidate.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyCreateCandidateFunction,
   ashbyCreateCandidateOutputType,
   ashbyCreateCandidateParamsType,

--- a/src/actions/providers/ashby/createNote.ts
+++ b/src/actions/providers/ashby/createNote.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyCreateNoteFunction,
   ashbyCreateNoteOutputType,
   ashbyCreateNoteParamsType,

--- a/src/actions/providers/ashby/getCandidateInfo.ts
+++ b/src/actions/providers/ashby/getCandidateInfo.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyGetCandidateInfoFunction,
   ashbyGetCandidateInfoOutputType,
   ashbyGetCandidateInfoParamsType,

--- a/src/actions/providers/ashby/listCandidateNotes.ts
+++ b/src/actions/providers/ashby/listCandidateNotes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyListCandidateNotesFunction,
   ashbyListCandidateNotesOutputType,
   ashbyListCandidateNotesParamsType,

--- a/src/actions/providers/ashby/listCandidates.ts
+++ b/src/actions/providers/ashby/listCandidates.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyListCandidatesFunction,
   ashbyListCandidatesOutputType,
   ashbyListCandidatesParamsType,

--- a/src/actions/providers/ashby/searchCandidates.ts
+++ b/src/actions/providers/ashby/searchCandidates.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbySearchCandidatesFunction,
   ashbySearchCandidatesOutputType,
   ashbySearchCandidatesParamsType,

--- a/src/actions/providers/ashby/updateCandidate.ts
+++ b/src/actions/providers/ashby/updateCandidate.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ashbyUpdateCandidateFunction,
   ashbyUpdateCandidateOutputType,
   ashbyUpdateCandidateParamsType,

--- a/src/actions/providers/confluence/fetchPageContent.ts
+++ b/src/actions/providers/confluence/fetchPageContent.ts
@@ -1,5 +1,5 @@
-import { AxiosRequestConfig } from "axios";
-import {
+import type { AxiosRequestConfig } from "axios";
+import type {
   confluenceFetchPageContentFunction,
   confluenceFetchPageContentParamsType,
   confluenceFetchPageContentOutputType,

--- a/src/actions/providers/confluence/overwritePage.ts
+++ b/src/actions/providers/confluence/overwritePage.ts
@@ -1,5 +1,5 @@
-import { AxiosRequestConfig } from "axios";
-import {
+import type { AxiosRequestConfig } from "axios";
+import type {
   confluenceOverwritePageFunction,
   confluenceOverwritePageParamsType,
   confluenceOverwritePageOutputType,

--- a/src/actions/providers/credal/callCopilot.ts
+++ b/src/actions/providers/credal/callCopilot.ts
@@ -1,5 +1,5 @@
 import { CredalClient } from "@credal/sdk";
-import {
+import type {
   AuthParamsType,
   credalCallCopilotFunction,
   credalCallCopilotOutputType,

--- a/src/actions/providers/finnhub/getBasicFinancials.ts
+++ b/src/actions/providers/finnhub/getBasicFinancials.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   finnhubGetBasicFinancialsFunction,
   finnhubGetBasicFinancialsParamsType,
   finnhubGetBasicFinancialsOutputType,
-  finnhubGetBasicFinancialsOutputSchema,
-  AuthParamsType,
+  AuthParamsType} from "../../autogen/types";
+import {
+  finnhubGetBasicFinancialsOutputSchema
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 

--- a/src/actions/providers/finnhub/getBasicFinancials.ts
+++ b/src/actions/providers/finnhub/getBasicFinancials.ts
@@ -2,10 +2,9 @@ import type {
   finnhubGetBasicFinancialsFunction,
   finnhubGetBasicFinancialsParamsType,
   finnhubGetBasicFinancialsOutputType,
-  AuthParamsType} from "../../autogen/types";
-import {
-  finnhubGetBasicFinancialsOutputSchema
+  AuthParamsType,
 } from "../../autogen/types";
+import { finnhubGetBasicFinancialsOutputSchema } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
 interface FinancialMetricData {

--- a/src/actions/providers/finnhub/symbolLookup.ts
+++ b/src/actions/providers/finnhub/symbolLookup.ts
@@ -2,10 +2,9 @@ import type {
   finnhubSymbolLookupFunction,
   finnhubSymbolLookupParamsType,
   finnhubSymbolLookupOutputType,
-  AuthParamsType} from "../../autogen/types";
-import {
-  finnhubSymbolLookupOutputSchema
+  AuthParamsType,
 } from "../../autogen/types";
+import { finnhubSymbolLookupOutputSchema } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
 const symbolLookup: finnhubSymbolLookupFunction = async ({

--- a/src/actions/providers/finnhub/symbolLookup.ts
+++ b/src/actions/providers/finnhub/symbolLookup.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   finnhubSymbolLookupFunction,
   finnhubSymbolLookupParamsType,
   finnhubSymbolLookupOutputType,
-  finnhubSymbolLookupOutputSchema,
-  AuthParamsType,
+  AuthParamsType} from "../../autogen/types";
+import {
+  finnhubSymbolLookupOutputSchema
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 

--- a/src/actions/providers/firecrawl/scrapeTweetDataWithNitter.ts
+++ b/src/actions/providers/firecrawl/scrapeTweetDataWithNitter.ts
@@ -1,5 +1,5 @@
 import FirecrawlApp from "@mendable/firecrawl-js";
-import {
+import type {
   AuthParamsType,
   firecrawlScrapeTweetDataWithNitterFunction,
   firecrawlScrapeTweetDataWithNitterParamsType,

--- a/src/actions/providers/firecrawl/scrapeUrl.ts
+++ b/src/actions/providers/firecrawl/scrapeUrl.ts
@@ -1,10 +1,11 @@
 import FirecrawlApp from "@mendable/firecrawl-js";
-import {
+import type {
   firecrawlScrapeUrlFunction,
   firecrawlScrapeUrlParamsType,
   firecrawlScrapeUrlOutputType,
-  firecrawlScrapeUrlOutputSchema,
-  AuthParamsType,
+  AuthParamsType} from "../../autogen/types";
+import {
+  firecrawlScrapeUrlOutputSchema
 } from "../../autogen/types";
 
 const scrapeUrl: firecrawlScrapeUrlFunction = async ({

--- a/src/actions/providers/firecrawl/scrapeUrl.ts
+++ b/src/actions/providers/firecrawl/scrapeUrl.ts
@@ -3,10 +3,9 @@ import type {
   firecrawlScrapeUrlFunction,
   firecrawlScrapeUrlParamsType,
   firecrawlScrapeUrlOutputType,
-  AuthParamsType} from "../../autogen/types";
-import {
-  firecrawlScrapeUrlOutputSchema
+  AuthParamsType,
 } from "../../autogen/types";
+import { firecrawlScrapeUrlOutputSchema } from "../../autogen/types";
 
 const scrapeUrl: firecrawlScrapeUrlFunction = async ({
   params,

--- a/src/actions/providers/github/createBranch.ts
+++ b/src/actions/providers/github/createBranch.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   githubCreateBranchFunction,
   githubCreateBranchOutputType,

--- a/src/actions/providers/github/createBranch.ts
+++ b/src/actions/providers/github/createBranch.ts
@@ -18,7 +18,7 @@ const createBranch: githubCreateBranchFunction = async ({
   if (!authParams.authToken) {
     return { success: false, error: "authToken is required for GitHub API" };
   }
-  const { Octokit, RequestError} = await import("octokit");
+  const { Octokit, RequestError } = await import("octokit");
 
   const { repositoryOwner, repositoryName, branchName, baseRefOrHash } = params;
 

--- a/src/actions/providers/github/createOrUpdateFile.ts
+++ b/src/actions/providers/github/createOrUpdateFile.ts
@@ -20,7 +20,7 @@ const createOrUpdateFile: githubCreateOrUpdateFileFunction = async ({
     return { success: false, error: "authToken is required for GitHub API" };
   }
 
-  const { Octokit, RequestError} = await import("octokit");
+  const { Octokit, RequestError } = await import("octokit");
 
   const { repositoryOwner, repositoryName, filePath, branch, fileContent, commitMessage } = params;
 

--- a/src/actions/providers/github/createOrUpdateFile.ts
+++ b/src/actions/providers/github/createOrUpdateFile.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   githubCreateOrUpdateFileFunction,
   githubCreateOrUpdateFileOutputType,

--- a/src/actions/providers/github/createPullRequest.ts
+++ b/src/actions/providers/github/createPullRequest.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   githubCreatePullRequestFunction,
   githubCreatePullRequestOutputType,

--- a/src/actions/providers/google-oauth/createNewGoogleDoc.ts
+++ b/src/actions/providers/google-oauth/createNewGoogleDoc.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   googleOauthCreateNewGoogleDocFunction,
   googleOauthCreateNewGoogleDocOutputType,

--- a/src/actions/providers/google-oauth/createPresentation.ts
+++ b/src/actions/providers/google-oauth/createPresentation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   googleOauthCreatePresentationFunction,
   googleOauthCreatePresentationParamsType,

--- a/src/actions/providers/google-oauth/createSpreadsheet.ts
+++ b/src/actions/providers/google-oauth/createSpreadsheet.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {
+import type {
   AuthParamsType,
   googleOauthCreateSpreadsheetFunction,
   googleOauthCreateSpreadsheetParamsType,

--- a/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
+++ b/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
@@ -1,5 +1,5 @@
 import { v4 } from "uuid";
-import {
+import type {
   AuthParamsType,
   googleOauthScheduleCalendarMeetingFunction,
   googleOauthScheduleCalendarMeetingOutputType,

--- a/src/actions/providers/google-oauth/updateDoc.ts
+++ b/src/actions/providers/google-oauth/updateDoc.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {
+import type {
   AuthParamsType,
   googleOauthUpdateDocFunction,
   googleOauthUpdateDocParamsType,

--- a/src/actions/providers/google-oauth/updatePresentation.ts
+++ b/src/actions/providers/google-oauth/updatePresentation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   googleOauthUpdatePresentationFunction,
   googleOauthUpdatePresentationOutputType,

--- a/src/actions/providers/google-oauth/updateSpreadsheet.ts
+++ b/src/actions/providers/google-oauth/updateSpreadsheet.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   googleOauthUpdateSpreadsheetFunction,
   googleOauthUpdateSpreadsheetOutputType,

--- a/src/actions/providers/googlemaps/nearbysearchRestaurants.ts
+++ b/src/actions/providers/googlemaps/nearbysearchRestaurants.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   googlemapsNearbysearchRestaurantsFunction,
   googlemapsNearbysearchRestaurantsParamsType,
   googlemapsNearbysearchRestaurantsOutputType,
-  googlemapsNearbysearchRestaurantsOutputSchema,
-  AuthParamsType,
+  AuthParamsType} from "../../autogen/types";
+import {
+  googlemapsNearbysearchRestaurantsOutputSchema
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 

--- a/src/actions/providers/googlemaps/nearbysearchRestaurants.ts
+++ b/src/actions/providers/googlemaps/nearbysearchRestaurants.ts
@@ -2,10 +2,9 @@ import type {
   googlemapsNearbysearchRestaurantsFunction,
   googlemapsNearbysearchRestaurantsParamsType,
   googlemapsNearbysearchRestaurantsOutputType,
-  AuthParamsType} from "../../autogen/types";
-import {
-  googlemapsNearbysearchRestaurantsOutputSchema
+  AuthParamsType,
 } from "../../autogen/types";
+import { googlemapsNearbysearchRestaurantsOutputSchema } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
 interface NearbySearchResult {

--- a/src/actions/providers/googlemaps/validateAddress.ts
+++ b/src/actions/providers/googlemaps/validateAddress.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   googlemapsValidateAddressFunction,
   googlemapsValidateAddressParamsType,
   googlemapsValidateAddressOutputType,

--- a/src/actions/providers/jira/assignJiraTicket.ts
+++ b/src/actions/providers/jira/assignJiraTicket.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosError } from "axios";
-import {
+import type { AxiosError } from "axios";
+import axios from "axios";
+import type {
   AuthParamsType,
   jiraAssignJiraTicketFunction,
   jiraAssignJiraTicketOutputType,

--- a/src/actions/providers/jira/commentJiraTicket.ts
+++ b/src/actions/providers/jira/commentJiraTicket.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraCommentJiraTicketFunction,
   jiraCommentJiraTicketOutputType,

--- a/src/actions/providers/jira/createJiraTicket.ts
+++ b/src/actions/providers/jira/createJiraTicket.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraCreateJiraTicketFunction,
   jiraCreateJiraTicketOutputType,

--- a/src/actions/providers/jira/getJiraTicketDetails.ts
+++ b/src/actions/providers/jira/getJiraTicketDetails.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraGetJiraTicketDetailsFunction,
   jiraGetJiraTicketDetailsOutputType,

--- a/src/actions/providers/jira/getJiraTicketHistory.ts
+++ b/src/actions/providers/jira/getJiraTicketHistory.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraGetJiraTicketHistoryFunction,
   jiraGetJiraTicketHistoryOutputType,

--- a/src/actions/providers/jira/updateJiraTicketDetails.ts
+++ b/src/actions/providers/jira/updateJiraTicketDetails.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraUpdateJiraTicketDetailsFunction,
   jiraUpdateJiraTicketDetailsOutputType,

--- a/src/actions/providers/jira/updateJiraTicketStatus.ts
+++ b/src/actions/providers/jira/updateJiraTicketStatus.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   jiraUpdateJiraTicketStatusFunction,
   jiraUpdateJiraTicketStatusOutputType,

--- a/src/actions/providers/jira/utils.ts
+++ b/src/actions/providers/jira/utils.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from "axios";
+import type { AxiosError } from "axios";
 import { axiosClient } from "../../util/axiosClient";
 
 export async function getUserAccountIdFromEmail(

--- a/src/actions/providers/linkedin/createSharePostLinkedinUrl.ts
+++ b/src/actions/providers/linkedin/createSharePostLinkedinUrl.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   linkedinCreateShareLinkedinPostUrlFunction,
   linkedinCreateShareLinkedinPostUrlParamsType,

--- a/src/actions/providers/looker/enableUserByEmail.ts
+++ b/src/actions/providers/looker/enableUserByEmail.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   lookerEnableUserByEmailFunction,
   lookerEnableUserByEmailParamsType,

--- a/src/actions/providers/math/add.ts
+++ b/src/actions/providers/math/add.ts
@@ -1,4 +1,4 @@
-import { mathAddFunction, mathAddParamsType, mathAddOutputType } from "../../../actions/autogen/types";
+import type { mathAddFunction, mathAddParamsType, mathAddOutputType } from "../../../actions/autogen/types";
 
 const mathAdd: mathAddFunction = async ({ params }: { params: mathAddParamsType }): Promise<mathAddOutputType> => {
   return {

--- a/src/actions/providers/microsoft/createDocument.ts
+++ b/src/actions/providers/microsoft/createDocument.ts
@@ -1,5 +1,5 @@
 import { microsoftCreateDocumentDefinition } from "../../autogen/templates";
-import {
+import type {
   AuthParamsType,
   microsoftCreateDocumentFunction,
   microsoftCreateDocumentOutputType,

--- a/src/actions/providers/microsoft/getDocument.ts
+++ b/src/actions/providers/microsoft/getDocument.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   microsoftGetDocumentFunction,
   microsoftGetDocumentOutputType,

--- a/src/actions/providers/microsoft/messageTeamsChannel.ts
+++ b/src/actions/providers/microsoft/messageTeamsChannel.ts
@@ -1,5 +1,5 @@
 import { microsoftMessageTeamsChannelDefinition } from "../../autogen/templates";
-import {
+import type {
   AuthParamsType,
   microsoftMessageTeamsChannelFunction,
   microsoftMessageTeamsChannelOutputType,

--- a/src/actions/providers/microsoft/messageTeamsChat.ts
+++ b/src/actions/providers/microsoft/messageTeamsChat.ts
@@ -1,5 +1,5 @@
 import { microsoftMessageTeamsChatDefinition } from "../../autogen/templates";
-import {
+import type {
   AuthParamsType,
   microsoftMessageTeamsChatFunction,
   microsoftMessageTeamsChatOutputType,

--- a/src/actions/providers/microsoft/updateDocument.ts
+++ b/src/actions/providers/microsoft/updateDocument.ts
@@ -1,5 +1,5 @@
 import { microsoftUpdateDocumentDefinition } from "../../autogen/templates";
-import {
+import type {
   AuthParamsType,
   microsoftUpdateDocumentFunction,
   microsoftUpdateDocumentOutputType,

--- a/src/actions/providers/microsoft/updateSpreadsheet.ts
+++ b/src/actions/providers/microsoft/updateSpreadsheet.ts
@@ -1,5 +1,5 @@
 import { microsoftUpdateSpreadsheetDefinition } from "../../autogen/templates";
-import {
+import type {
   AuthParamsType,
   microsoftUpdateSpreadsheetFunction,
   microsoftUpdateSpreadsheetOutputType,

--- a/src/actions/providers/microsoft/utils.ts
+++ b/src/actions/providers/microsoft/utils.ts
@@ -1,6 +1,6 @@
 import { Client } from "@microsoft/microsoft-graph-client";
 import { axiosClient } from "../../util/axiosClient";
-import { AuthParamsType } from "../../autogen/types";
+import type { AuthParamsType } from "../../autogen/types";
 
 export async function getGraphClient(authParams: AuthParamsType, scope: string): Promise<Client> {
   if (

--- a/src/actions/providers/mongodb/insertMongoDoc.ts
+++ b/src/actions/providers/mongodb/insertMongoDoc.ts
@@ -1,5 +1,5 @@
 import { MongoClient } from "mongodb";
-import {
+import type {
   AuthParamsType,
   mongoInsertMongoDocFunction,
   mongoInsertMongoDocOutputType,

--- a/src/actions/providers/nws/getForecastForLocation.ts
+++ b/src/actions/providers/nws/getForecastForLocation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   nwsGetForecastForLocationFunction,
   nwsGetForecastForLocationOutputType,

--- a/src/actions/providers/openstreetmap/getLatitudeLongitudeFromLocation.ts
+++ b/src/actions/providers/openstreetmap/getLatitudeLongitudeFromLocation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   openstreetmapGetLatitudeLongitudeFromLocationFunction,
   openstreetmapGetLatitudeLongitudeFromLocationOutputType,

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -1,10 +1,11 @@
 import { Resend } from "resend";
-import {
+import type {
   resendSendEmailFunction,
   resendSendEmailParamsType,
   resendSendEmailOutputType,
-  resendSendEmailOutputSchema,
-  AuthParamsType,
+  AuthParamsType} from "../../autogen/types";
+import {
+  resendSendEmailOutputSchema
 } from "../../autogen/types";
 
 const sendEmail: resendSendEmailFunction = async ({

--- a/src/actions/providers/resend/sendEmail.ts
+++ b/src/actions/providers/resend/sendEmail.ts
@@ -3,10 +3,9 @@ import type {
   resendSendEmailFunction,
   resendSendEmailParamsType,
   resendSendEmailOutputType,
-  AuthParamsType} from "../../autogen/types";
-import {
-  resendSendEmailOutputSchema
+  AuthParamsType,
 } from "../../autogen/types";
+import { resendSendEmailOutputSchema } from "../../autogen/types";
 
 const sendEmail: resendSendEmailFunction = async ({
   params,

--- a/src/actions/providers/salesforce/createCase.ts
+++ b/src/actions/providers/salesforce/createCase.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   salesforceCreateCaseFunction,
   salesforceCreateCaseOutputType,

--- a/src/actions/providers/salesforce/generateSalesReport.ts
+++ b/src/actions/providers/salesforce/generateSalesReport.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   salesforceGenerateSalesReportFunction,
   salesforceGenerateSalesReportOutputType,

--- a/src/actions/providers/salesforce/getRecord.ts
+++ b/src/actions/providers/salesforce/getRecord.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   salesforceGetRecordFunction,
   salesforceGetRecordOutputType,

--- a/src/actions/providers/salesforce/getSalesforceRecordByQuery.ts
+++ b/src/actions/providers/salesforce/getSalesforceRecordByQuery.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   salesforceGetSalesforceRecordsByQueryFunction,
   salesforceGetSalesforceRecordsByQueryOutputType,

--- a/src/actions/providers/salesforce/updateRecord.ts
+++ b/src/actions/providers/salesforce/updateRecord.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   salesforceUpdateRecordFunction,
   salesforceUpdateRecordOutputType,

--- a/src/actions/providers/slack/getChannelMessages.ts
+++ b/src/actions/providers/slack/getChannelMessages.ts
@@ -1,9 +1,9 @@
 import { WebClient } from "@slack/web-api";
-import {
+import type {
+  AuthParamsType,
   slackGetChannelMessagesFunction,
   slackGetChannelMessagesOutputType,
   slackGetChannelMessagesParamsType,
-  AuthParamsType,
 } from "../../autogen/types";
 import { getSlackChannels } from "./helpers";
 

--- a/src/actions/providers/slack/helpers.ts
+++ b/src/actions/providers/slack/helpers.ts
@@ -1,5 +1,5 @@
-import { ConversationsListResponse, WebClient } from "@slack/web-api";
-import { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse";
+import type { ConversationsListResponse, WebClient } from "@slack/web-api";
+import type { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse";
 
 export type ChannelWithId = Channel & { id: string };
 

--- a/src/actions/providers/slack/listConversations.ts
+++ b/src/actions/providers/slack/listConversations.ts
@@ -1,11 +1,12 @@
 import { WebClient } from "@slack/web-api";
-import {
-  slackListConversationsFunction,
-  slackListConversationsParamsType,
-  slackListConversationsOutputType,
+import type {
   AuthParamsType,
+  slackListConversationsFunction,
+  slackListConversationsOutputType,
+  slackListConversationsParamsType,
 } from "../../autogen/types";
-import { ChannelWithId, getSlackChannels } from "./helpers";
+import type { ChannelWithId } from "./helpers";
+import { getSlackChannels } from "./helpers";
 
 type ChannelWithIdTopicNamePurpose = ChannelWithId & { topic: string; name: string; purpose: string };
 

--- a/src/actions/providers/slack/sendMessage.ts
+++ b/src/actions/providers/slack/sendMessage.ts
@@ -1,5 +1,5 @@
 import { WebClient } from "@slack/web-api";
-import {
+import type {
   slackSendMessageFunction,
   slackSendMessageOutputType,
   slackSendMessageParamsType,

--- a/src/actions/providers/snowflake/getRowByFieldValue.ts
+++ b/src/actions/providers/snowflake/getRowByFieldValue.ts
@@ -1,5 +1,5 @@
 import snowflake from "snowflake-sdk";
-import {
+import type {
   AuthParamsType,
   snowflakeGetRowByFieldValueFunction,
   snowflakeGetRowByFieldValueOutputType,

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -1,5 +1,5 @@
 import snowflake from "snowflake-sdk";
-import {
+import type {
   AuthParamsType,
   snowflakeRunSnowflakeQueryFunction,
   snowflakeRunSnowflakeQueryOutputType,

--- a/src/actions/providers/x/createXSharePostUrl.ts
+++ b/src/actions/providers/x/createXSharePostUrl.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   xCreateShareXPostUrlFunction,
   xCreateShareXPostUrlParamsType,

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   zendeskAddCommentToTicketFunction,
   zendeskAddCommentToTicketOutputType,

--- a/src/actions/providers/zendesk/assignTicket.ts
+++ b/src/actions/providers/zendesk/assignTicket.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   zendeskAssignTicketFunction,
   zendeskAssignTicketOutputType,

--- a/src/actions/providers/zendesk/createZendeskTicket.ts
+++ b/src/actions/providers/zendesk/createZendeskTicket.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   zendeskCreateZendeskTicketFunction,
   zendeskCreateZendeskTicketOutputType,

--- a/src/actions/providers/zendesk/getTicketDetails.ts
+++ b/src/actions/providers/zendesk/getTicketDetails.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   zendeskGetTicketDetailsFunction,
   zendeskGetTicketDetailsOutputType,

--- a/src/actions/providers/zendesk/updateTicketStatus.ts
+++ b/src/actions/providers/zendesk/updateTicketStatus.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthParamsType,
   zendeskUpdateTicketStatusFunction,
   zendeskUpdateTicketStatusOutputType,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1532,7 +1532,26 @@ actions:
                         bulletPreset:
                           type: string
                           description: The preset type of bullet to use
-                          enum: [BULLET_UNSPECIFIED, BULLET_DISC_CIRCLE_SQUARE, BULLET_DIAMONDX_ARROW3D_SQUARE, BULLET_CHECKBOX, BULLET_ARROW_DIAMOND_DISC, BULLET_STAR_CIRCLE_SQUARE, BULLET_ARROW3D_CIRCLE_SQUARE, BULLET_LEFTTRIANGLE_DIAMOND_DISC, BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE, BULLET_DIAMOND_CIRCLE_SQUARE, NUMBERED_DECIMAL_NESTED, NUMBERED_DECIMAL_PARENTHESIS_NESTED, NUMBERED_DECIMAL_PERIOD_NESTED, NUMBERED_UPPERALPHA_PARENTHESIS_NESTED, NUMBERED_UPPERROMAN_PARENTHESIS_NESTED, NUMBERED_LOWERALPHA_PARENTHESIS_NESTED, NUMBERED_LOWERROMAN_PARENTHESIS_NESTED]
+                          enum:
+                            [
+                              BULLET_UNSPECIFIED,
+                              BULLET_DISC_CIRCLE_SQUARE,
+                              BULLET_DIAMONDX_ARROW3D_SQUARE,
+                              BULLET_CHECKBOX,
+                              BULLET_ARROW_DIAMOND_DISC,
+                              BULLET_STAR_CIRCLE_SQUARE,
+                              BULLET_ARROW3D_CIRCLE_SQUARE,
+                              BULLET_LEFTTRIANGLE_DIAMOND_DISC,
+                              BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE,
+                              BULLET_DIAMOND_CIRCLE_SQUARE,
+                              NUMBERED_DECIMAL_NESTED,
+                              NUMBERED_DECIMAL_PARENTHESIS_NESTED,
+                              NUMBERED_DECIMAL_PERIOD_NESTED,
+                              NUMBERED_UPPERALPHA_PARENTHESIS_NESTED,
+                              NUMBERED_UPPERROMAN_PARENTHESIS_NESTED,
+                              NUMBERED_LOWERALPHA_PARENTHESIS_NESTED,
+                              NUMBERED_LOWERROMAN_PARENTHESIS_NESTED,
+                            ]
                 - type: object
                   required: [deleteParagraphBullets]
                   properties:
@@ -2060,7 +2079,7 @@ actions:
         type: object
         required: [spreadsheetId, requests]
         properties:
-          spreadsheetId:  
+          spreadsheetId:
             type: string
             description: The ID of the Google Spreadsheet to update
           requests:
@@ -2222,7 +2241,17 @@ actions:
                                   properties:
                                     type:
                                       type: string
-                                      enum: ["TEXT", "NUMBER", "PERCENT", "CURRENCY", "DATE", "TIME", "DATE_TIME", "SCIENTIFIC"]
+                                      enum:
+                                        [
+                                          "TEXT",
+                                          "NUMBER",
+                                          "PERCENT",
+                                          "CURRENCY",
+                                          "DATE",
+                                          "TIME",
+                                          "DATE_TIME",
+                                          "SCIENTIFIC",
+                                        ]
                                       description: The type of the number format
                                     pattern:
                                       type: string
@@ -2766,11 +2795,11 @@ actions:
                           type: object
                           description: The properties to update for the table cell
                         fields:
-                           type: string
-                           description: Comma-separated list of fields to update (e.g., 'contentAlignment,backgroundColor')
+                          type: string
+                          description: Comma-separated list of fields to update (e.g., 'contentAlignment,backgroundColor')
                         tableRange:
-                           type: object
-                           description: The range of cells to update the properties for
+                          type: object
+                          description: The range of cells to update the properties for
                 - type: object
                   required: [updateLineProperties]
                   properties:
@@ -2786,8 +2815,8 @@ actions:
                           type: object
                           description: The properties to update for the line
                         fields:
-                           type: string
-                           description: Comma-separated list of fields to update (e.g., 'lineFill,weight')
+                          type: string
+                          description: Comma-separated list of fields to update (e.g., 'lineFill,weight')
                 - type: object
                   required: [createParagraphBullets]
                   properties:
@@ -2828,14 +2857,14 @@ actions:
                               type: boolean
                               description: Whether the text match is case-sensitive
                         replaceMethod:
-                           type: string
-                           enum: [CENTER_INSIDE, CENTER_CROP]
-                           description: The image replace method (Defaults to CENTER_INSIDE)
+                          type: string
+                          enum: [CENTER_INSIDE, CENTER_CROP]
+                          description: The image replace method (Defaults to CENTER_INSIDE)
                         pageObjectIds:
-                           type: array
-                           items:
-                             type: string
-                           description: Optional list of page object IDs to scope the replacement to
+                          type: array
+                          items:
+                            type: string
+                          description: Optional list of page object IDs to scope the replacement to
                 - type: object
                   required: [duplicateObject]
                   properties:
@@ -2851,7 +2880,7 @@ actions:
                           type: object
                           description: Optional map for assigning specific object IDs to the duplicated elements (key is original ID, value is new ID)
                           additionalProperties:
-                             type: string
+                            type: string
                 - type: object
                   required: [updateTextStyle]
                   properties:
@@ -2913,10 +2942,10 @@ actions:
                           enum: [LINKED, NOT_LINKED_IMAGE]
                           description: The linking mode of the chart (Defaults to LINKED)
                         pageObjectIds:
-                           type: array
-                           items:
-                             type: string
-                           description: Optional list of page object IDs to scope the replacement to
+                          type: array
+                          items:
+                            type: string
+                          description: Optional list of page object IDs to scope the replacement to
                 - type: object
                   required: [deleteParagraphBullets]
                   properties:
@@ -2988,25 +3017,25 @@ actions:
                           type: object
                           description: The border properties to update (e.g., dashStyle, weight, color)
                         fields:
-                           type: string
-                           description: Comma-separated list of fields to update (e.g., 'dashStyle,weight')
+                          type: string
+                          description: Comma-separated list of fields to update (e.g., 'dashStyle,weight')
                         borderPosition:
-                           type: string
-                           enum: [ALL, BOTTOM, TOP, LEFT, RIGHT, INNER_HORIZONTAL, INNER_VERTICAL]
-                           description: The position of the border segments to update (defaults to ALL if unspecified)
+                          type: string
+                          enum: [ALL, BOTTOM, TOP, LEFT, RIGHT, INNER_HORIZONTAL, INNER_VERTICAL]
+                          description: The position of the border segments to update (defaults to ALL if unspecified)
                         tableRange:
-                           type: object
-                           description: The range of cells whose border should be updated (defaults to the entire table if unspecified)
-                           properties:
-                             location:
-                               type: object
-                               description: The starting cell location
-                             rowSpan:
-                               type: integer
-                               description: The number of rows in the range
-                             columnSpan:
-                               type: integer
-                               description: The number of columns in the range
+                          type: object
+                          description: The range of cells whose border should be updated (defaults to the entire table if unspecified)
+                          properties:
+                            location:
+                              type: object
+                              description: The starting cell location
+                            rowSpan:
+                              type: integer
+                              description: The number of rows in the range
+                            columnSpan:
+                              type: integer
+                              description: The number of columns in the range
                 - type: object
                   required: [updateTableColumnProperties]
                   properties:
@@ -3019,16 +3048,16 @@ actions:
                           type: string
                           description: The object ID of the table
                         columnIndices:
-                           type: array
-                           items:
-                             type: integer
-                           description: The 0-based indices of the columns to update
+                          type: array
+                          items:
+                            type: integer
+                          description: The 0-based indices of the columns to update
                         tableColumnProperties:
                           type: object
                           description: The properties to update (e.g., columnWidth)
                         fields:
-                           type: string
-                           description: Comma-separated list of fields to update using FieldMask syntax (e.g., 'columnWidth')
+                          type: string
+                          description: Comma-separated list of fields to update using FieldMask syntax (e.g., 'columnWidth')
                 - type: object
                   required: [updateTableRowProperties]
                   properties:
@@ -3041,16 +3070,16 @@ actions:
                           type: string
                           description: The object ID of the table
                         rowIndices:
-                           type: array
-                           items:
-                              type: integer
-                           description: The 0-based indices of the rows to update
+                          type: array
+                          items:
+                            type: integer
+                          description: The 0-based indices of the rows to update
                         tableRowProperties:
                           type: object
                           description: The properties to update (e.g., minRowHeight)
                         fields:
-                           type: string
-                           description: Comma-separated list of fields to update using FieldMask syntax (e.g., 'minRowHeight')
+                          type: string
+                          description: Comma-separated list of fields to update using FieldMask syntax (e.g., 'minRowHeight')
                 - type: object
                   required: [mergeTableCells]
                   properties:
@@ -3201,17 +3230,17 @@ actions:
                   required: [updateLineCategory]
                   properties:
                     updateLineCategory:
-                       type: object
-                       description: Updates the category of a line
-                       required: [objectId, lineCategory]
-                       properties:
-                         objectId:
-                           type: string
-                           description: The object ID of the line
-                         lineCategory:
-                           type: string
-                           enum: [STRAIGHT, BENT, CURVED]
-                           description: The new line category
+                      type: object
+                      description: Updates the category of a line
+                      required: [objectId, lineCategory]
+                      properties:
+                        objectId:
+                          type: string
+                          description: The object ID of the line
+                        lineCategory:
+                          type: string
+                          enum: [STRAIGHT, BENT, CURVED]
+                          description: The new line category
                 - type: object
                   required: [rerouteLine]
                   properties:

--- a/src/actions/util/axiosClient.ts
+++ b/src/actions/util/axiosClient.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import axios, { AxiosError, AxiosInstance, AxiosResponse } from "axios";
+import type { AxiosError, AxiosInstance, AxiosResponse } from "axios";
+import axios from "axios";
 
 export class ApiError extends Error {
   status?: number;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,8 @@
-import { ActionTemplate } from "./actions/parse";
+import type { ActionTemplate } from "./actions/parse";
 import { ACTION_GROUPS } from "./actions/groups";
 import * as templates from "./actions/autogen/templates";
 import { invokeAction } from "./actions/invoke";
-import { AuthParamsType } from "./actions/autogen/types";
+import type { AuthParamsType } from "./actions/autogen/types";
 
 export async function runAction(
   name: string,

--- a/tests/asana/testCommentAsanaTask.ts
+++ b/tests/asana/testCommentAsanaTask.ts
@@ -6,12 +6,12 @@ async function runTest() {
     "commentTask",
     "asana",
     // Replace with actual valid test fields
-    {authToken:"auth-token-here"} ,
+    { authToken: "auth-token-here" },
     {
       taskId: "task-id-here",
       commentText: `Test Comment created on ${new Date().toISOString()}`,
       isPinned: true,
-    }
+    },
   );
 
   assert(result, "Response should not be null");

--- a/tests/asana/testCreateAsanaTask.ts
+++ b/tests/asana/testCreateAsanaTask.ts
@@ -6,7 +6,7 @@ async function runTest() {
     "createTask",
     "asana",
     // Replace with actual valid test fields
-    {authToken:"auth-token-here"} ,
+    { authToken: "auth-token-here" },
     {
       name: `Test Task created on ${new Date().toISOString()}`,
       workspaceId: "workpace-id-here",
@@ -15,11 +15,11 @@ async function runTest() {
       assignee: "test@vulcancollective.io",
       dueAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // Due in 7 days
       approvalStatus: "pending",
-      taskTemplate:"test-template-name",
+      taskTemplate: "test-template-name",
       custom_fields: {
-        "1234567890123456": "Custom Value" 
+        "1234567890123456": "Custom Value",
       },
-    }
+    },
   );
 
   assert(result, "Response should not be null");

--- a/tests/asana/testUpdateAsanaTask.ts
+++ b/tests/asana/testUpdateAsanaTask.ts
@@ -6,7 +6,7 @@ async function runTest() {
     "updateTask",
     "asana",
     // Replace with actual valid test fields
-    {authToken:"auth-token-here"} ,
+    { authToken: "auth-token-here" },
     {
       name: `Updated: Test Task updated on ${new Date().toISOString()}`,
       taskId: "task-id-here",
@@ -16,9 +16,9 @@ async function runTest() {
       approvalStatus: "pending",
       completed: true,
       custom_fields: {
-        "1234567890123456": "Custom Value" 
+        "1234567890123456": "Custom Value",
       },
-    }
+    },
   );
 
   assert(result, "Response should not be null");

--- a/tests/ashby/common.ts
+++ b/tests/ashby/common.ts
@@ -1,3 +1,3 @@
 export const authParams = {
-    authToken: "insert-during-testing"
+  authToken: "insert-during-testing",
 };

--- a/tests/ashby/testListCandidates.ts
+++ b/tests/ashby/testListCandidates.ts
@@ -2,12 +2,7 @@ import { runAction } from "../../src/app";
 import { authParams } from "./common";
 
 async function runTest() {
-  const result = await runAction(
-    "listCandidates",
-    "ashby",
-    authParams,
-    {}
-  );
+  const result = await runAction("listCandidates", "ashby", authParams, {});
   console.log(result);
 }
 

--- a/tests/confluence/testFetchConfluencePageContent.ts
+++ b/tests/confluence/testFetchConfluencePageContent.ts
@@ -4,17 +4,16 @@ import { runAction } from "../../src/app";
 async function runTest() {
   console.log("Running test for Confluence fetchPageContent");
 
- // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
- const authParams = {
-  baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
-  username: "insert-your-username-here", // Email associated with api token
-  authToken: "insert-your-token-here", 
-};
-
+  // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
+  const authParams = {
+    baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
+    username: "insert-your-username-here", // Email associated with api token
+    authToken: "insert-your-token-here",
+  };
 
   // Page ID to fetch
   const pageParams = {
-    pageId: "insert-confluence-page-id" // Replace with an actual page ID from your Confluence
+    pageId: "insert-confluence-page-id", // Replace with an actual page ID from your Confluence
   };
 
   try {
@@ -22,18 +21,21 @@ async function runTest() {
       "fetchPageContent",
       "confluence",
       authParams,
-      pageParams
+      pageParams,
     );
-    
+
     console.log("Confluence page content fetched successfully!");
     console.log("Page title:", result.title);
     console.log("Content", `${result.content.substring(0, 100)}..`);
-    
+
     // Validate the result
-    assert(result.pageId === pageParams.pageId, "Result should contain matching page ID");
+    assert(
+      result.pageId === pageParams.pageId,
+      "Result should contain matching page ID",
+    );
     assert(result.title, "Result should contain a page title");
     assert(result.content, "Result should contain page content");
-    
+
     return result;
   } catch (error) {
     console.error("Failed to fetch Confluence page content:", error);

--- a/tests/confluence/testOverwriteConfluencePage.ts
+++ b/tests/confluence/testOverwriteConfluencePage.ts
@@ -6,13 +6,12 @@ import { runAction } from "../../src/app";
 async function runTest() {
   console.log("Running test for Confluence overwritePage");
 
-
- // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
- const authParams = {
-  baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
-  username: "insert-your-username-here", // Email associated with api token
-  authToken: "insert-your-token-here", 
-};
+  // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
+  const authParams = {
+    baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
+    username: "insert-your-username-here", // Email associated with api token
+    authToken: "insert-your-token-here",
+  };
 
   // Define the page parameters
   const pageParams = {

--- a/tests/github/testCreateBranch.ts
+++ b/tests/github/testCreateBranch.ts
@@ -18,7 +18,7 @@ async function runTest() {
       repositoryName: "actions-sdk",
       branchName: `test-branch-${Date.now()}`,
       baseRefOrHash: "heads/main",
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/github/testCreateOrUpdateFile.ts
+++ b/tests/github/testCreateOrUpdateFile.ts
@@ -5,73 +5,90 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
+  const authToken = process.env.GITHUB_ACCESS_TOKEN;
+  const branch = "test"; // branch has to exist in the repo
 
-    const authToken = process.env.GITHUB_ACCESS_TOKEN;
-    const branch = "test";  // branch has to exist in the repo
+  const fileName = `test-file-${Date.now()}-${Math.random().toString(36).slice(-5)}.txt`;
 
-    const fileName = `test-file-${Date.now()}-${Math.random().toString(36).slice(-5)}.txt`;
+  const result = await runAction(
+    "createOrUpdateFile",
+    "github",
+    {
+      authToken: authToken,
+    },
+    {
+      repositoryOwner: "vintitres",
+      repositoryName: "actions-sdk",
+      filePath: `testing/${fileName}`,
+      branch,
+      fileContent: `This is a test file created by Credal SDK - ${new Date().toISOString()}`,
+      commitMessage: `Updating file via API - ${new Date().toISOString()}`,
+    },
+  );
 
+  console.log(JSON.stringify(result, null, 2));
 
-    const result = await runAction(
-        "createOrUpdateFile",
-        "github",
-        {
-            authToken: authToken,
-        },
-        {
-            repositoryOwner: "vintitres",
-            repositoryName: "actions-sdk",
-            filePath: `testing/${fileName}`,
-            branch,
-            fileContent: `This is a test file created by Credal SDK - ${new Date().toISOString()}`,
-            commitMessage: `Updating file via API - ${new Date().toISOString()}`,
-        }
-    );
+  // Validate response
+  assert(result, "Response should not be null");
+  assert(result.success, "Response should indicate success");
+  assert(result.newCommitSha, "Response should contain the new commit SHA");
+  assert(
+    /^[a-f0-9]{40}$/.test(result.newCommitSha),
+    "newCommitSha should be a valid SHA-1 hash",
+  );
+  assert(
+    result.operation == "created",
+    "Response should contain the operation type",
+  );
+  console.log(
+    `Successfully created file. New commit SHA: ${result.newCommitSha}`,
+  );
 
-    console.log(JSON.stringify(result, null, 2));
+  // Update the same file with new content
+  const updatedContent = `This is an updated test file created by Credal SDK - ${new Date().toISOString()}`;
+  const updateResult = await runAction(
+    "createOrUpdateFile",
+    "github",
+    {
+      authToken: authToken,
+    },
+    {
+      repositoryOwner: "vintitres",
+      repositoryName: "actions-sdk",
+      filePath: `testing/${fileName}`,
+      branch,
+      fileContent: updatedContent,
+      commitMessage: `Updating file content via API - ${new Date().toISOString()}`,
+    },
+  );
 
-    // Validate response
-    assert(result, "Response should not be null");
-    assert(result.success, "Response should indicate success");
-    assert(result.newCommitSha, "Response should contain the new commit SHA");
-    assert(/^[a-f0-9]{40}$/.test(result.newCommitSha), "newCommitSha should be a valid SHA-1 hash");
-    assert(result.operation == "created", "Response should contain the operation type");
-    console.log(`Successfully created file. New commit SHA: ${result.newCommitSha}`);
+  console.log(JSON.stringify(updateResult, null, 2));
 
-    // Update the same file with new content
-    const updatedContent = `This is an updated test file created by Credal SDK - ${new Date().toISOString()}`;
-    const updateResult = await runAction(
-        "createOrUpdateFile",
-        "github",
-        {
-            authToken: authToken,
-        },
-        {
-            repositoryOwner: "vintitres",
-            repositoryName: "actions-sdk",
-            filePath: `testing/${fileName}`,
-            branch,
-            fileContent: updatedContent,
-            commitMessage: `Updating file content via API - ${new Date().toISOString()}`,
-        }
-    );
-
-    console.log(JSON.stringify(updateResult, null, 2));
-
-    // Validate update response
-    assert(updateResult, "Update response should not be null");
-    assert(updateResult.success, "Update response should indicate success");
-    assert(updateResult.newCommitSha, "Update response should contain the new commit SHA");
-    assert(/^[a-f0-9]{40}$/.test(updateResult.newCommitSha), "newCommitSha should be a valid SHA-1 hash");
-    assert(updateResult.operation == "updated", "Update response should contain the operation type");
-    console.log(`Successfully updated file. New commit SHA: ${updateResult.newCommitSha}`);
+  // Validate update response
+  assert(updateResult, "Update response should not be null");
+  assert(updateResult.success, "Update response should indicate success");
+  assert(
+    updateResult.newCommitSha,
+    "Update response should contain the new commit SHA",
+  );
+  assert(
+    /^[a-f0-9]{40}$/.test(updateResult.newCommitSha),
+    "newCommitSha should be a valid SHA-1 hash",
+  );
+  assert(
+    updateResult.operation == "updated",
+    "Update response should contain the operation type",
+  );
+  console.log(
+    `Successfully updated file. New commit SHA: ${updateResult.newCommitSha}`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/github/testCreatePullRequest.ts
+++ b/tests/github/testCreatePullRequest.ts
@@ -29,7 +29,7 @@ async function runTest() {
       repositoryName,
       branchName: pullBranch,
       baseRefOrHash: `heads/${sourceBranch}`, // Use the target branch as the base
-    }
+    },
   );
 
   console.log(JSON.stringify(branchResult, null, 2));
@@ -38,7 +38,7 @@ async function runTest() {
   assert(branchResult, "Branch creation response should not be null");
   assert(
     branchResult.success,
-    "Branch creation response should indicate success"
+    "Branch creation response should indicate success",
   );
   console.log(`Successfully created branch: ${pullBranch}`);
 
@@ -56,7 +56,7 @@ async function runTest() {
       base: targetBranch,
       title,
       description,
-    }
+    },
   );
 
   console.log(JSON.stringify(pullRequestResult, null, 2));
@@ -65,18 +65,18 @@ async function runTest() {
   assert(pullRequestResult, "Pull request response should not be null");
   assert(
     pullRequestResult.success,
-    "Pull request response should indicate success"
+    "Pull request response should indicate success",
   );
   assert(
     pullRequestResult.pullRequestUrl,
-    "Pull request response should contain the pull request URL"
+    "Pull request response should contain the pull request URL",
   );
   assert(
     pullRequestResult.pullRequestNumber,
-    "Pull request response should contain the pull request number"
+    "Pull request response should contain the pull request number",
   );
   console.log(
-    `Successfully created pull request. URL: ${pullRequestResult.pullRequestUrl}`
+    `Successfully created pull request. URL: ${pullRequestResult.pullRequestUrl}`,
   );
 }
 

--- a/tests/github/testCreatePullRequest.ts
+++ b/tests/github/testCreatePullRequest.ts
@@ -5,72 +5,86 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-    const authToken = process.env.GITHUB_ACCESS_TOKEN;
+  const authToken = process.env.GITHUB_ACCESS_TOKEN;
 
-    const repositoryName = "actions-sdk";
-    const sourceRepositoryOwner = "vintitres";
-    const targetRepositoryOwner = "Credal-ai";
-    const sourceBranch = "test"; // Ensure this branch exists in the source repository
-    const pullBranch = `test-branch-${Date.now()}`;  // Will create this branch in source repo and it will be used as the head branch for the PR
-    const targetBranch = "main"; // Ensure this branch exists in the target repository
+  const repositoryName = "actions-sdk";
+  const sourceRepositoryOwner = "vintitres";
+  const targetRepositoryOwner = "Credal-ai";
+  const sourceBranch = "test"; // Ensure this branch exists in the source repository
+  const pullBranch = `test-branch-${Date.now()}`; // Will create this branch in source repo and it will be used as the head branch for the PR
+  const targetBranch = "main"; // Ensure this branch exists in the target repository
 
-    const title = `Test Pull Request - ${new Date().toISOString()}`;
-    const description = "This is a test pull request created by Credal SDK.";
+  const title = `Test Pull Request - ${new Date().toISOString()}`;
+  const description = "This is a test pull request created by Credal SDK.";
 
-    // Create a new branch to use as the source branch
-    const branchResult = await runAction(
-        "createBranch",
-        "github",
-        {
-            authToken: authToken,
-        },
-        {
-            repositoryOwner: sourceRepositoryOwner,
-            repositoryName,
-            branchName: pullBranch,
-            baseRefOrHash: `heads/${sourceBranch}`, // Use the target branch as the base
-        }
-    );
+  // Create a new branch to use as the source branch
+  const branchResult = await runAction(
+    "createBranch",
+    "github",
+    {
+      authToken: authToken,
+    },
+    {
+      repositoryOwner: sourceRepositoryOwner,
+      repositoryName,
+      branchName: pullBranch,
+      baseRefOrHash: `heads/${sourceBranch}`, // Use the target branch as the base
+    },
+  );
 
-    console.log(JSON.stringify(branchResult, null, 2));
+  console.log(JSON.stringify(branchResult, null, 2));
 
-    // Validate branch creation response
-    assert(branchResult, "Branch creation response should not be null");
-    assert(branchResult.success, "Branch creation response should indicate success");
-    console.log(`Successfully created branch: ${pullBranch}`);
+  // Validate branch creation response
+  assert(branchResult, "Branch creation response should not be null");
+  assert(
+    branchResult.success,
+    "Branch creation response should indicate success",
+  );
+  console.log(`Successfully created branch: ${pullBranch}`);
 
-    // Create a pull request
-    const pullRequestResult = await runAction(
-        "createPullRequest",
-        "github",
-        {
-            authToken: authToken,
-        },
-        {
-            repositoryOwner: targetRepositoryOwner,
-            repositoryName,
-            head: `${sourceRepositoryOwner}:${pullBranch}`,
-            base: targetBranch,
-            title,
-            description,
-        }
-    );
+  // Create a pull request
+  const pullRequestResult = await runAction(
+    "createPullRequest",
+    "github",
+    {
+      authToken: authToken,
+    },
+    {
+      repositoryOwner: targetRepositoryOwner,
+      repositoryName,
+      head: `${sourceRepositoryOwner}:${pullBranch}`,
+      base: targetBranch,
+      title,
+      description,
+    },
+  );
 
-    console.log(JSON.stringify(pullRequestResult, null, 2));
+  console.log(JSON.stringify(pullRequestResult, null, 2));
 
-    // Validate pull request response
-    assert(pullRequestResult, "Pull request response should not be null");
-    assert(pullRequestResult.success, "Pull request response should indicate success");
-    assert(pullRequestResult.pullRequestUrl, "Pull request response should contain the pull request URL");
-    assert(pullRequestResult.pullRequestNumber, "Pull request response should contain the pull request number");
-    console.log(`Successfully created pull request. URL: ${pullRequestResult.pullRequestUrl}`);
+  // Validate pull request response
+  assert(pullRequestResult, "Pull request response should not be null");
+  assert(
+    pullRequestResult.success,
+    "Pull request response should indicate success",
+  );
+  assert(
+    pullRequestResult.pullRequestUrl,
+    "Pull request response should contain the pull request URL",
+  );
+  assert(
+    pullRequestResult.pullRequestNumber,
+    "Pull request response should contain the pull request number",
+  );
+  console.log(
+    `Successfully created pull request. URL: ${pullRequestResult.pullRequestUrl}`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/jira/testAssignJiraTicket.ts
+++ b/tests/jira/testAssignJiraTicket.ts
@@ -16,7 +16,7 @@ async function runTest() {
     {
       issueId: issueId,
       assignee: assignee,
-    }
+    },
   );
 
   assert(result, "Response should not be null");

--- a/tests/jira/testCommentJiraTicket.ts
+++ b/tests/jira/testCommentJiraTicket.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app";
-import { jiraConfig } from './utils'; 
+import { jiraConfig } from "./utils";
 
 async function runTest() {
   const { authToken, cloudId, baseUrl, projectKey, issueId } = jiraConfig;
   const result = await runAction(
     "commentJiraTicket",
     "jira",
-    { 
+    {
       authToken,
       cloudId,
       baseUrl,
@@ -16,18 +16,21 @@ async function runTest() {
       projectKey,
       comment: `Test comment made on ${new Date().toISOString()}`,
       issueId: issueId,
-    }
+    },
   );
-  
+
   console.log(JSON.stringify(result, null, 2));
-  
+
   // Validate response
   assert(result, "Response should not be null");
-  assert(result.commentUrl, "Response should contain a url to the created comment");
+  assert(
+    result.commentUrl,
+    "Response should contain a url to the created comment",
+  );
   console.log(`Successfully created Jira comment: ${result.commentUrl}`);
 }
 
-runTest().catch(error => {
+runTest().catch((error) => {
   console.error("Test failed:", error);
   if (error.response) {
     console.error("API response:", error.response.data);

--- a/tests/jira/testCreateJiraTicket.ts
+++ b/tests/jira/testCreateJiraTicket.ts
@@ -3,41 +3,43 @@ import { runAction } from "../../src/app";
 import { jiraConfig } from "./utils";
 
 async function runTest() {
+  const { authToken, cloudId, baseUrl, projectKey } = jiraConfig;
 
-    const { authToken, cloudId, baseUrl, projectKey } = jiraConfig;
+  const result = await runAction(
+    "createJiraTicket",
+    "jira",
+    {
+      authToken,
+      cloudId,
+      baseUrl,
+    },
+    {
+      projectKey,
+      summary: `Credal - Test Ticket ${new Date().toISOString()}`,
+      description: `Credal - Test Ticket ${new Date().toISOString()}`,
+      issueType: "Task", // Adjust based on available issue types in your Jira
+      reporter: "", // Optional - (defaults to the authenticated user related to the oauth token)
+      assignee: "", // Optional
+      customFields: { customfield_10100: "High" }, // Example of custom fields setting
+    },
+  );
 
-    const result = await runAction(
-        "createJiraTicket",
-        "jira",
-        { 
-            authToken,        
-            cloudId,
-            baseUrl,
-        },
-        {
-            projectKey,
-            summary: `Credal - Test Ticket ${new Date().toISOString()}`,
-            description: `Credal - Test Ticket ${new Date().toISOString()}`,
-            issueType: "Task", // Adjust based on available issue types in your Jira
-            reporter: "", // Optional - (defaults to the authenticated user related to the oauth token)
-            assignee: "", // Optional
-            customFields: { customfield_10100: 'High' }, // Example of custom fields setting
-        }
-    );
-    
-    console.log(JSON.stringify(result, null, 2));
-    
-    // Validate response
-    assert(result, "Response should not be null");
-    assert(result.ticketUrl, "Response should contain a url to the created ticket");
-    console.log(`Successfully created Jira ticket: ${result.ticketUrl}`);
+  console.log(JSON.stringify(result, null, 2));
+
+  // Validate response
+  assert(result, "Response should not be null");
+  assert(
+    result.ticketUrl,
+    "Response should contain a url to the created ticket",
+  );
+  console.log(`Successfully created Jira ticket: ${result.ticketUrl}`);
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/jira/testGetJiraTicketDetails.ts
+++ b/tests/jira/testGetJiraTicketDetails.ts
@@ -15,7 +15,7 @@ async function runTest() {
     },
     {
       issueId,
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));
@@ -27,7 +27,9 @@ async function runTest() {
   assert(result.data.key, "Ticket data should include a key");
   assert(result.data.fields, "Ticket data should include fields");
 
-  console.log(`Successfully retrieved Jira ticket details for: ${result.data.key}`);
+  console.log(
+    `Successfully retrieved Jira ticket details for: ${result.data.key}`,
+  );
 }
 
 runTest().catch((error) => {

--- a/tests/jira/testGetJiraTicketHistory.ts
+++ b/tests/jira/testGetJiraTicketHistory.ts
@@ -15,7 +15,7 @@ async function runTest() {
     },
     {
       issueId,
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/jira/testUpdateJiraTicketDetails.ts
+++ b/tests/jira/testUpdateJiraTicketDetails.ts
@@ -18,14 +18,17 @@ async function runTest() {
       summary: "Updated Summary",
       description: `Updated description made on ${new Date().toISOString()}`,
       customFields: {
-        "customfield_12345": "Custom Value", // Example custom field, replace with actual
+        customfield_12345: "Custom Value", // Example custom field, replace with actual
       },
-    }
+    },
   );
 
   // Validate successful response
   assert(validResult, "Response should not be null");
-  assert(validResult.ticketUrl, "Response should contain a URL to the updated ticket");
+  assert(
+    validResult.ticketUrl,
+    "Response should contain a URL to the updated ticket",
+  );
   console.log(`Successfully updated Jira ticket: ${validResult.ticketUrl}`);
 
   // Partial update (only summary, no description/custom fields)
@@ -40,13 +43,18 @@ async function runTest() {
     {
       issueId,
       summary: "Partially Updated Summary",
-    }
+    },
   );
 
   // Validate successful response
   assert(partialUpdateResult, "Response should not be null");
-  assert(partialUpdateResult.ticketUrl, "Response should contain a URL to the updated ticket");
-  console.log(`Successfully updated Jira ticket with partial update: ${partialUpdateResult.ticketUrl}`);
+  assert(
+    partialUpdateResult.ticketUrl,
+    "Response should contain a URL to the updated ticket",
+  );
+  console.log(
+    `Successfully updated Jira ticket with partial update: ${partialUpdateResult.ticketUrl}`,
+  );
 }
 
 runTest().catch((error) => {

--- a/tests/jira/testUpdateJiraTicketStatus.ts
+++ b/tests/jira/testUpdateJiraTicketStatus.ts
@@ -13,7 +13,7 @@ async function runTest() {
       projectKey,
       issueId,
       status: "In Progress", // Adjust to a valid status for your workflow
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/jira/utils.ts
+++ b/tests/jira/utils.ts
@@ -1,5 +1,5 @@
 export const jiraConfig = {
-   // For OAuth Credentials with Jira: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+  // For OAuth Credentials with Jira: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
   authToken: "your-auth-token-here",
   cloudId: "your-cloud-id-here",
   baseUrl: "your-base-url-here",

--- a/tests/microsoft/getTokenTool.ts
+++ b/tests/microsoft/getTokenTool.ts
@@ -1,23 +1,27 @@
-import http from 'http';
-import open from 'open';
-import axios from 'axios';
-import dotenv from 'dotenv';
-import { URL } from 'url';
+import http from "http";
+import open from "open";
+import axios from "axios";
+import dotenv from "dotenv";
+import { URL } from "url";
 
 dotenv.config();
 
 // Ensure environment variables are set
 if (!process.env.MICROSOFT_CLIENT_ID) {
-    throw new Error('Missing required environment variable: MICROSOFT_CLIENT_ID');
+  throw new Error("Missing required environment variable: MICROSOFT_CLIENT_ID");
 }
 if (!process.env.MICROSOFT_CLIENT_SECRET) {
-    throw new Error('Missing required environment variable: MICROSOFT_CLIENT_SECRET');
+  throw new Error(
+    "Missing required environment variable: MICROSOFT_CLIENT_SECRET",
+  );
 }
 if (!process.env.MICROSOFT_TENANT_ID) {
-    throw new Error('Missing required environment variable: MICROSOFT_TENANT_ID');
+  throw new Error("Missing required environment variable: MICROSOFT_TENANT_ID");
 }
 if (!process.env.MICROSOFT_REDIRECT_URI) {
-    throw new Error('Missing required environment variable: MICROSOFT_REDIRECT_URI');
+  throw new Error(
+    "Missing required environment variable: MICROSOFT_REDIRECT_URI",
+  );
 }
 
 // Load environment variables
@@ -28,73 +32,79 @@ const REDIRECT_URI = process.env.MICROSOFT_REDIRECT_URI;
 
 // Extract the port from the redirect URI
 const parsedUrl = new URL(REDIRECT_URI);
-if (parsedUrl.hostname !== 'localhost' && parsedUrl.hostname !== '127.0.0.1') {
-    throw new Error('The redirect URI must be a localhost URL for this tool to work.');
+if (parsedUrl.hostname !== "localhost" && parsedUrl.hostname !== "127.0.0.1") {
+  throw new Error(
+    "The redirect URI must be a localhost URL for this tool to work.",
+  );
 }
 const AUTH_PORT = parsedUrl.port ? parseInt(parsedUrl.port, 10) : 80; // Default to port 80 if not specified
 
-const scope = "offline_access ChatMessage.Send ChannelMessage.Send Files.ReadWrite Sites.ReadWrite.All";  // offline_access ensures refresh token is returned
+const scope =
+  "offline_access ChatMessage.Send ChannelMessage.Send Files.ReadWrite Sites.ReadWrite.All"; // offline_access ensures refresh token is returned
 
 // Function to generate the Microsoft OAuth2 authorization URL
 function generateAuthUrl(): string {
-    const params = new URLSearchParams({
-        client_id: CLIENT_ID,
-        response_type: 'code',
-        redirect_uri: REDIRECT_URI,
-        scope: scope,
-        response_mode: 'query',
-        state: 'randomstatevalue',
-    });
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: "code",
+    redirect_uri: REDIRECT_URI,
+    scope: scope,
+    response_mode: "query",
+    state: "randomstatevalue",
+  });
 
-    return `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/authorize?${params.toString()}`;
+  return `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/authorize?${params.toString()}`;
 }
 
 // Function to exchange authorization code for tokens
 async function getTokens(authCode: string): Promise<void> {
-    const tokenUrl = `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`;
+  const tokenUrl = `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`;
 
-    const params = new URLSearchParams({
-        client_id: CLIENT_ID,
-        client_secret: CLIENT_SECRET,
-        code: authCode,
-        redirect_uri: REDIRECT_URI,
-        grant_type: 'authorization_code',
-        scope: scope,
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    code: authCode,
+    redirect_uri: REDIRECT_URI,
+    grant_type: "authorization_code",
+    scope: scope,
+  });
+
+  try {
+    const response = await axios.post(tokenUrl, params, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
     });
 
-    try {
-        const response = await axios.post(tokenUrl, params, {
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-        });
-
-        console.log('Access Token:', response.data.access_token);
-        console.log('\nRefresh Token:', response.data.refresh_token);
-    } catch (error: any) {
-        console.error('Error fetching tokens:', error.response?.data || error.message);
-    }
+    console.log("Access Token:", response.data.access_token);
+    console.log("\nRefresh Token:", response.data.refresh_token);
+  } catch (error: any) {
+    console.error(
+      "Error fetching tokens:",
+      error.response?.data || error.message,
+    );
+  }
 }
 
 // Start a temporary local server to capture the authorization code
 const server = http.createServer(async (req, res) => {
-    if (req.url?.startsWith('/callback')) {
-        const url = new URL(req.url, `http://localhost:${AUTH_PORT}`);
-        const authCode = url.searchParams.get('code');
+  if (req.url?.startsWith("/callback")) {
+    const url = new URL(req.url, `http://localhost:${AUTH_PORT}`);
+    const authCode = url.searchParams.get("code");
 
-        if (authCode) {
-            console.log('\nAuthorization Code received:', authCode);
-            res.end('Authorization successful! You can close this window.');
-            server.close(); // Close the server after receiving the code
-            await getTokens(authCode);
-        } else {
-            res.end('Error: No authorization code received.');
-        }
+    if (authCode) {
+      console.log("\nAuthorization Code received:", authCode);
+      res.end("Authorization successful! You can close this window.");
+      server.close(); // Close the server after receiving the code
+      await getTokens(authCode);
+    } else {
+      res.end("Error: No authorization code received.");
     }
+  }
 });
 
 // Start the server
 server.listen(AUTH_PORT, async () => {
-    console.log(`Server listening on port ${AUTH_PORT}`);
-    const authUrl = generateAuthUrl();
-    console.log(`\nOpening the browser for authentication...\n${authUrl}`);
-    await open(authUrl); // Open default web browser to authenticate
+  console.log(`Server listening on port ${AUTH_PORT}`);
+  const authUrl = generateAuthUrl();
+  console.log(`\nOpening the browser for authentication...\n${authUrl}`);
+  await open(authUrl); // Open default web browser to authenticate
 });

--- a/tests/microsoft/testCreateDocument.ts
+++ b/tests/microsoft/testCreateDocument.ts
@@ -20,7 +20,7 @@ async function runTest() {
       name: `TestDocument-${new Date()}.docx`,
       content: "",
       folderId: process.env.MICROSOFT_FOLDER_ID!,
-    }
+    },
   );
   console.log(result);
   assert(result.success, "Document was not created successfully");

--- a/tests/microsoft/testMessageTeamsChannel.ts
+++ b/tests/microsoft/testMessageTeamsChannel.ts
@@ -1,28 +1,29 @@
 import { runAction } from "../../src/app";
-import { assert } from "node:console"
-import dotenv from 'dotenv';
+import { assert } from "node:console";
+import dotenv from "dotenv";
 
 dotenv.config();
 
 async function runTest() {
-    const result = await runAction(
-        "messageTeamsChannel",
-        "microsoft",
-        {
-            tenantId: process.env.MICROSOFT_TENANT_ID!,
-            clientId: process.env.MICROSOFT_CLIENT_ID!,
-            clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
-            refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
-            redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
-        }, // authParams
-        {
-            message: "Hello from actions-sdk testing of Microsoft365 Teams channel integration",
-            teamId: process.env.MICROSOFT_TEAM_ID!,
-            channelId: process.env.MICROSOFT_CHANNEL_ID!,
-        },
-    );
-    console.log(result);
-    assert(result.success, "Message was not sent successfully");
+  const result = await runAction(
+    "messageTeamsChannel",
+    "microsoft",
+    {
+      tenantId: process.env.MICROSOFT_TENANT_ID!,
+      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+      refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
+      redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
+    }, // authParams
+    {
+      message:
+        "Hello from actions-sdk testing of Microsoft365 Teams channel integration",
+      teamId: process.env.MICROSOFT_TEAM_ID!,
+      channelId: process.env.MICROSOFT_CHANNEL_ID!,
+    },
+  );
+  console.log(result);
+  assert(result.success, "Message was not sent successfully");
 }
 
 runTest().catch(console.error);

--- a/tests/microsoft/testMessageTeamsChat.ts
+++ b/tests/microsoft/testMessageTeamsChat.ts
@@ -1,27 +1,28 @@
 import { runAction } from "../../src/app";
-import { assert } from "node:console"
-import dotenv from 'dotenv';
+import { assert } from "node:console";
+import dotenv from "dotenv";
 
 dotenv.config();
 
 async function runTest() {
-    const result = await runAction(
-        "messageTeamsChat",
-        "microsoft",
-        {
-            tenantId: process.env.MICROSOFT_TENANT_ID!,
-            clientId: process.env.MICROSOFT_CLIENT_ID!,
-            clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
-            refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
-            redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
-        }, // authParams
-        {
-            message: "Hello from actions-sdk testing of Microsoft365 Teams chat integration",
-            chatId: process.env.MICROSOFT_CHAT_ID!,
-        },
-    );
-    console.log(result);
-    assert(result.success, "Message was not sent successfully");
+  const result = await runAction(
+    "messageTeamsChat",
+    "microsoft",
+    {
+      tenantId: process.env.MICROSOFT_TENANT_ID!,
+      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+      refreshToken: process.env.MICROSOFT_REFRESH_TOKEN!,
+      redirectUri: process.env.MICROSOFT_REDIRECT_URI!,
+    }, // authParams
+    {
+      message:
+        "Hello from actions-sdk testing of Microsoft365 Teams chat integration",
+      chatId: process.env.MICROSOFT_CHAT_ID!,
+    },
+  );
+  console.log(result);
+  assert(result.success, "Message was not sent successfully");
 }
 
 runTest().catch(console.error);

--- a/tests/microsoft/testUpdateDocument.ts
+++ b/tests/microsoft/testUpdateDocument.ts
@@ -21,7 +21,7 @@ async function runTest() {
       folderId: process.env.MICROSOFT_FOLDER_ID!,
       name: `TestDocument-${Date.now()}.txt`,
       content: "This is the initial content of the document.",
-    }
+    },
   );
 
   console.log("Create Result:", createResult);
@@ -46,7 +46,7 @@ async function runTest() {
       siteId: process.env.MICROSOFT_SITE_ID!,
       documentId,
       content: updatedContent,
-    }
+    },
   );
 
   console.log("Update Result:", updateResult);
@@ -66,14 +66,14 @@ async function runTest() {
     {
       siteId: process.env.MICROSOFT_SITE_ID!,
       documentId,
-    }
+    },
   );
 
   console.log("Fetch Result:", fetchResult);
   assert(fetchResult.success, "Document was not fetched successfully");
   assert(
     fetchResult.content === updatedContent,
-    "Document content was not updated correctly"
+    "Document content was not updated correctly",
   );
 
   console.log("Document content verified successfully.");

--- a/tests/microsoft/testUpdateDocumentDocx.ts
+++ b/tests/microsoft/testUpdateDocumentDocx.ts
@@ -56,7 +56,7 @@ async function runTest() {
       folderId: process.env.MICROSOFT_FOLDER_ID!,
       name: `TestDocument-${Date.now()}.docx`,
       content: initialContent, // Pass the generated `.docx` content
-    }
+    },
   );
 
   console.log("Create Result:", createResult);
@@ -83,7 +83,7 @@ async function runTest() {
       siteId: process.env.MICROSOFT_SITE_ID!,
       documentId,
       content: updatedContent, // Pass the updated `.docx` content
-    }
+    },
   );
 
   console.log("Update Result:", updateResult);
@@ -103,7 +103,7 @@ async function runTest() {
     {
       siteId: process.env.MICROSOFT_SITE_ID!,
       documentId,
-    }
+    },
   );
 
   console.log("Fetch Result:", fetchResult);

--- a/tests/microsoft/testUpdateSpreadsheet.ts
+++ b/tests/microsoft/testUpdateSpreadsheet.ts
@@ -21,7 +21,7 @@ async function runTest() {
       folderId: process.env.MICROSOFT_FOLDER_ID!,
       name: `TestSpreadsheet-${Date.now()}.xlsx`,
       content: "",
-    }
+    },
   );
 
   console.log("Create Result:", createResult);
@@ -50,7 +50,7 @@ async function runTest() {
         ["John Doe", "30"],
         ["Date", new Date().toISOString()],
       ],
-    }
+    },
   );
 
   console.log("Update Result:", updateResult);

--- a/tests/salesforce/testCreateCase.ts
+++ b/tests/salesforce/testCreateCase.ts
@@ -9,23 +9,23 @@ async function runTest() {
   const authToken = await authenticateWithJWT();
   const baseUrl = "https://power-speed-8849.my.salesforce.com/"; // Must be a valid Salesforce instance URL
 
-const result = await runAction(
+  const result = await runAction(
     "createCase",
     "salesforce",
     {
-        authToken,
-        baseUrl,
+      authToken,
+      baseUrl,
     },
     {
-        subject: `Test Case Subject - ${new Date().toISOString()}`,
-        description: "This is a test case created via the Salesforce API.",
-        priority: "High",
-        origin: "Web",
-        customFields: {
-            Reason: "Test Reason",
-        },
-    }
-);
+      subject: `Test Case Subject - ${new Date().toISOString()}`,
+      description: "This is a test case created via the Salesforce API.",
+      priority: "High",
+      origin: "Web",
+      customFields: {
+        Reason: "Test Reason",
+      },
+    },
+  );
 
   console.log(JSON.stringify(result, null, 2));
 

--- a/tests/salesforce/testGenerateSalesReport.ts
+++ b/tests/salesforce/testGenerateSalesReport.ts
@@ -7,7 +7,7 @@ dotenv.config();
 
 async function runTest() {
   const authToken = await authenticateWithJWT();
-  const baseUrl = 'https://power-speed-8849.my.salesforce.com/';  // Must be a valid Salesforce instance URL
+  const baseUrl = "https://power-speed-8849.my.salesforce.com/"; // Must be a valid Salesforce instance URL
 
   const result = await runAction(
     "generateSalesReport",
@@ -22,7 +22,7 @@ async function runTest() {
       filters: {
         StageName: "Closed Won",
       },
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/salesforce/testGetRecord.ts
+++ b/tests/salesforce/testGetRecord.ts
@@ -7,7 +7,7 @@ dotenv.config();
 
 async function runTest() {
   const authToken = await authenticateWithJWT();
-  const baseUrl = 'https://power-speed-8849.my.salesforce.com/';  // Must be a valid Salesforce instance URL
+  const baseUrl = "https://power-speed-8849.my.salesforce.com/"; // Must be a valid Salesforce instance URL
 
   const result = await runAction(
     "getRecord",
@@ -19,7 +19,7 @@ async function runTest() {
     {
       objectType: "Lead", // Replace with the object type you want to retrieve
       recordId: "00Qfn0000004na7EAA", // Replace with a valid record ID
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/salesforce/testUpdateRecord.ts
+++ b/tests/salesforce/testUpdateRecord.ts
@@ -7,9 +7,9 @@ dotenv.config();
 
 async function runTest() {
   const authToken = await authenticateWithJWT();
-  const baseUrl = 'https://power-speed-8849.my.salesforce.com/';  // Must be a valid Salesforce instance URL
-  const recordId = "00Qfn0000004na7EAA";  // Must be a valid lead ID in your Salesforce instance
-  const objectType = "Lead";  // Must be a valid object type of recordId object
+  const baseUrl = "https://power-speed-8849.my.salesforce.com/"; // Must be a valid Salesforce instance URL
+  const recordId = "00Qfn0000004na7EAA"; // Must be a valid lead ID in your Salesforce instance
+  const objectType = "Lead"; // Must be a valid object type of recordId object
 
   const fieldsToUpdate = {
     FirstName: "Updated Actions SDK First Name",
@@ -30,7 +30,7 @@ async function runTest() {
       objectType,
       recordId,
       fieldsToUpdate,
-    }
+    },
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/salesforce/utils.ts
+++ b/tests/salesforce/utils.ts
@@ -1,5 +1,5 @@
-import jwt from 'jsonwebtoken';
-import axios from 'axios';
+import jwt from "jsonwebtoken";
+import axios from "axios";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -8,37 +8,44 @@ dotenv.config();
 // For setup see https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_jwt_flow.htm&type=5)
 
 // The private key of the connected app in pkcs8 format, base64 encoded
-const PRIVATE_KEY = Buffer.from(process.env.SALESFORCE_PRIVATE_KEY_BASE64!, 'base64').toString('utf-8');
+const PRIVATE_KEY = Buffer.from(
+  process.env.SALESFORCE_PRIVATE_KEY_BASE64!,
+  "base64",
+).toString("utf-8");
 // The client ID of the connected app
 const CLIENT_ID = process.env.SALESFORCE_CONSUMER_KEY!;
 // The Salesforce username associated with the connected app
 const USERNAME = process.env.SALESFORCE_USERNAME!;
 // Use the sandbox URL if you're working with a sandbox: https://test.salesforce.com
-const LOGIN_URL = 'https://login.salesforce.com';
+const LOGIN_URL = "https://login.salesforce.com";
 
 export async function authenticateWithJWT(): Promise<string> {
-    const payload = {
-        iss: CLIENT_ID,  // The client ID of the connected app
-        sub: USERNAME,   // The username of the Salesforce user
-        aud: `${LOGIN_URL}/services/oauth2/token`,
-        exp: Math.floor(Date.now() / 1000) + (60 * 5),  // Token expiration (5 minutes from now)
-    };
+  const payload = {
+    iss: CLIENT_ID, // The client ID of the connected app
+    sub: USERNAME, // The username of the Salesforce user
+    aud: `${LOGIN_URL}/services/oauth2/token`,
+    exp: Math.floor(Date.now() / 1000) + 60 * 5, // Token expiration (5 minutes from now)
+  };
 
-    try {
-        // Sign the JWT with the private key
-        const signedJWT = jwt.sign(payload, PRIVATE_KEY, { algorithm: 'RS256' });
+  try {
+    // Sign the JWT with the private key
+    const signedJWT = jwt.sign(payload, PRIVATE_KEY, { algorithm: "RS256" });
 
-        // Make a request to Salesforce to exchange the JWT for an access token
-        const response = await axios.post(`${LOGIN_URL}/services/oauth2/token`, null, {
-            params: {
-                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-                assertion: signedJWT,
-            }
-        });
+    // Make a request to Salesforce to exchange the JWT for an access token
+    const response = await axios.post(
+      `${LOGIN_URL}/services/oauth2/token`,
+      null,
+      {
+        params: {
+          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          assertion: signedJWT,
+        },
+      },
+    );
 
-        return response.data.access_token;
-    } catch (error) {
-        console.error('Error during JWT authentication:', error);
-        throw error;
-    }
+    return response.data.access_token;
+  } catch (error) {
+    console.error("Error during JWT authentication:", error);
+    throw error;
+  }
 }

--- a/tests/testCallCredalCopilot.ts
+++ b/tests/testCallCredalCopilot.ts
@@ -2,18 +2,18 @@ import { assert } from "node:console";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    const result = await runAction(
-        "callCopilot",
-        "credal",
-        { apiKey: "insert-during-test" }, // authParams
-        {
-            agentId: "insert-during-test",
-            query: "insert-during-test",
-            userEmail: "insert-during-test",
-        }
-    );
-    console.log(result);
-    assert(result.response != null);
+  const result = await runAction(
+    "callCopilot",
+    "credal",
+    { apiKey: "insert-during-test" }, // authParams
+    {
+      agentId: "insert-during-test",
+      query: "insert-during-test",
+      userEmail: "insert-during-test",
+    },
+  );
+  console.log(result);
+  assert(result.response != null);
 }
 
 runTest().catch(console.error);

--- a/tests/testCallNWSGetForecast.ts
+++ b/tests/testCallNWSGetForecast.ts
@@ -6,11 +6,10 @@ async function runTest() {
     "getForecastForLocation",
     "nws",
     { userAgent: "insert-test-user-agent" }, // format is "(example.com, name@example.com)"
-    { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" }
+    { latitude: 40.712776, longitude: -74.005974, isoDate: "2025-03-06" },
   );
   console.log(result);
   assert(result.result !== undefined, "Result should not be undefined");
 }
 
 runTest().catch(console.error);
-

--- a/tests/testCallOSMGetLatitudeLongitude.ts
+++ b/tests/testCallOSMGetLatitudeLongitude.ts
@@ -6,7 +6,7 @@ async function runTest() {
     "getLatitudeLongitudeFromLocation",
     "openstreetmap",
     { userAgent: "insert-test-user-agent" }, // format is "ExampleApp/1.0"
-    { location: "Lower East Side" }
+    { location: "Lower East Side" },
   );
   console.log(result);
   assert(result.length > 0, "Result should not be empty");

--- a/tests/testCreateNewGoogleDoc.ts
+++ b/tests/testCreateNewGoogleDoc.ts
@@ -19,7 +19,7 @@ async function runTest() {
       title: "Credal Test Doc",
       content:
         "This is a test document created automatically by the actions-sdk test suite.",
-    }
+    },
   );
 
   console.log("Result:", result);
@@ -27,7 +27,10 @@ async function runTest() {
   // Validate the result
   assert(result.documentId, "Result should contain a documentId");
   assert(result.documentUrl, "Result should contain a documentUrl");
-  assert(result.documentUrl.includes(result.documentId),"Document URL should contain the document ID");
+  assert(
+    result.documentUrl.includes(result.documentId),
+    "Document URL should contain the document ID",
+  );
 
   console.log("Linke to Google Doc: ", result.documentUrl);
 

--- a/tests/testCreateSharePostLinkedinUrl.ts
+++ b/tests/testCreateSharePostLinkedinUrl.ts
@@ -2,36 +2,40 @@ import assert from "node:assert";
 import { runAction } from "../src/app";
 
 async function runTest() {
-
-    const text = `This is a multi-line 👋
+  const text = `This is a multi-line 👋
 text for LinkedIn sharing
 
 This should work with whitespace 
 And should display in the post when you click the URL
     `;
-    const url = "https://app.credal.ai/";
-    
-    const result = await runAction(
-        "createShareLinkedinPostUrl",
-        "linkedin",
-        {}, 
-        {
-            text,
-            url
-        }
-    );
-        
-    assert(result, "Response should not be null");
-    assert(result.linkedinUrl, "Response should contain a shareable linkedin URL");
+  const url = "https://app.credal.ai/";
 
-    console.log(`Successfully created Linkedin Share Post URL: ${result.linkedinUrl}`);
+  const result = await runAction(
+    "createShareLinkedinPostUrl",
+    "linkedin",
+    {},
+    {
+      text,
+      url,
+    },
+  );
+
+  assert(result, "Response should not be null");
+  assert(
+    result.linkedinUrl,
+    "Response should contain a shareable linkedin URL",
+  );
+
+  console.log(
+    `Successfully created Linkedin Share Post URL: ${result.linkedinUrl}`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/testCreateXSharePostUrl.ts
+++ b/tests/testCreateXSharePostUrl.ts
@@ -2,56 +2,61 @@ import assert from "node:assert";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    const text = `
+  const text = `
     Check out this cool project 👋
     with multi-line text
 
     This should properly encode spaces and special characters!
     `;
-    const url = "https://app.credal.ai/";
-    const hashtag = ["#AI", "#DevTools", "Productivity"];
-    const via = "credalai";
-    const inReplyTo = "1899674121098957217";
-    
-    const result = await runAction(
-        "createShareXPostUrl",
-        "x",
-        {}, 
-        {
-            text,
-            url,
-            hashtag,
-            via,
-            inReplyTo
-        }
-    );
-        
-    assert(result, "Response should not be null");
-    assert(result.xUrl, "Response should contain a shareable X URL");
-    
-    console.log(`Successfully created X Share Post URL: ${result.xUrl}`);
+  const url = "https://app.credal.ai/";
+  const hashtag = ["#AI", "#DevTools", "Productivity"];
+  const via = "credalai";
+  const inReplyTo = "1899674121098957217";
 
-    // Test with minimal parameters (just text)
-    const minimalResult = await runAction(
-        "createShareXPostUrl",
-        "x",
-        {},
-        {
-            text: "Simple test tweet"
-        }
-    );
+  const result = await runAction(
+    "createShareXPostUrl",
+    "x",
+    {},
+    {
+      text,
+      url,
+      hashtag,
+      via,
+      inReplyTo,
+    },
+  );
 
-    assert(minimalResult, "Minimal response should not be null");
-    assert(minimalResult.xUrl, "Minimal response should contain a shareable X URL");
-    
-    console.log(`Successfully created minimal X Share Post URL: ${minimalResult.xUrl}`);
+  assert(result, "Response should not be null");
+  assert(result.xUrl, "Response should contain a shareable X URL");
+
+  console.log(`Successfully created X Share Post URL: ${result.xUrl}`);
+
+  // Test with minimal parameters (just text)
+  const minimalResult = await runAction(
+    "createShareXPostUrl",
+    "x",
+    {},
+    {
+      text: "Simple test tweet",
+    },
+  );
+
+  assert(minimalResult, "Minimal response should not be null");
+  assert(
+    minimalResult.xUrl,
+    "Minimal response should contain a shareable X URL",
+  );
+
+  console.log(
+    `Successfully created minimal X Share Post URL: ${minimalResult.xUrl}`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/testCreateZendeskTicket.ts
+++ b/tests/testCreateZendeskTicket.ts
@@ -1,35 +1,34 @@
 import assert from "node:assert";
 import { runAction } from "../src/app";
 
-
 async function runTest() {
+  const fullParams = {
+    subdomain: "insert-subdomain",
+    subject: "Credal Test Support Ticket",
+    body: "This is a test ticket created through the API.\nIt has multiple lines of text.\n\nPlease ignore.",
+  };
 
+  const result = await runAction(
+    "createZendeskTicket",
+    "zendesk",
+    {
+      apiKey: "insert-api-key",
+      username: "insert-email-associated-with-api-key",
+    },
+    fullParams,
+  );
 
-    const fullParams = {
-        subdomain: "insert-subdomain",
-        subject: "Credal Test Support Ticket",
-        body: "This is a test ticket created through the API.\nIt has multiple lines of text.\n\nPlease ignore.",
-    };
-    
-    const result = await runAction(
-        "createZendeskTicket",
-        "zendesk",
-        {
-            apiKey: "insert-api-key",
-            username: "insert-email-associated-with-api-key"
-        }, 
-        fullParams
-    );
-        
-    assert(result, "Response should not be null");
-    console.log(`Successfully created Zendesk ticket with ID: ${result.ticketId} and url ${result.ticketUrl}`);
+  assert(result, "Response should not be null");
+  console.log(
+    `Successfully created Zendesk ticket with ID: ${result.ticketId} and url ${result.ticketUrl}`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/testFinnhub.ts
+++ b/tests/testFinnhub.ts
@@ -2,14 +2,30 @@ import { runAction } from "../src/app";
 import { assert } from "node:console";
 
 async function runTest() {
-    const result = await runAction("symbolLookup", "finnhub", { apiKey: "insert-api-key" }, { query: "AAPL" });
-    console.log(result);
-    assert(result.result.length > 0, "Result should not be empty");
+  const result = await runAction(
+    "symbolLookup",
+    "finnhub",
+    { apiKey: "insert-api-key" },
+    { query: "AAPL" },
+  );
+  console.log(result);
+  assert(result.result.length > 0, "Result should not be empty");
 
-    const basicFinancialsResult = await runAction("getBasicFinancials", "finnhub", { apiKey: "insert-api-key" }, { symbol: "AAPL" });
-    console.log(basicFinancialsResult);
-    assert(basicFinancialsResult.result.annual.length > 0, "Annual financials should not be empty");
-    assert(basicFinancialsResult.result.quarterly.length > 0, "Quarterly financials should not be empty");
+  const basicFinancialsResult = await runAction(
+    "getBasicFinancials",
+    "finnhub",
+    { apiKey: "insert-api-key" },
+    { symbol: "AAPL" },
+  );
+  console.log(basicFinancialsResult);
+  assert(
+    basicFinancialsResult.result.annual.length > 0,
+    "Annual financials should not be empty",
+  );
+  assert(
+    basicFinancialsResult.result.quarterly.length > 0,
+    "Quarterly financials should not be empty",
+  );
 }
 
 runTest().catch(console.error);

--- a/tests/testFirecrawlScrape.ts
+++ b/tests/testFirecrawlScrape.ts
@@ -1,17 +1,17 @@
 import { runAction } from "../src/app";
-import { assert } from "node:console"
+import { assert } from "node:console";
 
 async function runTest() {
-    const result = await runAction(
-        "scrapeUrl",
-        "firecrawl",
-        { apiKey: "insert-during-testing" }, // authParams
-        {
-            url: "https://carbonenewyork.com",
-        }
-    );
-    console.log(result);
-    assert(result.content.length > 0, "No content found");
+  const result = await runAction(
+    "scrapeUrl",
+    "firecrawl",
+    { apiKey: "insert-during-testing" }, // authParams
+    {
+      url: "https://carbonenewyork.com",
+    },
+  );
+  console.log(result);
+  assert(result.content.length > 0, "No content found");
 }
 
 runTest().catch(console.error);

--- a/tests/testGoogleCreatePresentation.ts
+++ b/tests/testGoogleCreatePresentation.ts
@@ -29,7 +29,7 @@ async function runTest() {
           unit: "PT",
         },
       },
-    } as googleOauthCreatePresentationParamsType
+    } as googleOauthCreatePresentationParamsType,
   );
 
   console.log("Result:", result);
@@ -40,7 +40,7 @@ async function runTest() {
   assert(result.presentationUrl, "Result should contain a presentationUrl");
   assert(
     result.presentationUrl.includes(result.presentationId),
-    "Presentation URL should contain the presentation ID"
+    "Presentation URL should contain the presentation ID",
   );
 
   console.log("Link to Google Presentation:", result.presentationUrl);

--- a/tests/testGoogleCreateSpreadsheet.ts
+++ b/tests/testGoogleCreateSpreadsheet.ts
@@ -41,7 +41,7 @@ async function runTest() {
         timeZone: "America/New_York",
         autoRecalc: "ON_CHANGE",
       },
-    } as googleOauthCreateSpreadsheetParamsType
+    } as googleOauthCreateSpreadsheetParamsType,
   );
 
   console.log("Result:", result);
@@ -52,11 +52,11 @@ async function runTest() {
   assert(result.sheets.length === 2, "Should have created 2 sheets");
   assert(
     result.sheets[0].title === "Data",
-    "First sheet should be named 'Data'"
+    "First sheet should be named 'Data'",
   );
   assert(
     result.sheets[1].title === "Summary",
-    "Second sheet should be named 'Summary'"
+    "Second sheet should be named 'Summary'",
   );
 
   console.log("Link to Google Spreadsheet: ", result.spreadsheetUrl);

--- a/tests/testGoogleMapsAddressValidation.ts
+++ b/tests/testGoogleMapsAddressValidation.ts
@@ -2,18 +2,18 @@ import { assert } from "node:console";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    const result = await runAction(
-        "validateAddress",
-        "googlemaps",
-        { apiKey: "insert-during-testing" }, // authParams
-        {
-            postalCode: "11201",
-            regionCode: "USA",
-            addressLines: ["147 Prince St, Brooklyn, NY 11201-3022"],
-            addressType: "business",
-        }
-    );
-    assert(result.valid === true);
+  const result = await runAction(
+    "validateAddress",
+    "googlemaps",
+    { apiKey: "insert-during-testing" }, // authParams
+    {
+      postalCode: "11201",
+      regionCode: "USA",
+      addressLines: ["147 Prince St, Brooklyn, NY 11201-3022"],
+      addressType: "business",
+    },
+  );
+  assert(result.valid === true);
 }
 
 runTest().catch(console.error);

--- a/tests/testGoogleMapsNearbySearch.ts
+++ b/tests/testGoogleMapsNearbySearch.ts
@@ -1,18 +1,18 @@
 import { runAction } from "../src/app";
-import { assert } from "node:console"
+import { assert } from "node:console";
 
 async function runTest() {
-    const result = await runAction(
-        "nearbysearch",
-        "googlemaps",
-        { apiKey: "insert-during-testing" }, // authParams
-        {
-            latitude: 40.712776,
-            longitude: -74.005974,
-        }
-    );
-    console.log(result);
-    assert(result.results.length > 0, "No results found");
+  const result = await runAction(
+    "nearbysearch",
+    "googlemaps",
+    { apiKey: "insert-during-testing" }, // authParams
+    {
+      latitude: 40.712776,
+      longitude: -74.005974,
+    },
+  );
+  console.log(result);
+  assert(result.results.length > 0, "No results found");
 }
 
 runTest().catch(console.error);

--- a/tests/testGoogleScheduleMeeting.ts
+++ b/tests/testGoogleScheduleMeeting.ts
@@ -29,7 +29,7 @@ async function runTest() {
         "This is a test meeting created automatically by the actions-sdk test suite.",
       attendees: ["test@test.com", "test2@test.com"],
       useGoogleMeet: true,
-    } as googleOauthScheduleCalendarMeetingParamsType
+    } as googleOauthScheduleCalendarMeetingParamsType,
   );
 
   console.log("Result:", result);

--- a/tests/testGoogleUpdateDoc.ts
+++ b/tests/testGoogleUpdateDoc.ts
@@ -28,7 +28,7 @@ async function testInsertText() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Insert Result:", result);
@@ -36,7 +36,7 @@ async function testInsertText() {
   assert(result.documentUrl, "Result should contain a documentUrl");
   assert(
     result.documentUrl.includes(documentId),
-    "Document URL should contain the document ID"
+    "Document URL should contain the document ID",
   );
   return result;
 }
@@ -65,7 +65,7 @@ async function testReplaceText() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Replace Result:", result);
@@ -96,7 +96,7 @@ async function testDeleteContent() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Delete Result:", result);
@@ -143,7 +143,7 @@ async function testMultipleOperations() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Multiple Operations Result:", result);

--- a/tests/testGoogleUpdatePresentation.ts
+++ b/tests/testGoogleUpdatePresentation.ts
@@ -58,7 +58,7 @@ async function runTest() {
           },
         },
       ],
-    } as googleOauthUpdatePresentationParamsType
+    } as googleOauthUpdatePresentationParamsType,
   );
 
   console.log("Result:", result);
@@ -68,7 +68,7 @@ async function runTest() {
   assert(result.presentationUrl, "Result should contain a presentationUrl");
   assert(
     result.presentationUrl.includes(presentationId),
-    "Presentation URL should contain the presentation ID"
+    "Presentation URL should contain the presentation ID",
   );
 
   console.log("Link to updated Google Presentation:", result.presentationUrl);

--- a/tests/testGoogleUpdateSpreadsheet.ts
+++ b/tests/testGoogleUpdateSpreadsheet.ts
@@ -32,7 +32,7 @@ async function runTest() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Result:", result);
@@ -76,7 +76,7 @@ async function runUpdateSheetPropertiesTest(sheetId: string) {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Sheet properties update result:", result);
@@ -108,7 +108,7 @@ async function runUpdateSpreadsheetPropertiesTest() {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Spreadsheet properties update result:", result);
@@ -163,7 +163,7 @@ async function runUpdateCellsTest(sheetId: string) {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Cells update result:", result);
@@ -189,7 +189,7 @@ async function runDeleteSheetTest(sheetId: string) {
           },
         },
       ],
-    }
+    },
   );
 
   console.log("Sheet deletion result:", result);

--- a/tests/testLookerEnableUser.ts
+++ b/tests/testLookerEnableUser.ts
@@ -12,7 +12,9 @@ async function runTest() {
 
   if (!baseUrl || !clientId || !clientSecret || !userEmail) {
     console.error("Missing required environment variables for Looker test:");
-    console.error("Required: LOOKER_BASE_URL, LOOKER_CLIENT_ID, LOOKER_CLIENT_SECRET, LOOKER_TEST_USER_EMAIL");
+    console.error(
+      "Required: LOOKER_BASE_URL, LOOKER_CLIENT_ID, LOOKER_CLIENT_SECRET, LOOKER_TEST_USER_EMAIL",
+    );
     process.exit(1);
   }
 
@@ -23,17 +25,19 @@ async function runTest() {
     {
       baseUrl,
       clientId,
-      clientSecret
+      clientSecret,
     },
     {
-      userEmail
-    }
+      userEmail,
+    },
   );
 
   console.log("Result:", result);
-  
+
   if (result.success) {
-    console.log(`User ${result.userDetails?.email} status: ${result.userDetails?.isDisabled ? "disabled" : "enabled"}`);
+    console.log(
+      `User ${result.userDetails?.email} status: ${result.userDetails?.isDisabled ? "disabled" : "enabled"}`,
+    );
     assert(!result.userDetails?.isDisabled, "User should be enabled");
   }
 }

--- a/tests/testResendSendEmail.ts
+++ b/tests/testResendSendEmail.ts
@@ -1,23 +1,23 @@
 import { runAction } from "../src/app";
-import { assert } from "node:console"
+import { assert } from "node:console";
 
 async function runTest() {
-    const result = await runAction(
-        "sendEmail",
-        "resend",
-        { 
-            apiKey: "insert-during-testing", 
-            emailFrom: "Example User <example@example.com>",
-            emailReplyTo: "insert-during-testing", // "Example User <example@example.com>"
-        }, // authParams
-        {
-            to: "insert-during-testing",
-            subject: "Test Email",
-            content: "This is a test email",
-        },
-    );
-    console.log(result);
-    assert(result.success, "Email was not sent successfully");
+  const result = await runAction(
+    "sendEmail",
+    "resend",
+    {
+      apiKey: "insert-during-testing",
+      emailFrom: "Example User <example@example.com>",
+      emailReplyTo: "insert-during-testing", // "Example User <example@example.com>"
+    }, // authParams
+    {
+      to: "insert-during-testing",
+      subject: "Test Email",
+      content: "This is a test email",
+    },
+  );
+  console.log(result);
+  assert(result.success, "Email was not sent successfully");
 }
 
 runTest().catch(console.error);

--- a/tests/testRunMathAction.ts
+++ b/tests/testRunMathAction.ts
@@ -6,7 +6,7 @@ async function runTest() {
     "add",
     "math",
     {}, // authParams
-    { a: 1, b: 2 }
+    { a: 1, b: 2 },
   );
 
   assert(result.result === 3, "Result should be 3");

--- a/tests/testScrapeXTweetWithNitter.ts
+++ b/tests/testScrapeXTweetWithNitter.ts
@@ -2,55 +2,61 @@ import assert from "node:assert";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    // Note: This test requires a valid FIRECRAWL_API_KEY in your environment variables
-    if (!process.env.FIRECRAWL_API_KEY) {
-        console.warn("Warning: FIRECRAWL_API_KEY not found in environment variables. Test will likely fail.");
-    }
-
-    // Test with a real tweet URL from X.com (formerly Twitter)
-    const tweetUrl = "https://twitter.com/elonmusk/status/1899583456050598202";
-    
-    const result = await runAction(
-        "scrapeTweetDataWithNitter",
-        "firecrawl",
-        {
-            apiKey: process.env.FIRECRAWL_API_KEY
-        }, 
-        {
-            tweetUrl
-        }
+  // Note: This test requires a valid FIRECRAWL_API_KEY in your environment variables
+  if (!process.env.FIRECRAWL_API_KEY) {
+    console.warn(
+      "Warning: FIRECRAWL_API_KEY not found in environment variables. Test will likely fail.",
     );
-        
-    assert(result, "Response should not be null");
-    assert(result.text, "Response should contain tweet text");
-    
-    console.log(`Successfully scraped tweet content: ${result.text.substring(0, 100)}...`);
+  }
 
-    // Test with an X.com URL
-    const xUrl = "https://x.com/elonmusk/status/1899583456050598202";
-    
-    const xResult = await runAction(
-        "scrapeTweetDataWithNitter",
-        "firecrawl",
-        {
-            apiKey: process.env.FIRECRAWL_API_KEY
-        }, 
-        {
-            tweetUrl: xUrl
-        }
-    );
-        
-    assert(xResult, "X.com response should not be null");
-    assert(xResult.text, "X.com response should contain tweet text");
-    
-    console.log(`Successfully scraped X.com tweet content: ${xResult.text.substring(0, 100)}...`);
+  // Test with a real tweet URL from X.com (formerly Twitter)
+  const tweetUrl = "https://twitter.com/elonmusk/status/1899583456050598202";
+
+  const result = await runAction(
+    "scrapeTweetDataWithNitter",
+    "firecrawl",
+    {
+      apiKey: process.env.FIRECRAWL_API_KEY,
+    },
+    {
+      tweetUrl,
+    },
+  );
+
+  assert(result, "Response should not be null");
+  assert(result.text, "Response should contain tweet text");
+
+  console.log(
+    `Successfully scraped tweet content: ${result.text.substring(0, 100)}...`,
+  );
+
+  // Test with an X.com URL
+  const xUrl = "https://x.com/elonmusk/status/1899583456050598202";
+
+  const xResult = await runAction(
+    "scrapeTweetDataWithNitter",
+    "firecrawl",
+    {
+      apiKey: process.env.FIRECRAWL_API_KEY,
+    },
+    {
+      tweetUrl: xUrl,
+    },
+  );
+
+  assert(xResult, "X.com response should not be null");
+  assert(xResult.text, "X.com response should contain tweet text");
+
+  console.log(
+    `Successfully scraped X.com tweet content: ${xResult.text.substring(0, 100)}...`,
+  );
 }
 
-runTest().catch(error => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/testSlackGetChannelMessages.ts
+++ b/tests/testSlackGetChannelMessages.ts
@@ -2,37 +2,39 @@ import assert from "node:assert";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    const params = {
-        channelName: "insert-channel-name",
-        oldest: "insert-oldest-timestamp",
-    };
-    const authParams = {
-        authToken: "insert-oauth-access-token",
-    };
+  const params = {
+    channelName: "insert-channel-name",
+    oldest: "insert-oldest-timestamp",
+  };
+  const authParams = {
+    authToken: "insert-oauth-access-token",
+  };
 
-    try {
-        const result = await runAction(
-            "getChannelMessages",
-            "slack",
-            authParams,
-            params
-        );
+  try {
+    const result = await runAction(
+      "getChannelMessages",
+      "slack",
+      authParams,
+      params,
+    );
 
-        assert(result, "Response should not be null");
-        assert(result.messages, "Response should contain messages");
-        console.log("Test passed! with messages: " + JSON.stringify(result.messages, null, 2));
-    } catch (error) {
-        console.error("Test failed:", error);
-        process.exit(1);
-    }
+    assert(result, "Response should not be null");
+    assert(result.messages, "Response should contain messages");
+    console.log(
+      "Test passed! with messages: " + JSON.stringify(result.messages, null, 2),
+    );
+  } catch (error) {
+    console.error("Test failed:", error);
+    process.exit(1);
+  }
 }
 
 // Uncomment the test you want to run
 runTest().catch((error) => {
-    console.error("Test failed:", error);
-    if (error.response) {
-        console.error("API response:", error.response.data);
-        console.error("Status code:", error.response.status);
-    }
-    process.exit(1);
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
 });

--- a/tests/testSnowflakeGetRowByFieldValue.ts
+++ b/tests/testSnowflakeGetRowByFieldValue.ts
@@ -1,22 +1,21 @@
 import { runAction } from "../src/app";
 
 async function runTest() {
-
-    const result = await runAction(
-        "getRowByFieldValue",
-        "snowflake",
-        { authToken: "insert-oauth-access-token" },
-        {
-            databaseName: "insert-database-name",
-            accountName: "insert-account-name",
-            warehouse: "insert-warehouse-name",
-            user: "insert-user-name",
-            tableName: "insert-table-name",
-            fieldName: "insert-field-name",
-            fieldValue: "insert-field-value",
-        }
-    );
-    console.log(result);
+  const result = await runAction(
+    "getRowByFieldValue",
+    "snowflake",
+    { authToken: "insert-oauth-access-token" },
+    {
+      databaseName: "insert-database-name",
+      accountName: "insert-account-name",
+      warehouse: "insert-warehouse-name",
+      user: "insert-user-name",
+      tableName: "insert-table-name",
+      fieldName: "insert-field-name",
+      fieldValue: "insert-field-value",
+    },
+  );
+  console.log(result);
 }
 
 runTest().catch(console.error);

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -16,7 +16,7 @@ async function runTest() {
 
   const authParams = {
     authToken: "insert-oauth-access-token",
-  }; 
+  };
 
   try {
     // Run the action
@@ -24,14 +24,17 @@ async function runTest() {
       "runSnowflakeQuery",
       "snowflake",
       authParams,
-      params
+      params,
     );
 
     // Validate the response
     assert(result, "Response should not be null");
     assert(result.rowCount >= 0, "Response should contain a row count");
     assert(result.content, "Response should contain a result content");
-    assert((result.format == "csv" || result.format == "json"), "Response should contain a result format");
+    assert(
+      result.format == "csv" || result.format == "json",
+      "Response should contain a result format",
+    );
     console.log("Test passed! with content: " + result.content);
   } catch (error) {
     console.error("Test failed:", error);

--- a/tests/testZendeskAddCommentToTicket.ts
+++ b/tests/testZendeskAddCommentToTicket.ts
@@ -14,8 +14,8 @@ async function runTest() {
       comment: {
         body: "This is a test private comment",
         public: true,
-      }
-    }
+      },
+    },
   );
 }
 

--- a/tests/testZendeskAssignTicket.ts
+++ b/tests/testZendeskAssignTicket.ts
@@ -12,7 +12,7 @@ async function runTest() {
       ticketId: "62",
       subdomain: "credalai",
       assigneeEmail: "ravin@credal.ai",
-    }
+    },
   );
 }
 

--- a/tests/testZendeskCreateTicket.ts
+++ b/tests/testZendeskCreateTicket.ts
@@ -2,18 +2,18 @@ import { assert } from "node:console";
 import { runAction } from "../src/app";
 
 async function runTest() {
-    const result = await runAction(
-        "createTicket",
-        "zendesk",
-        { apiKey: "insert-during-testing" }, // authParams
-        {
-            subject: "Test ticket",
-            body: "This is a test ticket",
-            requesterEmail: "ravin@credal.ai",
-            subdomain: "credalaihelp",
-        }
-    );
-    assert(result.ticketId !== "Error");
+  const result = await runAction(
+    "createTicket",
+    "zendesk",
+    { apiKey: "insert-during-testing" }, // authParams
+    {
+      subject: "Test ticket",
+      body: "This is a test ticket",
+      requesterEmail: "ravin@credal.ai",
+      subdomain: "credalaihelp",
+    },
+  );
+  assert(result.ticketId !== "Error");
 }
 
 runTest().catch(console.error);

--- a/tests/testZendeskGetTicketDetails.ts
+++ b/tests/testZendeskGetTicketDetails.ts
@@ -12,7 +12,7 @@ async function runTest() {
     {
       ticketId: "62",
       subdomain: "credalai",
-    }
+    },
   );
   console.log(result);
   assert(result.id !== "");

--- a/tests/testZendeskUpdateTicket.ts
+++ b/tests/testZendeskUpdateTicket.ts
@@ -12,7 +12,7 @@ async function runTest() {
       ticketId: "62",
       subdomain: "credalai",
       status: "pending",
-    }
+    },
   );
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -25,8 +25,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -57,7 +57,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -77,12 +77,12 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -105,7 +105,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enforce `import type` for type-only imports across the codebase, affecting multiple providers and test files, with minor formatting adjustments.
> 
>   - **Type Imports**:
>     - Enforce `import type` for type-only imports in TypeScript files, e.g., `actionMapper.ts`, `groups.ts`, `parse.ts`, and many others.
>     - Affects various providers like Asana, Ashby, Confluence, GitHub, Jira, Microsoft, Salesforce, etc.
>   - **Formatting**:
>     - Minor formatting changes in `ci.yml`, `README.md`, and `schema.yaml` for consistency.
>     - Adjustments in test files for consistent parameter formatting and error handling.
>   - **Tests**:
>     - Update test files to align with new import style and improve error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 4bb0857f80395ebcfeb264fb67ba4828b937a30f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->