### PR TITLE
[Private Key] Snowflake Workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ const result = await runAction(
 ## Running a basic test for `runAction`
 
 ```
-npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/testRunMathAction.ts
+npm run test tests/testRunMathAction.ts
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "test": "npx ts-node -r tsconfig-paths/register --project tsconfig.json ",
     "build": "tsc",
     "dev": "ts-node-dev -r tsconfig-paths/register src/app.ts",
     "generate:types": "ts-node -r tsconfig-paths/register src/actions/parse.ts",

--- a/src/actions/providers/snowflake/auth/getSnowflakeConnection.ts
+++ b/src/actions/providers/snowflake/auth/getSnowflakeConnection.ts
@@ -1,0 +1,58 @@
+import type { AuthParamsType } from "../../../autogen/types";
+import crypto from "crypto";
+import type { Connection } from "snowflake-sdk";
+import snowflake from "snowflake-sdk";
+
+export function getSnowflakeConnection(
+  snowflakeData: {
+    account: string;
+    username: string;
+    warehouse: string;
+    database: string;
+  },
+  authParams: AuthParamsType,
+): Connection {
+  const { authToken, apiKey } = authParams;
+  const { account, username, warehouse, database } = snowflakeData;
+
+  if (authToken) {
+    // Always try to use Nango-Snowflake OAuth
+    return snowflake.createConnection({
+      account: account,
+      username: username,
+      authenticator: "OAUTH",
+      token: authToken,
+      role: "CREDAL_READ",
+      warehouse: warehouse,
+      database: database,
+    });
+  } else if (apiKey) {
+    // Use the apiKey for authentication (one off)
+    const getPrivateKeyCorrectFormat = (privateKey: string): string => {
+      const buffer: Buffer = Buffer.from(privateKey);
+      const privateKeyObject = crypto.createPrivateKey({
+        key: buffer,
+        format: "pem",
+        passphrase: "password",
+      });
+      const privateKeyCorrectFormat = privateKeyObject.export({
+        format: "pem",
+        type: "pkcs8",
+      });
+      return privateKeyCorrectFormat.toString();
+    };
+    const privateKeyCorrectFormatString = getPrivateKeyCorrectFormat(apiKey);
+
+    return snowflake.createConnection({
+      account: account,
+      username: username,
+      privateKey: privateKeyCorrectFormatString,
+      authenticator: "SNOWFLAKE_JWT",
+      role: "CREDAL_READ",
+      warehouse: warehouse,
+      database: database,
+    });
+  } else {
+    throw new Error("Snowflake authToken or apiKey is required");
+  }
+}

--- a/src/actions/providers/snowflake/getRowByFieldValue.ts
+++ b/src/actions/providers/snowflake/getRowByFieldValue.ts
@@ -1,10 +1,10 @@
-import snowflake from "snowflake-sdk";
 import type {
   AuthParamsType,
   snowflakeGetRowByFieldValueFunction,
   snowflakeGetRowByFieldValueOutputType,
   snowflakeGetRowByFieldValueParamsType,
 } from "../../autogen/types";
+import { getSnowflakeConnection } from "./auth/getSnowflakeConnection";
 
 const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
   params,
@@ -14,25 +14,24 @@ const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
   authParams: AuthParamsType;
 }): Promise<snowflakeGetRowByFieldValueOutputType> => {
   const { databaseName, tableName, fieldName, warehouse, fieldValue, user, accountName } = params;
-  const { authToken } = authParams;
-  if (!authToken) {
-    throw new Error("Access Token is required");
-  }
+
   if (!accountName || !user || !databaseName || !warehouse || !tableName || !fieldName || !fieldValue) {
     throw new Error("Account name and user are required");
   }
 
   // Set up a connection using snowflake-sdk
-  const connection = snowflake.createConnection({
-    account: accountName,
-    username: user,
-    authenticator: "OAUTH",
-    token: authToken,
-    role: "CREDAL_READ",
-    warehouse: warehouse,
-    database: databaseName,
-    schema: "PUBLIC",
-  });
+  const connection = getSnowflakeConnection(
+    {
+      account: accountName,
+      username: user,
+      warehouse: warehouse,
+      database: databaseName,
+    },
+    {
+      authToken: authParams.authToken,
+      apiKey: authParams.apiKey,
+    },
+  );
 
   try {
     await new Promise((resolve, reject) => {

--- a/tests/testSnowflakeGetRowByFieldValue.ts
+++ b/tests/testSnowflakeGetRowByFieldValue.ts
@@ -4,7 +4,9 @@ async function runTest() {
   const result = await runAction(
     "getRowByFieldValue",
     "snowflake",
-    { authToken: "insert-oauth-access-token" },
+    { authToken: "insert-oauth-access-token",
+      apiKey: "insert-private-key", // Optional if not using OAuth
+     },
     {
       databaseName: "insert-database-name",
       accountName: "insert-account-name",

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -16,6 +16,7 @@ async function runTest() {
 
   const authParams = {
     authToken: "insert-oauth-access-token",
+    apiKey: "insert-private-key", // Optional if not using OAuth
   };
 
   try {


### PR DESCRIPTION
- Some users have trouble logging in with OAuth (Nango Issue)
- Going to add in the backup option of private key for said users to unblock them


Tested ✅ 


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds private key authentication for Snowflake connections as a fallback to OAuth and updates related functions and tests.
> 
>   - **Authentication**:
>     - Adds `getSnowflakeConnection` in `getSnowflakeConnection.ts` to support OAuth and private key authentication for Snowflake.
>     - Uses `crypto` to format private keys for Snowflake JWT authentication.
>   - **Integration**:
>     - Replaces direct `snowflake.createConnection` calls with `getSnowflakeConnection` in `getRowByFieldValue.ts` and `runSnowflakeQuery.ts`.
>   - **Testing**:
>     - Updates `testSnowflakeGetRowByFieldValue.ts` and `testSnowflakeQuery.ts` to include `apiKey` in `authParams`.
>   - **Misc**:
>     - Adds `test` script in `package.json` and updates `README.md` to use `npm run test` for running tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 89124beddcf39ad42635e19795e8022652961579. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->