### PR TITLE
[Snowflake] Fix Private Key for Snowflake 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",
@@ -21,6 +21,7 @@
         "json-schema-to-zod": "^2.5.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.13.1",
+        "node-forge": "^1.3.1",
         "octokit": "^4.1.2",
         "resend": "^4.1.2",
         "snowflake-sdk": "^2.0.2",
@@ -33,6 +34,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.10.1",
+        "@types/node-forge": "^1.3.11",
         "@typescript-eslint/eslint-plugin": "^8.18.0",
         "@typescript-eslint/parser": "^8.18.0",
         "eslint": "^9.16.0",
@@ -2895,6 +2897,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/request": {
@@ -5968,6 +5980,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/nopt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,6 +27,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.10.1",
+    "@types/node-forge": "^1.3.11",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "eslint": "^9.16.0",
@@ -52,6 +53,7 @@
     "json-schema-to-zod": "^2.5.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.13.1",
+    "node-forge": "^1.3.1",
     "octokit": "^4.1.2",
     "resend": "^4.1.2",
     "snowflake-sdk": "^2.0.2",


### PR DESCRIPTION
 - Add handling for single line private key 
 - TLDR: Just added so the connection is more robust and we don't get formatting issues for private keys.
 - Tested with private keys generated via nango.
 <!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes private key handling for Snowflake connections by adding `node-forge` for correct formatting in `getSnowflakeConnection.ts`.
> 
>   - **Behavior**:
>     - Adds `getPrivateKeyCorrectFormat` function in `getSnowflakeConnection.ts` to handle single-line private keys using `node-forge`.
>     - Throws error for invalid private key format.
>   - **Dependencies**:
>     - Adds `node-forge` to `dependencies` in `package.json`.
>     - Adds `@types/node-forge` to `devDependencies` in `package.json`.
>   - **Versioning**:
>     - Bumps version in `package.json` from `0.1.44` to `0.1.45`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 2ea4b8e8e1e746adce9c8d0b72eeb0cb09e0b0cb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->