### PR TITLE
[Snowflake] Fix snowflake issue w/ new model formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -23,7 +23,7 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
     throw new Error("Missing required parameters for Snowflake query");
   }
   const executeQueryAndFormatData = async (): Promise<{ formattedData: string; resultsLength: number }> => {
-    const formattedQuery = query.trim().replace(/\n/g, " ").replace(/\s+/g, " "); // Replace newlines and multiple spaces with a single space
+    const formattedQuery = query.trim().replace(/\s+/g, " "); // Normalize all whitespace to single spaces
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const queryResults: any[] = await new Promise<any[]>((resolve, reject) => {

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -23,10 +23,12 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
     throw new Error("Missing required parameters for Snowflake query");
   }
   const executeQueryAndFormatData = async (): Promise<{ formattedData: string; resultsLength: number }> => {
+    const formattedQuery = query.trim().replace(/\n/g, " ").replace(/\s+/g, " "); // Replace newlines and multiple spaces with a single space
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const queryResults: any[] = await new Promise<any[]>((resolve, reject) => {
       connection.execute({
-        sqlText: query,
+        sqlText: formattedQuery,
         complete: (err, stmt, rows) => {
           if (err) {
             return reject(err);


### PR DESCRIPTION

- Trying out the snowflake action with the new 4.1 open-ai model
- it consistently adds newlines into the query param value
- seems like the simple fix
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query formatting in `runSnowflakeQuery.ts` to handle newlines and spaces, and updates version to `0.1.47`.
> 
>   - **Behavior**:
>     - Fixes query formatting in `runSnowflakeQuery.ts` by replacing newlines and multiple spaces with a single space in the `formattedQuery` variable.
>   - **Versioning**:
>     - Updates version in `package.json` from `0.1.46` to `0.1.47`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 69b72bac71032f9306c939149bacaa77f9d06987. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->