### PR TITLE
[Snowflake Action] Move username to auth param:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1345,10 +1345,6 @@ export const snowflakeGetRowByFieldValueDefinition: ActionTemplate = {
         type: "string",
         description: "The name of the Snowflake account",
       },
-      user: {
-        type: "string",
-        description: "The user to authenticate with",
-      },
       warehouse: {
         type: "string",
         description: "The warehouse to use",
@@ -1383,7 +1379,7 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
   scopes: [],
   parameters: {
     type: "object",
-    required: ["databaseName", "warehouse", "query", "user", "accountName"],
+    required: ["databaseName", "warehouse", "query", "accountName"],
     properties: {
       databaseName: {
         type: "string",
@@ -1396,10 +1392,6 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
       query: {
         type: "string",
         description: "The SQL query to execute",
-      },
-      user: {
-        type: "string",
-        description: "The username to authenticate with",
       },
       accountName: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -735,7 +735,6 @@ export const snowflakeGetRowByFieldValueParamsSchema = z.object({
   fieldName: z.string().describe("The name of the field to query"),
   fieldValue: z.string().describe("The value of the field to query"),
   accountName: z.string().describe("The name of the Snowflake account").optional(),
-  user: z.string().describe("The user to authenticate with").optional(),
   warehouse: z.string().describe("The warehouse to use").optional(),
 });
 
@@ -761,7 +760,6 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
   databaseName: z.string().describe("The name of the database to query"),
   warehouse: z.string().describe("The warehouse to use for executing the query"),
   query: z.string().describe("The SQL query to execute"),
-  user: z.string().describe("The username to authenticate with"),
   accountName: z.string().describe("The name of the Snowflake account"),
   outputFormat: z.enum(["json", "csv"]).describe("The format of the output").optional(),
 });

--- a/src/actions/providers/snowflake/getRowByFieldValue.ts
+++ b/src/actions/providers/snowflake/getRowByFieldValue.ts
@@ -13,9 +13,9 @@ const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
   params: snowflakeGetRowByFieldValueParamsType;
   authParams: AuthParamsType;
 }): Promise<snowflakeGetRowByFieldValueOutputType> => {
-  const { databaseName, tableName, fieldName, warehouse, fieldValue, user, accountName } = params;
+  const { databaseName, tableName, fieldName, warehouse, fieldValue, accountName } = params;
 
-  if (!accountName || !user || !databaseName || !warehouse || !tableName || !fieldName || !fieldValue) {
+  if (!accountName || !databaseName || !warehouse || !tableName || !fieldName || !fieldValue) {
     throw new Error("Account name and user are required");
   }
 
@@ -23,7 +23,7 @@ const getRowByFieldValue: snowflakeGetRowByFieldValueFunction = async ({
   const connection = getSnowflakeConnection(
     {
       account: accountName,
-      username: user,
+      username: authParams.username || "CREDAL_USER",
       warehouse: warehouse,
       database: databaseName,
     },

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -17,9 +17,9 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
   params: snowflakeRunSnowflakeQueryParamsType;
   authParams: AuthParamsType;
 }): Promise<snowflakeRunSnowflakeQueryOutputType> => {
-  const { databaseName, warehouse, query, user, accountName, outputFormat = "json" } = params;
+  const { databaseName, warehouse, query, accountName, outputFormat = "json" } = params;
 
-  if (!accountName || !user || !databaseName || !warehouse || !query) {
+  if (!accountName || !databaseName || !warehouse || !query) {
     throw new Error("Missing required parameters for Snowflake query");
   }
   const executeQueryAndFormatData = async (): Promise<{ formattedData: string; resultsLength: number }> => {
@@ -47,7 +47,7 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
   const connection = getSnowflakeConnection(
     {
       account: accountName,
-      username: user,
+      username: authParams.username || "CREDAL_USER",
       warehouse: warehouse,
       database: databaseName,
     },

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -968,9 +968,6 @@ actions:
           accountName:
             type: string
             description: The name of the Snowflake account
-          user:
-            type: string
-            description: The user to authenticate with
           warehouse:
             type: string
             description: The warehouse to use
@@ -993,7 +990,7 @@ actions:
       scopes: []
       parameters:
         type: object
-        required: [databaseName, warehouse, query, user, accountName]
+        required: [databaseName, warehouse, query, accountName]
         properties:
           databaseName:
             type: string
@@ -1004,9 +1001,6 @@ actions:
           query:
             type: string
             description: The SQL query to execute
-          user:
-            type: string
-            description: The username to authenticate with
           accountName:
             type: string
             description: The name of the Snowflake account

--- a/tests/testSnowflakeGetRowByFieldValue.ts
+++ b/tests/testSnowflakeGetRowByFieldValue.ts
@@ -4,14 +4,14 @@ async function runTest() {
   const result = await runAction(
     "getRowByFieldValue",
     "snowflake",
-    { authToken: "insert-oauth-access-token",
-      apiKey: "insert-private-key", // Optional if not using OAuth
+    { 
+      apiKey: "insert-private-key", // private key for key-pair auth
+      username: "insert-username", // username for key-pair auth
      },
     {
       databaseName: "insert-database-name",
       accountName: "insert-account-name",
       warehouse: "insert-warehouse-name",
-      user: "insert-user-name",
       tableName: "insert-table-name",
       fieldName: "insert-field-name",
       fieldValue: "insert-field-value",

--- a/tests/testSnowflakeQuery.ts
+++ b/tests/testSnowflakeQuery.ts
@@ -7,7 +7,6 @@ async function runTest() {
     // Database connection params
     databaseName: "insert-database-name",
     warehouse: "insert-warehouse-name",
-    user: "insert-user-name",
     accountName: "insert-account-name",
     // Query param
     query: "insert-query",
@@ -15,8 +14,8 @@ async function runTest() {
   };
 
   const authParams = {
-    authToken: "insert-oauth-access-token",
-    apiKey: "insert-private-key", // Optional if not using OAuth
+    apiKey: "insert-private-key", // Private Key for Key-pair authentication
+    username: "insert-username", // Username for Key-pair authentication
   };
 
   try {


### PR DESCRIPTION
#### TLDR:
- Now with the nango connection we don't need to pass the username as a field 
- The username is strongly tied to the private-key for the key-pair auth so it'd always be hardcoded
- Now nango returns it so we don't need to hardcode.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed hardcoded username from Snowflake actions, relying on Nango for authentication, and updated related files and tests.
> 
>   - **Behavior**:
>     - Removed `user` parameter from `snowflakeGetRowByFieldValueDefinition` and `snowflakeRunSnowflakeQueryDefinition` in `templates.ts`.
>     - Updated `getRowByFieldValue.ts` and `runSnowflakeQuery.ts` to use `authParams.username` or default to `CREDAL_USER`.
>     - Updated `schema.yaml` to remove `user` from required parameters for Snowflake actions.
>   - **Tests**:
>     - Updated `testSnowflakeGetRowByFieldValue.ts` and `testSnowflakeQuery.ts` to remove `username` from parameters and use `authParams` instead.
>   - **Misc**:
>     - Bumped version in `package.json` from `0.1.47` to `0.1.48`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e6f799fe12c92cde477bb8c2b241b16cdac2c0a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->