### PR TITLE
Return better error for Salesforce API

### DIFF
--- a/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
+++ b/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
@@ -4,7 +4,7 @@ import type {
   salesforceGetSalesforceRecordsByQueryOutputType,
   salesforceGetSalesforceRecordsByQueryParamsType,
 } from "../../autogen/types";
-import { axiosClient } from "../../util/axiosClient";
+import { ApiError, axiosClient } from "../../util/axiosClient";
 
 const getSalesforceRecordsByQuery: salesforceGetSalesforceRecordsByQueryFunction = async ({
   params,
@@ -41,7 +41,7 @@ const getSalesforceRecordsByQuery: salesforceGetSalesforceRecordsByQueryFunction
     console.error("Error retrieving Salesforce record:", error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : "An unknown error occurred",
+      error: error instanceof ApiError ? error.data.length > 0 ? error.data[0].message : error.message : "An unknown error occurred",
     };
   }
 };

--- a/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
+++ b/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
@@ -41,7 +41,12 @@ const getSalesforceRecordsByQuery: salesforceGetSalesforceRecordsByQueryFunction
     console.error("Error retrieving Salesforce record:", error);
     return {
       success: false,
-      error: error instanceof ApiError ? error.data.length > 0 ? error.data[0].message : error.message : "An unknown error occurred",
+      error:
+        error instanceof ApiError
+          ? error.data.length > 0
+            ? error.data[0].message
+            : error.message
+          : "An unknown error occurred",
     };
   }
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves error handling in `getSalesforceRecordsByQuery.ts` by returning specific Salesforce API error messages when available.
> 
>   - **Error Handling**:
>     - In `getSalesforceRecordsByQuery.ts`, improved error handling for Salesforce API errors.
>     - Checks if `error` is an instance of `ApiError` and if `error.data` contains messages, returns the first message.
>     - Defaults to `error.message` if no specific message is available, otherwise returns "An unknown error occurred".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for a4e4231f41f424998ca42795a2574a88bd67dd39. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->