### PR TITLE
don't filter to past year for list prs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.53",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/github/listPullRequests.ts
+++ b/src/actions/providers/github/listPullRequests.ts
@@ -15,12 +15,9 @@ const listPullRequests: githubListPullRequestsFunction = async ({
   authParams: AuthParamsType;
 }): Promise<githubListPullRequestsOutputType> => {
   const { authToken } = authParams;
-  const { repositoryName, repositoryOwner } = params;
+  const { repositoryName, repositoryOwner, state } = params;
 
   const url = `https://api.github.com/repos/${repositoryOwner}/${repositoryName}/pulls`;
-  const oneYearAgo = new Date();
-  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-
   type PullRequest = githubListPullRequestsOutputType["pullRequests"][number];
 
   const allPulls: PullRequest[] = [];
@@ -35,7 +32,7 @@ const listPullRequests: githubListPullRequestsFunction = async ({
         "X-GitHub-Api-Version": "2022-11-28",
       },
       params: {
-        state: "all",
+        state: state ?? "all",
         sort: "created",
         direction: "desc",
         per_page: perPage,
@@ -45,14 +42,10 @@ const listPullRequests: githubListPullRequestsFunction = async ({
 
     const pulls = response.data;
     if (pulls.length === 0) break;
-
-    // Filter by date
-    const recentPulls = pulls.filter(pr => pr.createdAt && new Date(pr.createdAt) >= oneYearAgo);
-
-    allPulls.push(...recentPulls);
+    allPulls.push(...pulls);
 
     // Stop if the rest are older than one year
-    if (recentPulls.length < pulls.length) break;
+    if (pulls.length < pulls.length) break;
 
     page++;
   }

--- a/src/actions/providers/github/listPullRequests.ts
+++ b/src/actions/providers/github/listPullRequests.ts
@@ -45,7 +45,7 @@ const listPullRequests: githubListPullRequestsFunction = async ({
     allPulls.push(...pulls);
 
     // Stop if the rest are older than one year
-    if (pulls.length < pulls.length) break;
+    if (pulls.length < perPage) break;
 
     page++;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes one-year filter from `listPullRequests` to allow retrieval of all pull requests, and increments version to `0.1.55`.
> 
>   - **Behavior**:
>     - Removes one-year filter from `listPullRequests` in `listPullRequests.ts`, allowing retrieval of all pull requests regardless of creation date.
>     - Adds optional `state` parameter to filter pull requests by state (e.g., open, closed).
>   - **Misc**:
>     - Increment version in `package.json` from `0.1.54` to `0.1.55`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for f2ee1047f54dbfcf9724432708dec860e83f3a27. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->