### PR TITLE
Salesforce create record action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.53",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -137,6 +137,8 @@ import {
   githubListPullRequestsOutputSchema,
   jiraGetJiraIssuesByQueryOutputSchema,
   jiraGetJiraIssuesByQueryParamsSchema,
+  salesforceCreateRecordParamsSchema,
+  salesforceCreateRecordOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -209,6 +211,7 @@ import fetchSalesforceSchemaByObject from "./providers/salesforce/fetchSalesforc
 import deepResearch from "./providers/firecrawl/deepResearch";
 import listPullRequests from "./providers/github/listPullRequests";
 import getJiraIssuesByQuery from "./providers/jira/getJiraIssuesByQuery";
+import createRecord from "./providers/salesforce/createRecord";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -540,6 +543,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: updateRecord,
       paramsSchema: salesforceUpdateRecordParamsSchema,
       outputSchema: salesforceUpdateRecordOutputSchema,
+    },
+    createRecord: {
+      fn: createRecord,
+      paramsSchema: salesforceCreateRecordParamsSchema,
+      outputSchema: salesforceCreateRecordOutputSchema,
     },
     createCase: {
       fn: createCase,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -5344,6 +5344,47 @@ export const salesforceUpdateRecordDefinition: ActionTemplate = {
   name: "updateRecord",
   provider: "salesforce",
 };
+export const salesforceCreateRecordDefinition: ActionTemplate = {
+  description: "Create a record in Salesforce",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["objectType", "fieldsToCreate"],
+    properties: {
+      objectType: {
+        type: "string",
+        description: "The Salesforce object type to create (e.g., Lead, Account, Contact)",
+      },
+      fieldsToCreate: {
+        type: "object",
+        description: "The fields to create on the record",
+        additionalProperties: {
+          type: "string",
+        },
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the record was successfully created",
+      },
+      recordId: {
+        type: "string",
+        description: "The ID of the created object",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the record was not successfully created",
+      },
+    },
+  },
+  name: "createRecord",
+  provider: "salesforce",
+};
 export const salesforceCreateCaseDefinition: ActionTemplate = {
   description: "Create a case or support ticket in Salesforce",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2842,6 +2842,26 @@ export type salesforceUpdateRecordFunction = ActionFunction<
   salesforceUpdateRecordOutputType
 >;
 
+export const salesforceCreateRecordParamsSchema = z.object({
+  objectType: z.string().describe("The Salesforce object type to create (e.g., Lead, Account, Contact)"),
+  fieldsToCreate: z.record(z.string()).describe("The fields to create on the record"),
+});
+
+export type salesforceCreateRecordParamsType = z.infer<typeof salesforceCreateRecordParamsSchema>;
+
+export const salesforceCreateRecordOutputSchema = z.object({
+  success: z.boolean().describe("Whether the record was successfully created"),
+  recordId: z.string().describe("The ID of the created object").optional(),
+  error: z.string().describe("The error that occurred if the record was not successfully created").optional(),
+});
+
+export type salesforceCreateRecordOutputType = z.infer<typeof salesforceCreateRecordOutputSchema>;
+export type salesforceCreateRecordFunction = ActionFunction<
+  salesforceCreateRecordParamsType,
+  AuthParamsType,
+  salesforceCreateRecordOutputType
+>;
+
 export const salesforceCreateCaseParamsSchema = z.object({
   subject: z.string().describe("The subject of the case"),
   description: z.string().describe("The detailed description of the case"),

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -57,6 +57,7 @@ import {
   firecrawlDeepResearchDefinition,
   jiraGetJiraIssuesByQueryDefinition,
   githubListPullRequestsDefinition,
+  salesforceCreateRecordDefinition,
 } from "../actions/autogen/templates";
 import type { ActionTemplate } from "../actions/parse";
 
@@ -171,6 +172,7 @@ export const ACTION_GROUPS: ActionGroups = {
     description: "Actions for interacting with Salesforce",
     actions: [
       salesforceUpdateRecordDefinition,
+      salesforceCreateRecordDefinition,
       salesforceCreateCaseDefinition,
       salesforceGenerateSalesReportDefinition,
       salesforceGetRecordDefinition,

--- a/src/actions/providers/salesforce/createRecord.ts
+++ b/src/actions/providers/salesforce/createRecord.ts
@@ -1,0 +1,49 @@
+import type {
+  AuthParamsType,
+  salesforceCreateRecordFunction,
+  salesforceCreateRecordOutputType,
+  salesforceCreateRecordParamsType,
+} from "../../autogen/types";
+import { axiosClient } from "../../util/axiosClient";
+
+const createRecord: salesforceCreateRecordFunction = async ({
+  params,
+  authParams,
+}: {
+  params: salesforceCreateRecordParamsType;
+  authParams: AuthParamsType;
+}): Promise<salesforceCreateRecordOutputType> => {
+  const { authToken, baseUrl } = authParams;
+  const { objectType, fieldsToCreate } = params;
+
+  if (!authToken || !baseUrl) {
+    return {
+      success: false,
+      error: "authToken and baseUrl are required for Salesforce API",
+    };
+  }
+
+  const url = `${baseUrl}/services/data/v56.0/sobjects/${objectType}/`;
+
+  try {
+    const response = await axiosClient.post(url, fieldsToCreate, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    return {
+      success: true,
+      recordId: response.data.id,
+    };
+  } catch (error) {
+    console.error("Error creating Salesforce object:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unknown error occurred",
+    };
+  }
+};
+
+export default createRecord;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -3735,6 +3735,34 @@ actions:
           error:
             type: string
             description: The error that occurred if the record was not successfully updated
+    createRecord:
+      description: Create a record in Salesforce
+      scopes: []
+      parameters:
+        type: object
+        required: [objectType, fieldsToCreate]
+        properties:
+          objectType:
+            type: string
+            description: The Salesforce object type to create (e.g., Lead, Account, Contact)
+          fieldsToCreate:
+            type: object
+            description: The fields to create on the record
+            additionalProperties:
+              type: string
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the record was successfully created
+          recordId:
+            type: string
+            description: The ID of the created object
+          error:
+            type: string
+            description: The error that occurred if the record was not successfully created
     createCase:
       description: Create a case or support ticket in Salesforce
       scopes: []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new Salesforce `createRecord` action to handle record creation via API, including schema and template updates.
> 
>   - **Behavior**:
>     - Adds `createRecord` action to Salesforce in `actionMapper.ts`.
>     - Handles missing `authToken` or `baseUrl` by returning an error.
>     - Logs errors to console if record creation fails.
>   - **Schemas**:
>     - Adds `salesforceCreateRecordParamsSchema` and `salesforceCreateRecordOutputSchema` in `types.ts`.
>     - Updates `schema.yaml` to include `createRecord` action under Salesforce.
>   - **Providers**:
>     - Implements `createRecord` function in `createRecord.ts` to post new records to Salesforce API.
>   - **Templates**:
>     - Adds `salesforceCreateRecordDefinition` to `templates.ts`.
>   - **Groups**:
>     - Adds `salesforceCreateRecordDefinition` to Salesforce action group in `groups.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 8ab18a3f4d948af94b5417778051dc20658af86a. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->