### PR TITLE
[Snowflake] Add limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1461,6 +1461,10 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
         description: "The format of the output",
         enum: ["json", "csv"],
       },
+      limit: {
+        type: "number",
+        description: "A limit on the number of rows to return",
+      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -785,6 +785,7 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
   query: z.string().describe("The SQL query to execute"),
   accountName: z.string().describe("The name of the Snowflake account"),
   outputFormat: z.enum(["json", "csv"]).describe("The format of the output").optional(),
+  limit: z.number().describe("A limit on the number of rows to return").optional(),
 });
 
 export type snowflakeRunSnowflakeQueryParamsType = z.infer<typeof snowflakeRunSnowflakeQueryParamsSchema>;

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -17,7 +17,7 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
   params: snowflakeRunSnowflakeQueryParamsType;
   authParams: AuthParamsType;
 }): Promise<snowflakeRunSnowflakeQueryOutputType> => {
-  const { databaseName, warehouse, query, accountName, outputFormat = "json" } = params;
+  const { databaseName, warehouse, query, accountName, outputFormat = "json", limit } = params;
 
   if (!accountName || !databaseName || !warehouse || !query) {
     throw new Error("Missing required parameters for Snowflake query");
@@ -39,6 +39,9 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
     });
 
     // Format the results based on the output format
+    if (limit && queryResults.length - 1 > limit) {
+      queryResults.splice(limit + 1); // Include header
+    }
     const { formattedData, resultsLength } = formatDataForCodeInterpreter(queryResults, outputFormat);
     return { formattedData, resultsLength };
   };

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1049,6 +1049,9 @@ actions:
             type: string
             description: The format of the output
             enum: [json, csv]
+          limit: 
+            type: number
+            description: A limit on the number of rows to return
       output:
         type: object
         required: [format, content, rowCount]


### PR DESCRIPTION
- Want to add a limit option
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a `limit` parameter to Snowflake query execution to restrict the number of rows returned.
> 
>   - **Behavior**:
>     - Adds `limit` parameter to `runSnowflakeQuery` in `runSnowflakeQuery.ts` to limit the number of rows returned.
>     - If `limit` is set, truncates `queryResults` to `limit + 1` to include header.
>   - **Schema and Types**:
>     - Updates `snowflakeRunSnowflakeQueryParamsSchema` in `types.ts` to include optional `limit` parameter.
>     - Updates `schema.yaml` to include `limit` parameter in `runSnowflakeQuery` action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for bfc477bbf8a73bb8c15c3c762db0e0c45408df72. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->