### PR TITLE
Switch confluence actions over to using oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Easily add custom actions for your Credal Copilots. Read more about Credal's Age
 
 ## Adding or updating actions
 
+We strongly encourage you to develop actions that rely on oauth based credentials. This is to ensure we respect the permissions of the underlying systems the actions library interacts with. In some situations, oauth is not a valid option and so API keys are a good fallback.
+
 1. Add or update the action in `src/actions/schema.yaml`
 2. Run `npm run generate:types` to generate the new types
 3. Run `npm run prettier-format` to format the new files
@@ -25,7 +27,7 @@ const result = await runAction(
   "listConversations",
   "slack",
   { authToken: "xoxb-..." },
-  {},
+  {}
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/confluence/fetchPageContent.ts
+++ b/src/actions/providers/confluence/fetchPageContent.ts
@@ -7,12 +7,12 @@ import type {
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
-function getConfluenceRequestConfig(baseUrl: string, username: string, apiToken: string): AxiosRequestConfig {
+function getConfluenceRequestConfig(baseUrl: string, authToken: string): AxiosRequestConfig {
   return {
     baseURL: baseUrl,
     headers: {
       Accept: "application/json",
-      Authorization: `Basic ${Buffer.from(`${username}:${apiToken}`).toString("base64")}`,
+      Authorization: `Bearer ${authToken}`,
     },
   };
 }
@@ -25,16 +25,20 @@ const confluenceFetchPageContent: confluenceFetchPageContentFunction = async ({
   authParams: AuthParamsType;
 }): Promise<confluenceFetchPageContentOutputType> => {
   const { pageId } = params;
-  const { baseUrl, authToken, username } = authParams;
+  const { authToken } = authParams;
 
-  if (!baseUrl || !authToken || !username) {
+  if (!authToken) {
     throw new Error("Missing required authentication parameters");
   }
 
-  const config = getConfluenceRequestConfig(baseUrl, username, authToken);
+  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources");
+  const cloudId = cloudDetails.data[0].id;
+  const baseUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/api/v2`;
+
+  const config = getConfluenceRequestConfig(baseUrl, authToken);
 
   // Get page content and metadata
-  const response = await axiosClient.get(`/api/v2/pages/${pageId}?body-format=storage`, config);
+  const response = await axiosClient.get(`/pages/${pageId}?body-format=storage`, config);
 
   // Extract needed data from response
   const title = response.data.title;

--- a/src/actions/providers/confluence/fetchPageContent.ts
+++ b/src/actions/providers/confluence/fetchPageContent.ts
@@ -1,21 +1,11 @@
-import type { AxiosRequestConfig } from "axios";
 import type {
   confluenceFetchPageContentFunction,
   confluenceFetchPageContentParamsType,
   confluenceFetchPageContentOutputType,
   AuthParamsType,
 } from "../../autogen/types";
+import { getConfluenceRequestConfig } from "./helpers";
 import { axiosClient } from "../../util/axiosClient";
-
-function getConfluenceRequestConfig(baseUrl: string, authToken: string): AxiosRequestConfig {
-  return {
-    baseURL: baseUrl,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${authToken}`,
-    },
-  };
-}
 
 const confluenceFetchPageContent: confluenceFetchPageContentFunction = async ({
   params,

--- a/src/actions/providers/confluence/helpers.ts
+++ b/src/actions/providers/confluence/helpers.ts
@@ -1,0 +1,11 @@
+import type { AxiosRequestConfig } from "axios";
+
+export function getConfluenceRequestConfig(baseUrl: string, authToken: string): AxiosRequestConfig {
+  return {
+    baseURL: baseUrl,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+  };
+}

--- a/src/actions/providers/confluence/overwritePage.ts
+++ b/src/actions/providers/confluence/overwritePage.ts
@@ -7,12 +7,12 @@ import type {
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
-function getConfluenceRequestConfig(baseUrl: string, username: string, apiToken: string): AxiosRequestConfig {
+function getConfluenceRequestConfig(baseUrl: string, authToken: string): AxiosRequestConfig {
   return {
     baseURL: baseUrl,
     headers: {
       Accept: "application/json",
-      Authorization: `Basic ${Buffer.from(`${username}:${apiToken}`).toString("base64")}`,
+      Authorization: `Bearer ${authToken}`,
     },
   };
 }
@@ -25,15 +25,20 @@ const confluenceOverwritePage: confluenceOverwritePageFunction = async ({
   authParams: AuthParamsType;
 }): Promise<confluenceOverwritePageOutputType> => {
   const { pageId, content, title } = params;
-  const { baseUrl, authToken, username } = authParams;
+  const { authToken } = authParams;
 
-  if (!baseUrl || !authToken || !username) {
+  if (!authToken) {
     throw new Error("Missing required authentication parameters");
   }
-  const config = getConfluenceRequestConfig(baseUrl, username, authToken);
+
+  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources");
+  const cloudId = cloudDetails.data[0].id;
+  const baseUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/api/v2`;
+
+  const config = getConfluenceRequestConfig(baseUrl, authToken);
 
   // Get current page content and version number
-  const response = await axiosClient.get(`/api/v2/pages/${pageId}?body-format=storage`, config);
+  const response = await axiosClient.get(`/pages/${pageId}?body-format=storage`, config);
   const currVersion = response.data.version.number;
 
   const payload = {
@@ -49,7 +54,7 @@ const confluenceOverwritePage: confluenceOverwritePageFunction = async ({
     },
   };
 
-  await axiosClient.put(`/api/v2/pages/${pageId}`, payload, config);
+  await axiosClient.put(`/pages/${pageId}`, payload, config);
 };
 
 export default confluenceOverwritePage;

--- a/src/actions/providers/confluence/overwritePage.ts
+++ b/src/actions/providers/confluence/overwritePage.ts
@@ -1,4 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
 import type {
   confluenceOverwritePageFunction,
   confluenceOverwritePageParamsType,
@@ -6,16 +5,7 @@ import type {
   AuthParamsType,
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
-
-function getConfluenceRequestConfig(baseUrl: string, authToken: string): AxiosRequestConfig {
-  return {
-    baseURL: baseUrl,
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${authToken}`,
-    },
-  };
-}
+import { getConfluenceRequestConfig } from "./helpers";
 
 const confluenceOverwritePage: confluenceOverwritePageFunction = async ({
   params,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1049,7 +1049,7 @@ actions:
             type: string
             description: The format of the output
             enum: [json, csv]
-          limit: 
+          limit:
             type: number
             description: A limit on the number of rows to return
       output:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch Confluence actions to use OAuth for authentication, updating `fetchPageContent.ts` and `overwritePage.ts`, and add OAuth configuration helper.
> 
>   - **Authentication**:
>     - Switch Confluence actions to OAuth in `fetchPageContent.ts` and `overwritePage.ts`, removing username and API token.
>     - Introduce `getConfluenceRequestConfig` in `helpers.ts` for OAuth-based Axios configuration.
>   - **Documentation**:
>     - Update `README.md` to encourage OAuth for action development.
>   - **Versioning**:
>     - Increment package version in `package.json` from `0.1.57` to `0.1.58`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 445d4b1f5f0a37b4b9ce49c0435bb1a61bd9e053. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->