### PR TITLE
export ActionMapper to make it possible to get params schema from action template name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 export { runAction, getActionGroups, type ActionGroupsReturn } from "./app";
 export { ACTION_GROUPS, type ActionGroups } from "./actions/groups";
+export { ActionMapper } from "./actions/actionMapper";
 
 export * from "./actions/autogen/templates";
 export * from "./actions/autogen/types";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Export `ActionMapper` in `src/index.ts` to enable access to parameter schemas from action template names, and update version to `0.1.59`.
> 
>   - **Exports**:
>     - Export `ActionMapper` from `src/index.ts` to allow access to parameter schemas from action template names.
>   - **Versioning**:
>     - Increment version in `package.json` from `0.1.58` to `0.1.59`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for ab111beda88a9efdb8ac36904836f301dff67513. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->