### PR TITLE
Fix confluence oauth actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/confluence/fetchPageContent.ts
+++ b/src/actions/providers/confluence/fetchPageContent.ts
@@ -21,7 +21,11 @@ const confluenceFetchPageContent: confluenceFetchPageContentFunction = async ({
     throw new Error("Missing required authentication parameters");
   }
 
-  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources");
+  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources", {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
   const cloudId = cloudDetails.data[0].id;
   const baseUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/api/v2`;
 

--- a/src/actions/providers/confluence/overwritePage.ts
+++ b/src/actions/providers/confluence/overwritePage.ts
@@ -21,7 +21,11 @@ const confluenceOverwritePage: confluenceOverwritePageFunction = async ({
     throw new Error("Missing required authentication parameters");
   }
 
-  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources");
+  const cloudDetails = await axiosClient.get("https://api.atlassian.com/oauth/token/accessible-resources", {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
   const cloudId = cloudDetails.data[0].id;
   const baseUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/api/v2`;
 

--- a/tests/confluence/testFetchConfluencePageContent.ts
+++ b/tests/confluence/testFetchConfluencePageContent.ts
@@ -6,8 +6,6 @@ async function runTest() {
 
   // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
   const authParams = {
-    baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
-    username: "insert-your-username-here", // Email associated with api token
     authToken: "insert-your-token-here",
   };
 
@@ -21,7 +19,7 @@ async function runTest() {
       "fetchPageContent",
       "confluence",
       authParams,
-      pageParams,
+      pageParams
     );
 
     console.log("Confluence page content fetched successfully!");
@@ -31,7 +29,7 @@ async function runTest() {
     // Validate the result
     assert(
       result.pageId === pageParams.pageId,
-      "Result should contain matching page ID",
+      "Result should contain matching page ID"
     );
     assert(result.title, "Result should contain a page title");
     assert(result.content, "Result should contain page content");

--- a/tests/confluence/testOverwriteConfluencePage.ts
+++ b/tests/confluence/testOverwriteConfluencePage.ts
@@ -8,8 +8,6 @@ async function runTest() {
 
   // Generate from https://id.atlassian.com/manage-profile/security/api-tokens
   const authParams = {
-    baseUrl: "insert-your-baseurl-here", // https://<your-domain>.atlassian.net/wiki
-    username: "insert-your-username-here", // Email associated with api token
     authToken: "insert-your-token-here",
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add authorization headers to Confluence API requests and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `Authorization` header with `Bearer` token in `fetchPageContent.ts` and `overwritePage.ts` for Confluence API requests.
>   - **Tests**:
>     - Remove `baseUrl` and `username` from `authParams` in `testFetchConfluencePageContent.ts` and `testOverwriteConfluencePage.ts`.
>     - Ensure tests use `authToken` for authentication.
>   - **Misc**:
>     - Update version in `package.json` from `0.1.59` to `0.1.60`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for e8db66efbadae2bb1671f62fbdcc35bf0279fe3f. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->