### PR TITLE
[Snowflake ]should show full results length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.59",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.59",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -38,12 +38,14 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
       });
     });
 
+    const fullResultLength = queryResults.length;
+
     // Format the results based on the output format
-    if (limit && queryResults.length - 1 > limit) {
-      queryResults.splice(limit + 1); // Include header
+    if (limit && queryResults.length > limit) {
+      queryResults.splice(limit);
     }
-    const { formattedData, resultsLength } = formatDataForCodeInterpreter(queryResults, outputFormat);
-    return { formattedData, resultsLength };
+    const formattedData = formatDataForCodeInterpreter(queryResults, outputFormat);
+    return { formattedData: formattedData, resultsLength: fullResultLength };
   };
 
   // Set up a connection using snowflake-sdk

--- a/src/actions/util/formatDataForCodeInterpreter.ts
+++ b/src/actions/util/formatDataForCodeInterpreter.ts
@@ -6,10 +6,7 @@
  * @param outputFormat The desired output format ("csv" or "json")
  * @returns Object containing formatted data and result count
  */
-export function formatDataForCodeInterpreter(
-  queryResults: any[],
-  outputFormat: string = "json",
-): { formattedData: string; resultsLength: number } {
+export function formatDataForCodeInterpreter(queryResults: any[], outputFormat: string = "json"): string {
   let formattedData: string;
 
   if (outputFormat.toLowerCase() === "csv") {
@@ -46,5 +43,5 @@ export function formatDataForCodeInterpreter(
     formattedData = JSON.stringify(queryResults, null, 2);
   }
 
-  return { formattedData, resultsLength: queryResults.length };
+  return formattedData;
 }


### PR DESCRIPTION

- was returning the wrong rowCount here 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `rowCount` in `runSnowflakeQuery` to return full result length and updates `formatDataForCodeInterpreter` to return only formatted data.
> 
>   - **Behavior**:
>     - Fixes incorrect `rowCount` in `runSnowflakeQuery` by returning full result length.
>     - Applies limit correctly without affecting `rowCount`.
>   - **Functions**:
>     - `runSnowflakeQuery` in `runSnowflakeQuery.ts` now returns `resultsLength` as `rowCount`.
>     - `formatDataForCodeInterpreter` in `formatDataForCodeInterpreter.ts` now returns only `formattedData`.
>   - **Misc**:
>     - Bumps version in `package.json` from `0.1.60` to `0.1.61`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 0671c5b09140782956833999f6b08f3fca24a20c. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->