### PR TITLE
Make create salesforce account parameter optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -5353,7 +5353,7 @@ export const salesforceCreateRecordDefinition: ActionTemplate = {
   scopes: [],
   parameters: {
     type: "object",
-    required: ["objectType", "fieldsToCreate"],
+    required: ["objectType"],
     properties: {
       objectType: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2845,7 +2845,7 @@ export type salesforceUpdateRecordFunction = ActionFunction<
 
 export const salesforceCreateRecordParamsSchema = z.object({
   objectType: z.string().describe("The Salesforce object type to create (e.g., Lead, Account, Contact)"),
-  fieldsToCreate: z.record(z.string()).describe("The fields to create on the record"),
+  fieldsToCreate: z.record(z.string()).describe("The fields to create on the record").optional(),
 });
 
 export type salesforceCreateRecordParamsType = z.infer<typeof salesforceCreateRecordParamsSchema>;

--- a/src/actions/providers/salesforce/createRecord.ts
+++ b/src/actions/providers/salesforce/createRecord.ts
@@ -27,7 +27,7 @@ const createRecord: salesforceCreateRecordFunction = async ({
     return {
       success: false,
       error: "fieldsToCreate is required to create a Salesforce object",
-    }
+    };
   }
 
   const url = `${baseUrl}/services/data/v56.0/sobjects/${objectType}/`;

--- a/src/actions/providers/salesforce/createRecord.ts
+++ b/src/actions/providers/salesforce/createRecord.ts
@@ -23,6 +23,13 @@ const createRecord: salesforceCreateRecordFunction = async ({
     };
   }
 
+  if (!fieldsToCreate) {
+    return {
+      success: false,
+      error: "fieldsToCreate is required to create a Salesforce object",
+    }
+  }
+
   const url = `${baseUrl}/services/data/v56.0/sobjects/${objectType}/`;
 
   try {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -3743,7 +3743,7 @@ actions:
       scopes: []
       parameters:
         type: object
-        required: [objectType, fieldsToCreate]
+        required: [objectType]
         properties:
           objectType:
             type: string


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Makes `fieldsToCreate` optional for Salesforce record creation, adding a runtime check to ensure it is provided, and updates related schema and version.
> 
>   - **Behavior**:
>     - Makes `fieldsToCreate` optional in `salesforceCreateRecordParamsSchema` in `types.ts` and `salesforceCreateRecordDefinition` in `templates.ts`.
>     - Adds runtime check in `createRecord` in `createRecord.ts` to ensure `fieldsToCreate` is provided, returning an error if not.
>   - **Schema**:
>     - Updates `createRecord` action in `schema.yaml` to make `fieldsToCreate` optional.
>   - **Misc**:
>     - Bumps version in `package.json` from `0.1.61` to `0.1.62`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 0bdadb4f2461d82c8083072ae32bb1fc22b305da. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->