### PR TITLE
[New action] Bing - get top N search results using query and optionally also site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -143,6 +143,8 @@ import {
   salesforceCreateRecordOutputSchema,
   firecrawlDeepResearchParamsSchema,
   firecrawlDeepResearchOutputSchema,
+  bingGetTopNSearchResultUrlsParamsSchema,
+  bingGetTopNSearchResultUrlsOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -217,6 +219,7 @@ import deepResearch from "./providers/firecrawl/deepResearch";
 import listPullRequests from "./providers/github/listPullRequests";
 import getJiraIssuesByQuery from "./providers/jira/getJiraIssuesByQuery";
 import createRecord from "./providers/salesforce/createRecord";
+import getTopNSearchResultUrls from "./providers/bing/getTopNSearchResultUrls";
 
 interface ActionFunctionComponents {
   // eslint-disable-next-line
@@ -303,6 +306,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: callCopilot,
       paramsSchema: credalCallCopilotParamsSchema,
       outputSchema: credalCallCopilotOutputSchema,
+    },
+  },
+  bing: {
+    getTopNSearchResultUrls: {
+      fn: getTopNSearchResultUrls,
+      paramsSchema: bingGetTopNSearchResultUrlsParamsSchema,
+      outputSchema: bingGetTopNSearchResultUrlsOutputSchema,
     },
   },
   zendesk: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -983,6 +983,54 @@ export const googlemapsNearbysearchRestaurantsDefinition: ActionTemplate = {
   name: "nearbysearchRestaurants",
   provider: "googlemaps",
 };
+export const bingGetTopNSearchResultUrlsDefinition: ActionTemplate = {
+  description: "Get the top five search result URLs from Bing",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["query"],
+    properties: {
+      query: {
+        type: "string",
+        description: "The query to search for",
+      },
+      count: {
+        type: "number",
+        description: "The number of results to return. Default is 5.",
+      },
+      site: {
+        type: "string",
+        description:
+          "The site to restrict the search to (by inserting site:<site.com> in the query). Examples include openai.com, github.com",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["results"],
+    properties: {
+      results: {
+        type: "array",
+        description: "The top five search result objects",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name or title of the search result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the search result",
+            },
+          },
+        },
+      },
+    },
+  },
+  name: "getTopNSearchResultUrls",
+  provider: "bing",
+};
 export const credalCallCopilotDefinition: ActionTemplate = {
   description: "Call Credal Copilot for response on a given query",
   scopes: [],

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -525,6 +525,37 @@ export type googlemapsNearbysearchRestaurantsFunction = ActionFunction<
   googlemapsNearbysearchRestaurantsOutputType
 >;
 
+export const bingGetTopNSearchResultUrlsParamsSchema = z.object({
+  query: z.string().describe("The query to search for"),
+  count: z.number().describe("The number of results to return. Default is 5.").optional(),
+  site: z
+    .string()
+    .describe(
+      "The site to restrict the search to (by inserting site:<site.com> in the query). Examples include openai.com, github.com",
+    )
+    .optional(),
+});
+
+export type bingGetTopNSearchResultUrlsParamsType = z.infer<typeof bingGetTopNSearchResultUrlsParamsSchema>;
+
+export const bingGetTopNSearchResultUrlsOutputSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name or title of the search result").optional(),
+        url: z.string().describe("The URL of the search result").optional(),
+      }),
+    )
+    .describe("The top five search result objects"),
+});
+
+export type bingGetTopNSearchResultUrlsOutputType = z.infer<typeof bingGetTopNSearchResultUrlsOutputSchema>;
+export type bingGetTopNSearchResultUrlsFunction = ActionFunction<
+  bingGetTopNSearchResultUrlsParamsType,
+  AuthParamsType,
+  bingGetTopNSearchResultUrlsOutputType
+>;
+
 export const credalCallCopilotParamsSchema = z.object({
   agentId: z.string().describe("The ID of the copilot to call"),
   query: z.string().describe("The query to ask Credal Copilot"),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -546,7 +546,7 @@ export const bingGetTopNSearchResultUrlsOutputSchema = z.object({
         url: z.string().describe("The URL of the search result").optional(),
       }),
     )
-    .describe("The top five search result objects"),
+    .describe("The top N search result objects"),
 });
 
 export type bingGetTopNSearchResultUrlsOutputType = z.infer<typeof bingGetTopNSearchResultUrlsOutputSchema>;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -72,6 +72,7 @@ import {
   ashbyCreateCandidateDefinition,
   ashbyUpdateCandidateDefinition,
   ashbyAddCandidateToProjectDefinition,
+  bingGetTopNSearchResultUrlsDefinition,
 } from "../actions/autogen/templates";
 import type { ActionTemplate } from "../actions/parse";
 
@@ -135,6 +136,10 @@ export const ACTION_GROUPS: ActionGroups = {
       zendeskAddCommentToTicketDefinition,
       zendeskAssignTicketDefinition,
     ],
+  },
+  BING_SEARCH: {
+    description: "Action for searching Bing",
+    actions: [bingGetTopNSearchResultUrlsDefinition],
   },
   MONGO_INSERT_DOC: {
     description: "Action for inserting a document into a MongoDB collection",

--- a/src/actions/providers/bing/getTopNSearchResultUrls.ts
+++ b/src/actions/providers/bing/getTopNSearchResultUrls.ts
@@ -1,54 +1,54 @@
 import {
-    type bingGetTopNSearchResultUrlsFunction,
-    type bingGetTopNSearchResultUrlsParamsType,
-    type bingGetTopNSearchResultUrlsOutputType,
-    type AuthParamsType,
-    bingGetTopNSearchResultUrlsOutputSchema,
+  type bingGetTopNSearchResultUrlsFunction,
+  type bingGetTopNSearchResultUrlsParamsType,
+  type bingGetTopNSearchResultUrlsOutputType,
+  type AuthParamsType,
+  bingGetTopNSearchResultUrlsOutputSchema,
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
 const getTopNSearchResultUrls: bingGetTopNSearchResultUrlsFunction = async ({
-    params,
-    authParams,
+  params,
+  authParams,
 }: {
-    params: bingGetTopNSearchResultUrlsParamsType;
-    authParams: AuthParamsType;
+  params: bingGetTopNSearchResultUrlsParamsType;
+  authParams: AuthParamsType;
 }): Promise<bingGetTopNSearchResultUrlsOutputType> => {
-    const { query, count = 5, site } = params;
-    const { apiKey } = authParams;
+  const { query, count = 5, site } = params;
+  const { apiKey } = authParams;
 
-    // Build the search query
-    const searchQuery = `${query}${site ? ` site:${site}` : ""}`;
+  // Build the search query
+  const searchQuery = `${query}${site ? ` site:${site}` : ""}`;
 
-    // Ensure we have an API key
-    if (!apiKey) {
-        throw new Error("Missing Bing API key in auth parameters");
-    }
+  // Ensure we have an API key
+  if (!apiKey) {
+    throw new Error("Missing Bing API key in auth parameters");
+  }
 
-    try {
-        // Call Bing Search API
-        const response = await axiosClient.get("https://api.bing.microsoft.com/v7.0/search", {
-            params: {
-                q: searchQuery,
-                count: count,
-                responseFilter: "Webpages",
-                mkt: "en-US",
-            },
-            headers: {
-                "Ocp-Apim-Subscription-Key": apiKey,
-            },
-        });
+  try {
+    // Call Bing Search API
+    const response = await axiosClient.get("https://api.bing.microsoft.com/v7.0/search", {
+      params: {
+        q: searchQuery,
+        count: count,
+        responseFilter: "Webpages",
+        mkt: "en-US",
+      },
+      headers: {
+        "Ocp-Apim-Subscription-Key": apiKey,
+      },
+    });
 
-        // Extract URLs and names from search results
-        const searchResults = response.data.webPages?.value || [];
+    // Extract URLs and names from search results
+    const searchResults = response.data.webPages?.value || [];
 
-        return bingGetTopNSearchResultUrlsOutputSchema.parse({
-            results: searchResults,
-        });
-    } catch (error) {
-        console.error("Error fetching search results from Bing:", error);
-        throw error;
-    }
+    return bingGetTopNSearchResultUrlsOutputSchema.parse({
+      results: searchResults,
+    });
+  } catch (error) {
+    console.error("Error fetching search results from Bing:", error);
+    throw error;
+  }
 };
 
 export default getTopNSearchResultUrls;

--- a/src/actions/providers/bing/getTopNSearchResultUrls.ts
+++ b/src/actions/providers/bing/getTopNSearchResultUrls.ts
@@ -18,10 +18,7 @@ const getTopNSearchResultUrls: bingGetTopNSearchResultUrlsFunction = async ({
     const { apiKey } = authParams;
 
     // Build the search query
-    let searchQuery = query;
-    if (site) {
-        searchQuery = `${searchQuery} site:${site}`;
-    }
+    const searchQuery = `${query}${site ? ` site:${site}` : ""}`;
 
     // Ensure we have an API key
     if (!apiKey) {

--- a/src/actions/providers/bing/getTopNSearchResultUrls.ts
+++ b/src/actions/providers/bing/getTopNSearchResultUrls.ts
@@ -1,0 +1,61 @@
+import {
+  type bingGetTopNSearchResultUrlsFunction,
+  type bingGetTopNSearchResultUrlsParamsType,
+  type bingGetTopNSearchResultUrlsOutputType,
+  type AuthParamsType,
+  bingGetTopNSearchResultUrlsOutputSchema,
+} from "../../autogen/types";
+import { axiosClient } from "../../util/axiosClient";
+
+const getTopNSearchResultUrls: bingGetTopNSearchResultUrlsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: bingGetTopNSearchResultUrlsParamsType;
+  authParams: AuthParamsType;
+}): Promise<bingGetTopNSearchResultUrlsOutputType> => {
+  const { query, count = 5, site } = params;
+  const { apiKey } = authParams;
+
+  // Build the search query
+  let searchQuery = query;
+  if (site) {
+    searchQuery = `${searchQuery} site:${site}`;
+  }
+
+  // Ensure we have an API key
+  if (!apiKey) {
+    throw new Error("Missing Bing API key in auth parameters");
+  }
+
+  try {
+    // Call Bing Search API
+    const response = await axiosClient.get("https://api.bing.microsoft.com/v7.0/search", {
+      params: {
+        q: searchQuery,
+        count: count,
+        responseFilter: "Webpages",
+        mkt: "en-US",
+      },
+      headers: {
+        "Ocp-Apim-Subscription-Key": apiKey,
+      },
+    });
+
+    // Extract URLs and names from search results
+    const searchResults = response.data.webPages?.value || [];
+    const namesAndUrls = searchResults.slice(0, count).map((result: any) => ({
+      name: result.name || "",
+      url: result.url,
+    }));
+
+    return bingGetTopNSearchResultUrlsOutputSchema.parse({
+      results: namesAndUrls,
+    });
+  } catch (error) {
+    console.error("Error fetching search results from Bing:", error);
+    throw error;
+  }
+};
+
+export default getTopNSearchResultUrls;

--- a/src/actions/providers/bing/getTopNSearchResultUrls.ts
+++ b/src/actions/providers/bing/getTopNSearchResultUrls.ts
@@ -1,61 +1,57 @@
 import {
-  type bingGetTopNSearchResultUrlsFunction,
-  type bingGetTopNSearchResultUrlsParamsType,
-  type bingGetTopNSearchResultUrlsOutputType,
-  type AuthParamsType,
-  bingGetTopNSearchResultUrlsOutputSchema,
+    type bingGetTopNSearchResultUrlsFunction,
+    type bingGetTopNSearchResultUrlsParamsType,
+    type bingGetTopNSearchResultUrlsOutputType,
+    type AuthParamsType,
+    bingGetTopNSearchResultUrlsOutputSchema,
 } from "../../autogen/types";
 import { axiosClient } from "../../util/axiosClient";
 
 const getTopNSearchResultUrls: bingGetTopNSearchResultUrlsFunction = async ({
-  params,
-  authParams,
+    params,
+    authParams,
 }: {
-  params: bingGetTopNSearchResultUrlsParamsType;
-  authParams: AuthParamsType;
+    params: bingGetTopNSearchResultUrlsParamsType;
+    authParams: AuthParamsType;
 }): Promise<bingGetTopNSearchResultUrlsOutputType> => {
-  const { query, count = 5, site } = params;
-  const { apiKey } = authParams;
+    const { query, count = 5, site } = params;
+    const { apiKey } = authParams;
 
-  // Build the search query
-  let searchQuery = query;
-  if (site) {
-    searchQuery = `${searchQuery} site:${site}`;
-  }
+    // Build the search query
+    let searchQuery = query;
+    if (site) {
+        searchQuery = `${searchQuery} site:${site}`;
+    }
 
-  // Ensure we have an API key
-  if (!apiKey) {
-    throw new Error("Missing Bing API key in auth parameters");
-  }
+    // Ensure we have an API key
+    if (!apiKey) {
+        throw new Error("Missing Bing API key in auth parameters");
+    }
 
-  try {
-    // Call Bing Search API
-    const response = await axiosClient.get("https://api.bing.microsoft.com/v7.0/search", {
-      params: {
-        q: searchQuery,
-        count: count,
-        responseFilter: "Webpages",
-        mkt: "en-US",
-      },
-      headers: {
-        "Ocp-Apim-Subscription-Key": apiKey,
-      },
-    });
+    try {
+        // Call Bing Search API
+        const response = await axiosClient.get("https://api.bing.microsoft.com/v7.0/search", {
+            params: {
+                q: searchQuery,
+                count: count,
+                responseFilter: "Webpages",
+                mkt: "en-US",
+            },
+            headers: {
+                "Ocp-Apim-Subscription-Key": apiKey,
+            },
+        });
 
-    // Extract URLs and names from search results
-    const searchResults = response.data.webPages?.value || [];
-    const namesAndUrls = searchResults.slice(0, count).map((result: any) => ({
-      name: result.name || "",
-      url: result.url,
-    }));
+        // Extract URLs and names from search results
+        const searchResults = response.data.webPages?.value || [];
 
-    return bingGetTopNSearchResultUrlsOutputSchema.parse({
-      results: namesAndUrls,
-    });
-  } catch (error) {
-    console.error("Error fetching search results from Bing:", error);
-    throw error;
-  }
+        return bingGetTopNSearchResultUrlsOutputSchema.parse({
+            results: searchResults,
+        });
+    } catch (error) {
+        console.error("Error fetching search results from Bing:", error);
+        throw error;
+    }
 };
 
 export default getTopNSearchResultUrls;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -703,7 +703,39 @@ actions:
                 websiteUri:
                   type: string
                   description: The website URI of the place
-
+  bing:
+    getTopNSearchResultUrls:
+      description: Get the top five search result URLs from Bing
+      scopes: []
+      parameters:
+        type: object
+        required: [query]
+        properties:
+          query:
+            type: string
+            description: The query to search for
+          count:
+            type: number
+            description: The number of results to return. Default is 5.
+          site:
+            type: string
+            description: The site to restrict the search to (by inserting site:<site.com> in the query). Examples include openai.com, github.com
+      output:
+        type: object
+        required: [results]
+        properties:
+          results:
+            type: array
+            description: The top five search result objects
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name or title of the search result
+                url:
+                  type: string
+                  description: The URL of the search result
   credal:
     callCopilot:
       description: Call Credal Copilot for response on a given query

--- a/tests/bing/testGetTopNSearchResultUrls.ts
+++ b/tests/bing/testGetTopNSearchResultUrls.ts
@@ -1,0 +1,17 @@
+import { runAction } from "../../src/app";
+
+async function runTest() {
+  const result = await runAction(
+    "getTopNSearchResultUrls",
+    "bing",
+    { apiKey: "insert-during-test" }, // authParams
+    {
+      query: "function calling",
+      count: 5,
+      site: "openai.com",
+    },
+  );
+  console.log(result);
+}
+
+runTest().catch(console.error);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `getTopNSearchResultUrls` action to fetch top N Bing search results with optional site restriction.
> 
>   - **Behavior**:
>     - Adds `getTopNSearchResultUrls` action to fetch top N search results from Bing in `getTopNSearchResultUrls.ts`.
>     - Supports optional site restriction and defaults to 5 results if count is not specified.
>   - **Schemas**:
>     - Adds `bingGetTopNSearchResultUrlsParamsSchema` and `bingGetTopNSearchResultUrlsOutputSchema` in `types.ts`.
>     - Updates `schema.yaml` with new action parameters and output.
>   - **Integration**:
>     - Registers new action in `actionMapper.ts` and `groups.ts` under BING_SEARCH.
>   - **Testing**:
>     - Adds `testGetTopNSearchResultUrls.ts` to test the new Bing search action.
>   - **Misc**:
>     - Bumps package version in `package.json` from 0.1.64 to 0.1.65.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 94df9f2b74b3f763f092ee08bf84fc0d6791365d. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->