### PR TITLE
Update zendesk actions to use oauth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -13,23 +13,20 @@ const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
   params: zendeskAddCommentToTicketParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskAddCommentToTicketOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, ticketId, comment } = params;
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
-  if (!apiKey) {
-    throw new Error("API key is required");
+  if (!authToken) {
+    throw new Error("Auth token is required");
   }
 
   await axiosClient.request({
     url: url,
     method: "PUT",
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
     data: {
       ticket: {

--- a/src/actions/providers/zendesk/assignTicket.ts
+++ b/src/actions/providers/zendesk/assignTicket.ts
@@ -13,23 +13,20 @@ const updateTicketStatus: zendeskAssignTicketFunction = async ({
   params: zendeskAssignTicketParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskAssignTicketOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, ticketId, assigneeEmail } = params;
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
-  if (!apiKey) {
-    throw new Error("API key is required");
+  if (!authToken) {
+    throw new Error("Auth token is required");
   }
 
   await axiosClient.request({
     url: url,
     method: "PUT",
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
     data: {
       ticket: {

--- a/src/actions/providers/zendesk/createZendeskTicket.ts
+++ b/src/actions/providers/zendesk/createZendeskTicket.ts
@@ -13,7 +13,7 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
   params: zendeskCreateZendeskTicketParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskCreateZendeskTicketOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, subject, body } = params;
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
   const payload = {
@@ -25,17 +25,14 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
     },
   };
 
-  if (!apiKey) {
-    throw new Error("API key is required");
+  if (!authToken) {
+    throw new Error("Auth token is required");
   }
 
   const response = await axiosClient.post(url, payload, {
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
   });
   return {

--- a/src/actions/providers/zendesk/getTicketDetails.ts
+++ b/src/actions/providers/zendesk/getTicketDetails.ts
@@ -13,23 +13,20 @@ const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
   params: zendeskGetTicketDetailsParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskGetTicketDetailsOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, ticketId } = params;
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
-  if (!apiKey) {
-    throw new Error("API key is required");
+  if (!authToken) {
+    throw new Error("Auth token is required");
   }
 
   const response = await axiosClient.request({
     url: url,
     method: "GET",
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
   });
   return {

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -25,7 +25,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
 
   if (!authToken) {
-    throw new Error("API key is required");
+    throw new Error("Auth token is required");
   }
 
   // Add query parameters for filtering

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -13,7 +13,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   params: zendeskListZendeskTicketsParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskListZendeskTicketsOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, status } = params;
 
   // Calculate date 3 months ago from now
@@ -24,7 +24,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   // Endpoint for getting tickets
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
 
-  if (!apiKey) {
+  if (!authToken) {
     throw new Error("API key is required");
   }
 
@@ -37,12 +37,9 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   }
 
   const response = await axiosClient.get(`${url}?${queryParams.toString()}`, {
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
   });
 

--- a/src/actions/providers/zendesk/updateTicketStatus.ts
+++ b/src/actions/providers/zendesk/updateTicketStatus.ts
@@ -13,22 +13,19 @@ const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
   params: zendeskUpdateTicketStatusParamsType;
   authParams: AuthParamsType;
 }): Promise<zendeskUpdateTicketStatusOutputType> => {
-  const { apiKey, username } = authParams;
+  const { authToken } = authParams;
   const { subdomain, ticketId, status } = params;
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
-  if (!apiKey) {
-    throw new Error("API key is required");
+  if (!authToken) {
+    throw new Error("Auth token is required");
   }
   await axiosClient.request({
     url: url,
     method: "PUT",
-    auth: {
-      username: `${username}/token`,
-      password: apiKey,
-    },
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
     },
     data: {
       ticket: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Zendesk actions to use OAuth token for authentication instead of API key, affecting multiple ticket management functions.
> 
>   - **Authentication**:
>     - Replace API key authentication with OAuth token in `addCommentToTicket.ts`, `assignTicket.ts`, and `createZendeskTicket.ts`.
>     - Update `getTicketDetails.ts`, `listTickets.ts`, and `updateTicketStatus.ts` to use OAuth token.
>     - Throw error if `authToken` is missing in all updated functions.
>   - **Headers**:
>     - Add `Authorization: Bearer {authToken}` header in all affected functions.
>   - **Versioning**:
>     - Increment package version in `package.json` from `0.1.66` to `0.1.67`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 975a519d58a7fc8cfeab42a468f45af51cfb8d62. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->