### PR TITLE
[CSV] Fix format of CSV to include null / undefined explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/util/formatDataForCodeInterpreter.ts
+++ b/src/actions/util/formatDataForCodeInterpreter.ts
@@ -17,7 +17,7 @@ export function formatDataForCodeInterpreter(queryResults: any[], outputFormat: 
 
       // Helper function to properly escape CSV fields
       const escapeCsvField = (field: any): string => {
-        if (field === null || field === undefined) return "";
+        if (field === null || field === undefined) return "null";
 
         const stringValue = typeof field === "object" ? JSON.stringify(field) : String(field);
 


### PR DESCRIPTION
### Small fix 

Was facing an issue with code interpreter when the number of rows was not the expected amount for a CSV.
This makes parsing the next row of values have trouble by Code interpreter (expected 2 column values - but got 1) 
This typically results it the next row being ignored 

Solution: Make sure any undefined/null value from the data provided is marked as null 

- Issue for Snowflake Action Agent 