### PR TITLE
Gong action working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -7,22 +7,34 @@ import type {
   gongGetGongTranscriptsOutputType,
 } from "../../autogen/types";
 
-const UserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  title: z.string(),
-});
+const UserSchema = z
+  .object({
+    id: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    title: z.string(),
+  })
+  .partial()
+  .passthrough();
 
-const TrackerSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-});
+const TrackerSchema = z
+  .object({
+    trackerId: z.string(),
+    trackerName: z.string(),
+  })
+  .partial()
+  .passthrough();
 
-const CallSchema = z.object({
-  id: z.string(),
-  primaryUserId: z.string().optional(),
-  started: z.string().optional(),
-});
+const CallSchema = z
+  .object({
+    metaData: z.object({
+      id: z.string(),
+      primaryUserId: z.string(),
+      started: z.string(),
+    }),
+  })
+  .partial()
+  .passthrough();
 
 const SentenceSchema = z.object({
   start: z.number(),
@@ -30,16 +42,19 @@ const SentenceSchema = z.object({
   text: z.string(),
 });
 
-const TranscriptSchema = z.object({
-  callId: z.string(),
-  transcript: z.array(
-    z.object({
-      speakerId: z.string(),
-      topic: z.string(),
-      sentences: z.array(SentenceSchema),
-    }),
-  ),
-});
+const TranscriptSchema = z
+  .object({
+    callId: z.string(),
+    transcript: z.array(
+      z.object({
+        speakerId: z.string().optional(),
+        topic: z.string(),
+        sentences: z.array(SentenceSchema),
+      }),
+    ),
+  })
+  .partial()
+  .passthrough();
 
 type User = z.infer<typeof UserSchema>;
 type Tracker = z.infer<typeof TrackerSchema>;
@@ -49,7 +64,7 @@ type Transcript = z.infer<typeof TranscriptSchema>;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const GongResponseSchema = z.object({
   users: z.array(UserSchema).optional(),
-  trackers: z.array(TrackerSchema).optional(),
+  keywordTrackers: z.array(TrackerSchema).optional(),
   calls: z.array(CallSchema).optional(),
   callTranscripts: z.array(TranscriptSchema).optional(),
   cursor: z.string().optional(),
@@ -57,18 +72,12 @@ const GongResponseSchema = z.object({
 
 type GongResponse = z.infer<typeof GongResponseSchema>;
 
-async function getUsers(authToken: string, params: Record<string, number | string> = {}): Promise<User[]> {
+async function getUsers(authToken: string): Promise<User[]> {
   let results: User[] = [];
   let cursor: string | undefined = undefined;
-
   do {
-    const response: { data: GongResponse } = await axios.post<GongResponse>(
-      `https://api.gong.io/v2/users/extensive` + (cursor ? `?cursor=${cursor}` : ""),
-      {
-        filter: {
-          ...params,
-        },
-      },
+    const response: { data: GongResponse } = await axios.get<GongResponse>(
+      `https://api.gong.io/v2/users` + (cursor ? `?cursor=${cursor}` : ""),
       {
         headers: {
           Authorization: `Bearer ${authToken}`,
@@ -87,11 +96,10 @@ async function getUsers(authToken: string, params: Record<string, number | strin
     }
     cursor = response.data.cursor;
   } while (cursor);
-
   return results;
 }
 
-async function getTrackers(authToken: string, params: Record<string, number | string> = {}): Promise<Tracker[]> {
+async function getTrackers(authToken: string): Promise<Tracker[]> {
   let results: Tracker[] = [];
   let cursor: string | undefined = undefined;
 
@@ -103,17 +111,13 @@ async function getTrackers(authToken: string, params: Record<string, number | st
           Authorization: `Bearer ${authToken}`,
           "Content-Type": "application/json",
         },
-        params: {
-          filter: {
-            ...params,
-          },
-        },
+        params: {},
       },
     );
     if (!response) {
       return results;
     }
-    const parsedItems = z.array(TrackerSchema).safeParse(response.data.trackers);
+    const parsedItems = z.array(TrackerSchema).safeParse(response.data.keywordTrackers);
     if (parsedItems.success) {
       results = [...results, ...parsedItems.data];
     } else {
@@ -171,7 +175,7 @@ async function getTranscripts(
 
   do {
     const response: { data: GongResponse } = await axios.post<GongResponse>(
-      `https://api.gong.io/v2/transcript/calls/transcripts` + (cursor ? `?cursor=${cursor}` : ""),
+      `https://api.gong.io/v2/calls/transcript` + (cursor ? `?cursor=${cursor}` : ""),
       {
         filter: {
           ...params,
@@ -214,32 +218,43 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
     };
   }
   try {
-    const gongUsers = await getUsers(authParams.authToken, { userRole: params.userRole });
+    const gongUsers = await getUsers(authParams.authToken);
     const filteredGongUsers = gongUsers.filter(user => user.title === params.userRole);
-    const trackers = await getTrackers(authParams.authToken, {});
-    const filteredTrackers = trackers.filter(tracker => (params.trackers ?? []).includes(tracker.name));
-    // Get calls owned by the users and filtered by the trackers
+    const trackers = await getTrackers(authParams.authToken);
+    const filteredTrackers = trackers.filter(tracker => params.trackers?.includes(tracker.trackerName ?? ""));
     const calls = await getCalls(authParams.authToken, {
       fromDateTime: params.startDate ?? "",
       toDateTime: params.endDate ?? "",
-      primaryUserIds: filteredGongUsers.length > 0 ? filteredGongUsers.map(user => user.id) : undefined,
-      trackerIds: filteredTrackers.length > 0 ? filteredTrackers.map(tracker => tracker.id) : undefined,
+      primaryUserIds:
+        filteredGongUsers.length > 0
+          ? filteredGongUsers.map(user => user.id).filter((id): id is string => id !== undefined)
+          : undefined,
+      trackerIds:
+        filteredTrackers.length > 0
+          ? filteredTrackers.map(tracker => tracker.trackerId).filter((id): id is string => id !== undefined)
+          : undefined,
     });
     // Get transcripts for the calls we found
     const callTranscripts = await getTranscripts(authParams.authToken, {
       fromDateTime: params.startDate ?? "",
       toDateTime: params.endDate ?? "",
-      callIds: calls.map(call => call.id),
+      callIds: calls.map(call => call.metaData?.id).filter((id): id is string => id !== undefined),
     });
     // Map speaker IDs to names in the transcripts
-    const userIdToNameMap = Object.fromEntries(filteredGongUsers.map(user => [user.id, user.name]));
-    const callTranscriptsWithNames = callTranscripts.map(callTranscript => ({
-      ...callTranscript,
-      transcript: callTranscript.transcript.map((transcript: { speakerId: string }) => ({
-        ...transcript,
-        speakerName: userIdToNameMap[transcript.speakerId] || transcript.speakerId,
-      })),
-    }));
+    const userIdToNameMap = Object.fromEntries(
+      gongUsers.map(user => [user.id, user.firstName + " " + user.lastName]),
+    );
+    const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
+      const currTranscript = { ...callTranscript };
+      currTranscript.transcript = callTranscript.transcript?.map(transcript => {
+        const {speakerId, ...rest} = transcript;
+        return {
+        ...rest,
+        speakerName: userIdToNameMap[transcript.speakerId ?? ""],
+        }
+      });
+      return currTranscript;
+    });
     return {
       success: true,
       callTranscripts: callTranscriptsWithNames,

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -241,17 +241,15 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
       callIds: calls.map(call => call.metaData?.id).filter((id): id is string => id !== undefined),
     });
     // Map speaker IDs to names in the transcripts
-    const userIdToNameMap = Object.fromEntries(
-      gongUsers.map(user => [user.id, user.firstName + " " + user.lastName]),
-    );
+    const userIdToNameMap = Object.fromEntries(gongUsers.map(user => [user.id, user.firstName + " " + user.lastName]));
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
-        const {speakerId, ...rest} = transcript;
+        const { speakerId, ...rest } = transcript;
         return {
-        ...rest,
-        speakerName: userIdToNameMap[transcript.speakerId ?? ""],
-        }
+          ...rest,
+          speakerName: userIdToNameMap[transcript.speakerId ?? ""],
+        };
       });
       return currTranscript;
     });

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -245,6 +245,7 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,

--- a/tests/gong/testGetGongTranscripts.ts
+++ b/tests/gong/testGetGongTranscripts.ts
@@ -12,20 +12,20 @@ async function runTest() {
       authToken: process.env.GONG_TOKEN!,
     },
     {
-      userRole: "Sales",
-      trackers: ["Tracker1", "Tracker2"],
-      startDate: "2022-07-01T02:00:00-05:00",
-      endDate: "2022-07-31T02:00:00-05:00"
+      userRole: "Chief of Staff",
+      trackers: ["Value Prop"],
+      startDate: "2025-05-01T00:00:00Z",
+      endDate: "2025-05-08T23:59:59Z"
     }
   );
 
   // Validate response
   assert(result, "Response should not be null");
   assert(result.success, "Response should indicate success");
-  assert(Array.isArray(result.transcripts), "Response should contain transcripts array");
+  assert(Array.isArray(result.callTranscripts), "Response should contain callTranscripts array");
   
-  if (result.transcripts.length > 0) {
-    const firstTranscript = result.transcripts[0];
+  if (result.callTranscripts.length > 0) {
+    const firstTranscript = result.callTranscripts[0];
     assert(firstTranscript.callId, "Transcript should have a callId");
     assert(firstTranscript, "Transcript should have transcript data");
     assert(firstTranscript.speakerNames, "Transcript should have speaker names");

--- a/tests/gong/testGetGongTranscriptsMock.test.ts
+++ b/tests/gong/testGetGongTranscriptsMock.test.ts
@@ -25,11 +25,11 @@ describe("getGongTranscripts", () => {
 
   it("should successfully fetch transcripts", async () => {
     // Mock users response
-    mockedAxios.post.mockResolvedValueOnce({
+    mockedAxios.get.mockResolvedValueOnce({
       data: {
         users: [
-          { id: "user1", title: "Sales", name: "John" },
-          { id: "user2", title: "Sales", name: "Jane" },
+          { id: "user1", title: "Sales", firstName: "John", lastName: "Doe" },
+          { id: "user2", title: "Sales", firstName: "Jane", lastName: "Doe" },
         ],
         cursor: null,
       },
@@ -39,8 +39,8 @@ describe("getGongTranscripts", () => {
     mockedAxios.get.mockResolvedValueOnce({
       data: {
         trackers: [
-          { id: "tracker1", name: "Tracker1" },
-          { id: "tracker2", name: "Tracker2" },
+          { trackerId: "tracker1", trackerName: "Tracker1" },
+          { trackerId: "tracker2", trackerName: "Tracker2" },
         ],
         cursor: null,
       },
@@ -64,7 +64,7 @@ describe("getGongTranscripts", () => {
           {
             callId: "call1",
             transcript: [{
-              speakerId: "John",
+              speakerId: "user1",
               topic: "Sales Call",
               sentences: [{
                 start: 0,
@@ -81,7 +81,7 @@ describe("getGongTranscripts", () => {
           {
             callId: "call2",
             transcript: [{
-              speakerId: "Jane",
+              speakerId: "user2",
               topic: "Product Demo",
               sentences: [
                 {
@@ -111,7 +111,7 @@ describe("getGongTranscripts", () => {
     expect(result.callTranscripts).toBeDefined();
     expect(result.callTranscripts).toHaveLength(2);
     expect(result.callTranscripts![0].callId).toBe("call1");
-    expect(result.callTranscripts![0].transcript![0].speakerName).toEqual("John");
+    expect(result.callTranscripts![0].transcript![0].speakerName).toEqual("John Doe");
     expect(result.callTranscripts![1].transcript![0].topic).toBe("Product Demo");
   });
 
@@ -141,7 +141,7 @@ describe("getGongTranscripts", () => {
 
   it("should handle empty results", async () => {
     // Mock users response
-    mockedAxios.post.mockResolvedValueOnce({
+    mockedAxios.get.mockResolvedValueOnce({
       data: {
         users: [],
         cursor: null,
@@ -183,17 +183,17 @@ describe("getGongTranscripts", () => {
 
   it("should handle pagination in responses", async () => {
     // Mock users response with pagination
-    mockedAxios.post.mockResolvedValueOnce({
+    mockedAxios.get.mockResolvedValueOnce({
       data: {
         users: [
-          { id: "user1", title: "Sales", name: "John" },
+          { id: "user1", title: "Sales", firstName: "John", lastName: "Doe" },
         ],
         cursor: "cursor1",
       },
     }).mockResolvedValueOnce({
       data: {
         users: [
-          { id: "user2", title: "Sales", name: "Jane" },
+          { id: "user2", title: "Sales", firstName: "Jane", lastName: "Doe" },
         ],
         cursor: null,
       },
@@ -234,7 +234,7 @@ describe("getGongTranscripts", () => {
           {
             callId: "call1",
             transcript: [{
-              speakerId: "John",
+              speakerId: "user1",
               topic: "First Call",
               sentences: [{
                 start: 0,
@@ -246,7 +246,7 @@ describe("getGongTranscripts", () => {
           {
             callId: "call2",
             transcript: [{
-              speakerId: "Jane",
+              speakerId: "user2",
               topic: "Second Call",
               sentences: [{
                 start: 10,
@@ -268,10 +268,10 @@ describe("getGongTranscripts", () => {
     expect(result.success).toBe(true);
     expect(result.callTranscripts).toHaveLength(2);
     expect(result.callTranscripts![0].callId).toBe("call1");
-    expect(result.callTranscripts![0].transcript![0].speakerName).toBe("John");
+    expect(result.callTranscripts![0].transcript![0].speakerName).toBe("John Doe");
     expect(result.callTranscripts![1].callId).toBe("call2");
-    expect(result.callTranscripts![1].transcript![0].speakerName).toBe("Jane");
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-    expect(mockedAxios.post).toHaveBeenCalledTimes(5);
+    expect(result.callTranscripts![1].transcript![0].speakerName).toBe("Jane Doe");
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(mockedAxios.post).toHaveBeenCalledTimes(3);
   });
 }); 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updated Gong action to handle optional fields and map speaker IDs to names, with corresponding test updates.
> 
>   - **Behavior**:
>     - Updated `getGongTranscripts.ts` to use `axios.get` for fetching users and trackers, and `axios.post` for calls and transcripts.
>     - Modified `UserSchema`, `TrackerSchema`, `CallSchema`, and `TranscriptSchema` to use `.partial().passthrough()` for optional fields.
>     - Changed `getUsers` and `getTrackers` functions to remove `params` argument and adjust API endpoints.
>     - Updated `getTranscripts` to map `speakerId` to `speakerName` using `firstName` and `lastName`.
>   - **Tests**:
>     - Updated `testGetGongTranscripts.ts` and `testGetGongTranscriptsMock.test.ts` to reflect changes in schema and API calls.
>     - Adjusted mock data to include `firstName` and `lastName` instead of `name`.
>     - Added checks for `speakerName` in transcripts.
>   - **Misc**:
>     - Bumped version in `package.json` from `0.1.71` to `0.1.72`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 4e3f563b74bfbe8b83abc8f6320c6d04c7725f1e. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->