### PR TITLE
Get parties from Gong action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4916,6 +4916,7 @@ export const gongGetGongTranscriptsDefinition: ActionTemplate = {
                   },
                   topic: {
                     type: "string",
+                    nullable: true,
                     description: "The topic of the transcript",
                   },
                   sentences: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2573,7 +2573,7 @@ export const gongGetGongTranscriptsOutputSchema = z.object({
               z
                 .object({
                   speakerName: z.string().describe("The name of the speaker").optional(),
-                  topic: z.string().describe("The topic of the transcript").optional(),
+                  topic: z.string().nullable().describe("The topic of the transcript").optional(),
                   sentences: z
                     .array(
                       z

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -280,7 +280,6 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -246,6 +246,7 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -33,25 +33,42 @@ const CallSchema = z
       primaryUserId: z.string(),
       started: z.string(),
     }),
+    parties: z.array(
+      z
+        .object({
+          id: z.string(),
+          name: z.string(),
+          userId: z.string(),
+          speakerId: z.string().nullable(),
+        })
+        .partial()
+        .passthrough(),
+    ),
   })
   .partial()
   .passthrough();
 
-const SentenceSchema = z.object({
-  start: z.number(),
-  end: z.number(),
-  text: z.string(),
-});
+const SentenceSchema = z
+  .object({
+    start: z.number(),
+    end: z.number(),
+    text: z.string(),
+  })
+  .partial()
+  .passthrough();
 
 const TranscriptSchema = z
   .object({
     callId: z.string(),
     transcript: z.array(
-      z.object({
-        speakerId: z.string().optional(),
-        topic: z.string(),
-        sentences: z.array(SentenceSchema),
-      }),
+      z
+        .object({
+          speakerId: z.string(),
+          topic: z.string().nullable(),
+          sentences: z.array(SentenceSchema),
+        })
+        .partial()
+        .passthrough(),
     ),
   })
   .partial()
@@ -143,6 +160,11 @@ async function getCalls(
       {
         filter: {
           ...params,
+        },
+        contentSelector: {
+          exposedFields: {
+            parties: true,
+          },
         },
       },
       {
@@ -242,7 +264,19 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
       callIds: calls.map(call => call.metaData?.id).filter((id): id is string => id !== undefined),
     });
     // Map speaker IDs to names in the transcripts
-    const userIdToNameMap = Object.fromEntries(gongUsers.map(user => [user.id, user.firstName + " " + user.lastName]));
+    const userIdToNameMap: Record<string, string> = {};
+    calls.forEach(call => {
+      // Check if call has parties array
+      if (call.parties && Array.isArray(call.parties)) {
+        // Iterate through each party in the call
+        call.parties.forEach(party => {
+          // Add the mapping of speakerId to name
+          if (party.speakerId && party.name) {
+            userIdToNameMap[party.speakerId] = party.name;
+          }
+        });
+      }
+    });
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
@@ -250,7 +284,7 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,
-          speakerName: userIdToNameMap[transcript.speakerId ?? ""],
+          speakerName: userIdToNameMap[transcript.speakerId ?? ""] ?? "Unknown",
         };
       });
       return currTranscript;

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -283,7 +283,7 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,
-          speakerName: userIdToNameMap[transcript.speakerId ?? ""] ?? "Unknown",
+          speakerName: userIdToNameMap[speakerId ?? ""] ?? "Unknown",
         };
       });
       return currTranscript;

--- a/src/actions/providers/gong/getGongTranscripts.ts
+++ b/src/actions/providers/gong/getGongTranscripts.ts
@@ -246,7 +246,6 @@ const getGongTranscripts: gongGetGongTranscriptsFunction = async ({
     const callTranscriptsWithNames = callTranscripts.map(callTranscript => {
       const currTranscript = { ...callTranscript };
       currTranscript.transcript = callTranscript.transcript?.map(transcript => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { speakerId, ...rest } = transcript;
         return {
           ...rest,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -3442,6 +3442,7 @@ actions:
                         description: The name of the speaker
                       topic:
                         type: string
+                        nullable: true
                         description: The topic of the transcript
                       sentences:
                         type: array

--- a/tests/gong/testGetGongTranscripts.ts
+++ b/tests/gong/testGetGongTranscripts.ts
@@ -28,9 +28,8 @@ async function runTest() {
     const firstTranscript = result.callTranscripts[0];
     assert(firstTranscript.callId, "Transcript should have a callId");
     assert(firstTranscript, "Transcript should have transcript data");
-    assert(firstTranscript.speakerNames, "Transcript should have speaker names");
-    assert(firstTranscript.topic, "Transcript should have a topic");
-    assert(Array.isArray(firstTranscript.sentences), "Transcript should have sentences array");
+    assert(firstTranscript.transcript[0].speakerName, "Transcript should have speaker names");
+    assert(Array.isArray(firstTranscript.transcript[0].sentences), "Transcript should have sentences array");
   }
 
   console.log("Test passed successfully!");

--- a/tests/gong/testGetGongTranscriptsMock.test.ts
+++ b/tests/gong/testGetGongTranscriptsMock.test.ts
@@ -50,8 +50,21 @@ describe("getGongTranscripts", () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {
         calls: [
-          { id: "call1", primaryUserId: "user1", started: "2024-01-02T00:00:00.000Z" },
-          { id: "call2", primaryUserId: "user2", started: "2024-01-02T00:00:00.000Z" },
+          {
+            metaData: { id: "call1", primaryUserId: "user1", started: "2024-01-02T00:00:00.000Z" },
+            parties: [{speakerId: "speaker1", name: "Joe Jonas"},
+                  {speakerId: "user1", name: "John Doe"},
+                  {speakerId: "user2", name: "Jane Doe"},
+            ],
+          },
+          {
+            metaData: { id: "call2", primaryUserId: "user2", started: "2024-01-02T00:00:00.000Z" },
+            parties: [
+              {speakerId: "speaker1", name: "Joe Jonas"},
+              {speakerId: "user1", name: "John Doe"},
+              {speakerId: "user2", name: "Jane Doe"},
+        ],
+          }
         ],
         cursor: null,
       },
@@ -97,6 +110,20 @@ describe("getGongTranscripts", () => {
             ],
             }],
           },
+          {
+            callId: "call2",
+            transcript: [{
+              speakerId: "speaker1",
+              topic: "Product Demo",
+              sentences: [
+                {
+                start: 0,
+                end: 10,
+                text: "Sick demo",
+              },
+            ],
+            }],
+          },
         ],
         cursor: null,     
       },
@@ -109,10 +136,11 @@ describe("getGongTranscripts", () => {
 
     expect(result.success).toBe(true);
     expect(result.callTranscripts).toBeDefined();
-    expect(result.callTranscripts).toHaveLength(2);
+    expect(result.callTranscripts).toHaveLength(3);
     expect(result.callTranscripts![0].callId).toBe("call1");
     expect(result.callTranscripts![0].transcript![0].speakerName).toEqual("John Doe");
     expect(result.callTranscripts![1].transcript![0].topic).toBe("Product Demo");
+    expect(result.callTranscripts![2].transcript![0].speakerName).toEqual("Joe Jonas");
   });
 
   it("should handle authentication error", async () => {
@@ -213,15 +241,24 @@ describe("getGongTranscripts", () => {
     // Mock calls response with pagination
     mockedAxios.post.mockResolvedValueOnce({
       data: {
-        calls: [
-          { id: "call1", primaryUserId: "user1", started: "2024-01-02T00:00:00.000Z" },
+        calls: [{
+          metaData: { id: "call1", primaryUserId: "user1", started: "2024-01-02T00:00:00.000Z" },
+          parties: [
+            { speakerId: "user1", name: "John Doe"},
+          ],
+        },
         ],
         cursor: "cursor2",
       },
     }).mockResolvedValueOnce({
       data: {
         calls: [
-          { id: "call2", primaryUserId: "user2", started: "2024-01-02T00:00:00.000Z" },
+          {
+            metaData: { id: "call2", primaryUserId: "user2", started: "2024-01-02T00:00:00.000Z" },
+            parties: [
+              {speakerId: "user2", name: "Jane Doe"},
+            ],
+          },
         ],
         cursor: null,
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances Gong integration by adding support for fetching call parties and mapping speaker IDs to names in transcripts.
> 
>   - **Behavior**:
>     - Adds `parties` field to `CallSchema` in `getGongTranscripts.ts` to fetch call participants.
>     - Updates `getCalls()` to include `parties` in the `contentSelector`.
>     - Maps `speakerId` to `speakerName` using `parties` data in `getGongTranscripts()`.
>   - **Schema**:
>     - Marks `topic` as nullable in `gongGetGongTranscriptsOutputSchema` in `types.ts` and `schema.yaml`.
>   - **Tests**:
>     - Updates `testGetGongTranscripts.ts` to check for `speakerName` and `sentences` in transcripts.
>     - Mocks `parties` data in `testGetGongTranscriptsMock.test.ts` to validate `speakerName` mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Factions-sdk&utm_source=github&utm_medium=referral)<sup> for 6bdb76528be009abcc571b5f1810b801a4e08337. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->