### PR TITLE
grabbing subdomain from params, not auth params for kandji actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -715,11 +715,15 @@ export const kandjiGetFVRecoveryKeyForDeviceDefinition: ActionTemplate = {
   scopes: [],
   parameters: {
     type: "object",
-    required: ["serialNumber"],
+    required: ["serialNumber", "subdomain"],
     properties: {
       serialNumber: {
         type: "string",
         description: "The serial number of the device",
+      },
+      subdomain: {
+        type: "string",
+        description: "The subdomain of the Kandji account",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -395,6 +395,7 @@ export type jiraGetJiraIssuesByQueryFunction = ActionFunction<
 
 export const kandjiGetFVRecoveryKeyForDeviceParamsSchema = z.object({
   serialNumber: z.string().describe("The serial number of the device"),
+  subdomain: z.string().describe("The subdomain of the Kandji account"),
 });
 
 export type kandjiGetFVRecoveryKeyForDeviceParamsType = z.infer<typeof kandjiGetFVRecoveryKeyForDeviceParamsSchema>;

--- a/src/actions/providers/kandji/getFVRecoveryKeyForDevice.ts
+++ b/src/actions/providers/kandji/getFVRecoveryKeyForDevice.ts
@@ -28,10 +28,10 @@ const getFVRecoveryKeyForDevice: kandjiGetFVRecoveryKeyForDeviceFunction = async
   params: kandjiGetFVRecoveryKeyForDeviceParamsType;
   authParams: AuthParamsType;
 }): Promise<kandjiGetFVRecoveryKeyForDeviceOutputType> => {
-  const { serialNumber } = params;
-  const { subdomain, apiKey } = authParams;
-  if (!apiKey || !subdomain) {
-    throw new Error("Missing API key or subdomain in auth parameters");
+  const { serialNumber, subdomain } = params;
+  const { apiKey } = authParams;
+  if (!apiKey) {
+    throw new Error("Missing API key in auth parameters");
   }
   try {
     // First list all devices to get the device for the specific device

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -514,11 +514,14 @@ actions:
       scopes: []
       parameters:
         type: object
-        required: [serialNumber]
+        required: [serialNumber, subdomain]
         properties:
           serialNumber:
             type: string
             description: The serial number of the device
+          subdomain:
+            type: string
+            description: The subdomain of the Kandji account
       output:
         type: object
         required: [success]


### PR DESCRIPTION
Kandji has api connect and Nango cannot validate the scoped key, therefore we have to pass in the subdomain as a parameter 