### PR TITLE
Add additional fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1723,6 +1723,10 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
         type: "number",
         description: "A limit on the number of rows to return",
       },
+      codeInterpreterLimit: {
+        type: "number",
+        description: "A minimum number of rows required to pass to code interpreter (if enabled)",
+      },
     },
   },
   output: {
@@ -1741,6 +1745,10 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
       rowCount: {
         type: "number",
         description: "The number of rows returned by the query",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the query results failed or were limited",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -917,6 +917,10 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
   accountName: z.string().describe("The name of the Snowflake account"),
   outputFormat: z.enum(["json", "csv"]).describe("The format of the output").optional(),
   limit: z.number().describe("A limit on the number of rows to return").optional(),
+  codeInterpreterLimit: z
+    .number()
+    .describe("A minimum number of rows required to pass to code interpreter (if enabled)")
+    .optional(),
 });
 
 export type snowflakeRunSnowflakeQueryParamsType = z.infer<typeof snowflakeRunSnowflakeQueryParamsSchema>;
@@ -925,6 +929,7 @@ export const snowflakeRunSnowflakeQueryOutputSchema = z.object({
   format: z.enum(["json", "csv"]).describe("The format of the output"),
   content: z.string().describe("The content of the query result (json)"),
   rowCount: z.number().describe("The number of rows returned by the query"),
+  error: z.string().describe("The error that occurred if the query results failed or were limited").optional(),
 });
 
 export type snowflakeRunSnowflakeQueryOutputType = z.infer<typeof snowflakeRunSnowflakeQueryOutputSchema>;

--- a/src/actions/providers/snowflake/runSnowflakeQuery.ts
+++ b/src/actions/providers/snowflake/runSnowflakeQuery.ts
@@ -71,6 +71,7 @@ const runSnowflakeQuery: snowflakeRunSnowflakeQueryFunction = async ({
       rowCount: resultsLength,
       content: formattedData,
       format: outputFormat,
+      error: limit && limit < resultsLength ? `Query results truncated to ${limit} rows.` : undefined,
     };
   } catch (error: unknown) {
     connection.destroy(err => {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1221,6 +1221,9 @@ actions:
           limit:
             type: number
             description: A limit on the number of rows to return
+          codeInterpreterLimit:
+            type: number
+            description: A minimum number of rows required to pass to code interpreter (if enabled)
       output:
         type: object
         required: [format, content, rowCount]
@@ -1235,6 +1238,9 @@ actions:
           rowCount:
             type: number
             description: The number of rows returned by the query
+          error: 
+            type: string
+            description: The error that occurred if the query results failed or were limited
   openstreetmap:
     getLatitudeLongitudeFromLocation:
       description: Get the latitude and longitude of a location


### PR DESCRIPTION
### Summary of Changes:
- There's a high level of flakiness with code interpreter when it has a small set of results.
- Typically it works fine but in some cases it just doesn't return as expected (see image below)
- Just adding @Credal.ai makes the second query fail (an issue as we need to support slack)

### Fix:
- As code interpreter is being sunsetted there's no permanent fix for this
- Right now if we have <=2 rows we don't use code interpreter 
- This PR is to make that configurable so I don't need to deploy to retest and we can tweak per use-case

### Note:
- The error message is just an added note to let the LLM know when we go over our set limit

<img width="1351" alt="Screenshot 2025-05-14 at 9 36 35 AM" src="https://github.com/user-attachments/assets/78e42669-328f-4922-aaa8-2ff8bd186294" />
