### PR TITLE
[Image Check]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1727,6 +1727,12 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
         type: "number",
         description: "A minimum number of rows required to pass to code interpreter (if enabled)",
       },
+      generateImageViaCodeInterpreter: {
+        enum: [true, false],
+        type: "boolean",
+        description:
+          "Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached",
+      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -921,6 +921,12 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
     .number()
     .describe("A minimum number of rows required to pass to code interpreter (if enabled)")
     .optional(),
+  generateImageViaCodeInterpreter: z
+    .union([z.literal(true), z.literal(false)])
+    .describe(
+      "Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached",
+    )
+    .optional(),
 });
 
 export type snowflakeRunSnowflakeQueryParamsType = z.infer<typeof snowflakeRunSnowflakeQueryParamsSchema>;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1224,6 +1224,10 @@ actions:
           codeInterpreterLimit:
             type: number
             description: A minimum number of rows required to pass to code interpreter (if enabled)
+          generateImageViaCodeInterpreter:
+            enum: [true, false]
+            type: boolean
+            description: Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached
       output:
         type: object
         required: [format, content, rowCount]


### PR DESCRIPTION
### Changes:
For the snowflake action as we move to using more reliable thinking models.
Customers still want the option to have code interpreter generate an image to go along with the response.

If this is the case then we should allow an enum to toggle image generation
- If the toggle is enabled we'll run code interpreter but only take the images generated as part of our response.

### Note:
- heading in the direction that we let the thinking models do the actual work and only use code interpreter to generate images associated with the results.