### PR TITLE
More configuration - Code Interpreter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "AI Actions by Credal AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1725,13 +1725,13 @@ export const snowflakeRunSnowflakeQueryDefinition: ActionTemplate = {
       },
       codeInterpreterLimit: {
         type: "number",
-        description: "A minimum number of rows required to pass to code interpreter (if enabled)",
-      },
-      generateImageViaCodeInterpreter: {
-        enum: [true, false],
-        type: "boolean",
         description:
-          "Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached",
+          "A minimum number of rows required to pass to code interpreter for analysis and image generation (if enabled)",
+      },
+      codeInterpreterImageGenLimit: {
+        type: "number",
+        description:
+          "A minimum number of rows required to pass to code interpreter for image generation only (if enabled)",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -919,13 +919,13 @@ export const snowflakeRunSnowflakeQueryParamsSchema = z.object({
   limit: z.number().describe("A limit on the number of rows to return").optional(),
   codeInterpreterLimit: z
     .number()
-    .describe("A minimum number of rows required to pass to code interpreter (if enabled)")
-    .optional(),
-  generateImageViaCodeInterpreter: z
-    .union([z.literal(true), z.literal(false)])
     .describe(
-      "Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached",
+      "A minimum number of rows required to pass to code interpreter for analysis and image generation (if enabled)",
     )
+    .optional(),
+  codeInterpreterImageGenLimit: z
+    .number()
+    .describe("A minimum number of rows required to pass to code interpreter for image generation only (if enabled)")
     .optional(),
 });
 

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1223,11 +1223,10 @@ actions:
             description: A limit on the number of rows to return
           codeInterpreterLimit:
             type: number
-            description: A minimum number of rows required to pass to code interpreter (if enabled)
-          generateImageViaCodeInterpreter:
-            enum: [true, false]
-            type: boolean
-            description: Whether we should try to generate an image with results via code interpreter, regardless of if the codeInterpreter limit is reached
+            description: A minimum number of rows required to pass to code interpreter for analysis and image generation (if enabled)
+          codeInterpreterImageGenLimit:
+            type: number
+            description: A minimum number of rows required to pass to code interpreter for image generation only (if enabled)
       output:
         type: object
         required: [format, content, rowCount]


### PR DESCRIPTION

- Small Nit: 
- To make it more configurable we should allow when we want image generation with code interpreter (> 5 results)
- Right now image generation will try to run for all results even if we have 1/2 (pretty bad) 
- Code interpreter will have 2 limits (one needed to run for analysis + image gen) + one needed to run just for image gen.