### PR TITLE
[new action] Notion search by title

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -157,6 +157,8 @@ import {
   asanaSearchTasksOutputSchema,
   asanaGetTasksDetailsParamsSchema,
   asanaGetTasksDetailsOutputSchema,
+  notionSearchByTitleParamsSchema,
+  notionSearchByTitleOutputSchema,
 } from "./autogen/types";
 import callCopilot from "./providers/credal/callCopilot";
 import validateAddress from "./providers/googlemaps/validateAddress";
@@ -238,6 +240,8 @@ import { gongGetGongTranscriptsParamsSchema, gongGetGongTranscriptsOutputSchema 
 import getFVRecoveryKeyForDevice from "./providers/kandji/getFVRecoveryKeyForDevice";
 import listAsanaTasksByProject from "./providers/asana/listAsanaTasksByProject";
 import getTasksDetails from "./providers/asana/getTasksDetails";
+import searchByTitle from "./providers/notion/searchByTitle";
+
 interface ActionFunctionComponents {
   // eslint-disable-next-line
   fn: ActionFunction<any, any, any>;
@@ -693,6 +697,13 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: listPullRequests,
       paramsSchema: githubListPullRequestsParamsSchema,
       outputSchema: githubListPullRequestsOutputSchema,
+    },
+  },
+  notion: {
+    searchByTitle: {
+      fn: searchByTitle,
+      paramsSchema: notionSearchByTitleParamsSchema,
+      outputSchema: notionSearchByTitleOutputSchema,
     },
   },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -6758,3 +6758,56 @@ export const googleDriveSearchFilesByKeywordsDefinition: ActionTemplate = {
   name: "searchFilesByKeywords",
   provider: "googleDrive",
 };
+export const notionSearchByTitleDefinition: ActionTemplate = {
+  description: "Search Notion pages and databases by title",
+  scopes: [],
+  parameters: {
+    type: "object",
+    required: ["query"],
+    properties: {
+      query: {
+        type: "string",
+        description: "The query to search for in Notion titles",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the search was successful",
+      },
+      results: {
+        type: "array",
+        description: "List of matching Notion pages",
+        items: {
+          type: "object",
+          required: ["id", "url"],
+          properties: {
+            id: {
+              type: "string",
+              description: "The Notion page ID",
+            },
+            title: {
+              type: "string",
+              description: "The page title",
+              nullable: true,
+            },
+            url: {
+              type: "string",
+              description: "The URL to the Notion page",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if search failed",
+      },
+    },
+  },
+  name: "searchByTitle",
+  provider: "notion",
+};

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -3542,3 +3542,31 @@ export type googleDriveSearchFilesByKeywordsFunction = ActionFunction<
   AuthParamsType,
   googleDriveSearchFilesByKeywordsOutputType
 >;
+
+export const notionSearchByTitleParamsSchema = z.object({
+  query: z.string().describe("The query to search for in Notion titles"),
+});
+
+export type notionSearchByTitleParamsType = z.infer<typeof notionSearchByTitleParamsSchema>;
+
+export const notionSearchByTitleOutputSchema = z.object({
+  success: z.boolean().describe("Whether the search was successful"),
+  results: z
+    .array(
+      z.object({
+        id: z.string().describe("The Notion page ID"),
+        title: z.string().nullable().describe("The page title").optional(),
+        url: z.string().describe("The URL to the Notion page"),
+      }),
+    )
+    .describe("List of matching Notion pages")
+    .optional(),
+  error: z.string().describe("Error message if search failed").optional(),
+});
+
+export type notionSearchByTitleOutputType = z.infer<typeof notionSearchByTitleOutputSchema>;
+export type notionSearchByTitleFunction = ActionFunction<
+  notionSearchByTitleParamsType,
+  AuthParamsType,
+  notionSearchByTitleOutputType
+>;

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -77,6 +77,7 @@ import {
   gongGetGongTranscriptsDefinition,
   kandjiGetFVRecoveryKeyForDeviceDefinition,
   asanaListAsanaTasksByProjectDefinition,
+  notionSearchByTitleDefinition,
 } from "../actions/autogen/templates";
 import type { ActionTemplate } from "../actions/parse";
 
@@ -257,5 +258,9 @@ export const ACTION_GROUPS: ActionGroups = {
       ashbyUpdateCandidateDefinition,
       ashbyAddCandidateToProjectDefinition,
     ],
+  },
+  NOTION: {
+    description: "Actions for interacting with Notion",
+    actions: [notionSearchByTitleDefinition],
   },
 };

--- a/src/actions/providers/notion/searchByTitle.ts
+++ b/src/actions/providers/notion/searchByTitle.ts
@@ -1,0 +1,106 @@
+import type {
+  AuthParamsType,
+  notionSearchByTitleFunction,
+  notionSearchByTitleOutputType,
+  notionSearchByTitleParamsType,
+} from "../../autogen/types";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants";
+import axios from "axios";
+
+interface NotionResult {
+  object: "database";
+  id: string;
+  url: string;
+  title?: { plain_text: string }[];
+  properties: {
+    [key: string]: {
+      type: string;
+      title?: { plain_text: string }[];
+      rich_text?: { plain_text: string }[];
+    };
+  };
+}
+
+interface SearchResult {
+  id: string;
+  title: string;
+  url: string;
+}
+
+// Notion response is not standard for title, title can be in different places
+// This function checks if the title is in the properties object
+function isTitleProperty(prop: unknown): prop is { type: string; title: { plain_text: string }[] } {
+  return (
+    typeof prop === "object" &&
+    prop !== null &&
+    "type" in prop &&
+    (prop as { type: string }).type === "title" &&
+    "title" in prop &&
+    Array.isArray((prop as { title: unknown }).title)
+  );
+}
+
+const searchByTitle: notionSearchByTitleFunction = async ({
+  params,
+  authParams,
+}: {
+  params: notionSearchByTitleParamsType;
+  authParams: AuthParamsType;
+}): Promise<notionSearchByTitleOutputType> => {
+  const { authToken } = authParams;
+  const { query } = params;
+
+  if (!authToken) {
+    return { success: false, error: MISSING_AUTH_TOKEN, results: [] };
+  }
+
+  try {
+    const response = await axios.post(
+      "https://api.notion.com/v1/search",
+      { query },
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          "Notion-Version": "2022-06-28",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    const { results: notionResults = [] } = response.data;
+
+    const results: SearchResult[] =
+      (notionResults as NotionResult[]).map((item: NotionResult): SearchResult => {
+        let title = "";
+
+        // Try to find a title property in properties (for pages)
+        if (item.properties) {
+          const titleProp = Object.values(item.properties).find(isTitleProperty);
+          if (titleProp && Array.isArray(titleProp.title)) {
+            title = titleProp.title.map(t => t.plain_text).join("") || "";
+          }
+        }
+
+        // If still no title, try item.title (for databases)
+        if (!title && Array.isArray(item.title)) {
+          title = item.title.map(t => t.plain_text).join("") || "";
+        }
+
+        return {
+          id: item.id,
+          title,
+          url: item.url,
+        };
+      }) || [];
+
+    return { success: true, results };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      results: [],
+    };
+  }
+};
+
+export default searchByTitle;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -4712,3 +4712,41 @@ actions:
           error:
             type: string
             description: Error message if search failed
+  notion:
+    searchByTitle:
+      description: Search Notion pages and databases by title
+      scopes: []
+      parameters:
+        type: object
+        required: [query]
+        properties:
+          query:
+            type: string
+            description: The query to search for in Notion titles
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the search was successful
+          results:
+            type: array
+            description: List of matching Notion pages
+            items:
+              type: object
+              required: [id, url]
+              properties:
+                id:
+                  type: string
+                  description: The Notion page ID
+                title:
+                  type: string
+                  description: The page title
+                  nullable: true
+                url:
+                  type: string
+                  description: The URL to the Notion page
+          error:
+            type: string
+            description: Error message if search failed

--- a/tests/notion/testNotionSearchByTitle.ts
+++ b/tests/notion/testNotionSearchByTitle.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app";
+
+async function runTest() {
+  const result = await runAction(
+    "searchByTitle",
+    "notion",
+    { authToken: "replace-me-with-token" },
+    { query: "replace-me-withsearch-query" }
+  );
+
+  assert(result, "Response should not be null");
+  assert(result.success, "Success should be true");
+  assert(Array.isArray(result.results), "Results should be an array");
+  console.log("Notion search results:", result.results);
+}
+
+runTest().catch((error) => {
+ console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
Basic action to return search results, up to 100. No paging implemented

how to get a testing token:
followed this: https://developers.notion.com/docs/authorization#set-up-the-auth-flow-for-a-public-integration
- there are 2 versions, i just did internal for testing purposes
steps for internal integration:
- make an integration https://www.notion.so/profile/integrations
- press edit or get to settings
- copy Internal Integration Secret to use as your token for testing
- you have to manually add your integration to pages/databases on notion https://www.notion.com/help/add-and-manage-connections-with-the-api#add-connections-to-pages
- go to page -> 3dots -> connections -> select your integration

test:
```
lindali@Lindas-MacBook-Air actions-sdk % npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/notion/testNotionSearchByTitle.ts
(node:81309) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Notion search results: [
  {
    id: '1f8aef65-d625-802a-8031-cfbd8c35c0a8',
    title: 'test-search-query',
    url: 'https://www.notion.so/1f8aef65d625802a8031cfbd8c35c0a8'
  },
  {
    id: '1f8aef65-d625-80c3-9e53-f68f3d3d0d5b',
    title: 'Feature Requests',
    url: 'https://www.notion.so/1f8aef65d62580c39e53f68f3d3d0d5b'
  },
  {
    id: '1f8aef65-d625-80d3-b36d-f8af907beb85',
    title: 'test-search-query',
    url: 'https://www.notion.so/test-search-query-1f8aef65d62580d3b36df8af907beb85'
  },
  {
    id: '1f8aef65-d625-8033-9eef-e03446cfb21c',
    title: 'test-search-query',
    url: 'https://www.notion.so/test-search-query-1f8aef65d62580339eefe03446cfb21c'
  },
  {
    id: '1f8aef65-d625-80ab-aa7c-e0bd614b4b7f',
    title: 'test-search-query',
    url: 'https://www.notion.so/test-search-query-1f8aef65d62580abaa7ce0bd614b4b7f'
  }
]
```