### PR TITLE
[new action] Google Calendar Move Event

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -95,6 +95,8 @@ import {
   googleOauthUpdatePresentationOutputSchema,
   googleOauthSearchDriveByKeywordsParamsSchema,
   googleOauthSearchDriveByKeywordsOutputSchema,
+  googleOauthMoveCalendarEventParamsSchema,
+  googleOauthMoveCalendarEventOutputSchema,
   googleOauthListGroupsOutputSchema,
   googleOauthListGroupsParamsSchema,
   googleOauthGetGroupOutputSchema,
@@ -233,6 +235,7 @@ import listCalendars from "./providers/google-oauth/listCalendars";
 import listCalendarEvents from "./providers/google-oauth/listCalendarEvents";
 import updateCalendarEvent from "./providers/google-oauth/updateCalendarEvent";
 import deleteCalendarEvent from "./providers/google-oauth/deleteCalendarEvent";
+import moveCalendarEvent from "./providers/google-oauth/moveCalendarEvent";
 import createSpreadsheet from "./providers/google-oauth/createSpreadsheet";
 import updateSpreadsheet from "./providers/google-oauth/updateSpreadsheet";
 import createPresentation from "./providers/google-oauth/createPresentation";
@@ -272,9 +275,6 @@ import getTasksDetails from "./providers/asana/getTasksDetails";
 import searchByTitle from "./providers/notion/searchByTitle";
 import searchGmailMessages from "./providers/googlemail/searchGmailMessages";
 import listGmailThreads from "./providers/googlemail/listGmailThreads";
-// import listCalendarEvents from "./providers/google-oauth/listCalendarEvents";
-// import updateCalendarEvent from "./providers/google-oauth/updateCalendarEvent";
-// import deleteCalendarEvent from "./providers/google-oauth/deleteCalendarEvent";
 import listGroups from "./providers/google-oauth/listGroups";
 import getGroup from "./providers/google-oauth/getGroup";
 import listGroupMembers from "./providers/google-oauth/listGroupMembers";
@@ -601,6 +601,11 @@ export const ActionMapper: Record<string, Record<string, ActionFunctionComponent
       fn: deleteCalendarEvent,
       paramsSchema: googleOauthDeleteCalendarEventParamsSchema,
       outputSchema: googleOauthDeleteCalendarEventOutputSchema,
+    },
+    moveCalendarEvent: {
+      fn: moveCalendarEvent,
+      paramsSchema: googleOauthMoveCalendarEventParamsSchema,
+      outputSchema: googleOauthMoveCalendarEventOutputSchema,
     },
     listGroups: {
       fn: listGroups,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -3636,20 +3636,6 @@ export const googleOauthUpdateCalendarEventDefinition: ActionTemplate = {
             type: "string",
             description: "The new status of the event (e.g., confirmed, cancelled)",
           },
-          organizer: {
-            type: "object",
-            description: "The new organizer of the event",
-            properties: {
-              email: {
-                type: "string",
-                description: "The organizer's email address",
-              },
-              displayName: {
-                type: "string",
-                description: "The organizer's name",
-              },
-            },
-          },
         },
       },
     },
@@ -3711,6 +3697,48 @@ export const googleOauthDeleteCalendarEventDefinition: ActionTemplate = {
     },
   },
   name: "deleteCalendarEvent",
+  provider: "googleOauth",
+};
+export const googleOauthMoveCalendarEventDefinition: ActionTemplate = {
+  description: "Moves an event to another calendar, i.e. changes an event's organizer.",
+  scopes: ["https://www.googleapis.com/auth/calendar"],
+  parameters: {
+    type: "object",
+    required: ["calendarId", "eventId", "destination"],
+    properties: {
+      calendarId: {
+        type: "string",
+        description: "The ID of the source calendar containing the event",
+      },
+      eventId: {
+        type: "string",
+        description: "The ID of the event to move",
+      },
+      destination: {
+        type: "string",
+        description: "The ID of the destination calendar to move the event to",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the event was moved successfully",
+      },
+      eventId: {
+        type: "string",
+        description: "The ID of the moved event in the destination calendar",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the event was not moved successfully",
+      },
+    },
+  },
+  name: "moveCalendarEvent",
   provider: "googleOauth",
 };
 export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1875,13 +1875,6 @@ export const googleOauthUpdateCalendarEventParamsSchema = z.object({
         .describe("The new list of attendees")
         .optional(),
       status: z.string().describe("The new status of the event (e.g., confirmed, cancelled)").optional(),
-      organizer: z
-        .object({
-          email: z.string().describe("The organizer's email address").optional(),
-          displayName: z.string().describe("The organizer's name").optional(),
-        })
-        .describe("The new organizer of the event")
-        .optional(),
     })
     .describe("The fields to update on the event")
     .optional(),
@@ -1920,6 +1913,27 @@ export type googleOauthDeleteCalendarEventFunction = ActionFunction<
   googleOauthDeleteCalendarEventParamsType,
   AuthParamsType,
   googleOauthDeleteCalendarEventOutputType
+>;
+
+export const googleOauthMoveCalendarEventParamsSchema = z.object({
+  calendarId: z.string().describe("The ID of the source calendar containing the event"),
+  eventId: z.string().describe("The ID of the event to move"),
+  destination: z.string().describe("The ID of the destination calendar to move the event to"),
+});
+
+export type googleOauthMoveCalendarEventParamsType = z.infer<typeof googleOauthMoveCalendarEventParamsSchema>;
+
+export const googleOauthMoveCalendarEventOutputSchema = z.object({
+  success: z.boolean().describe("Whether the event was moved successfully"),
+  eventId: z.string().describe("The ID of the moved event in the destination calendar").optional(),
+  error: z.string().describe("The error that occurred if the event was not moved successfully").optional(),
+});
+
+export type googleOauthMoveCalendarEventOutputType = z.infer<typeof googleOauthMoveCalendarEventOutputSchema>;
+export type googleOauthMoveCalendarEventFunction = ActionFunction<
+  googleOauthMoveCalendarEventParamsType,
+  AuthParamsType,
+  googleOauthMoveCalendarEventOutputType
 >;
 
 export const googleOauthCreateSpreadsheetParamsSchema = z.object({

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -54,6 +54,7 @@ import {
   googleOauthHasGroupMemberDefinition,
   googleOauthAddGroupMemberDefinition,
   googleOauthDeleteGroupMemberDefinition,
+  googleOauthMoveCalendarEventDefinition,
   salesforceUpdateRecordDefinition,
   salesforceCreateCaseDefinition,
   salesforceGenerateSalesReportDefinition,
@@ -148,6 +149,7 @@ export const ACTION_GROUPS: ActionGroups = {
       googleOauthListCalendarEventsDefinition,
       googleOauthUpdateCalendarEventDefinition,
       googleOauthDeleteCalendarEventDefinition,
+      googleOauthMoveCalendarEventDefinition,
     ],
   },
   GMAIL: {

--- a/src/actions/providers/google-oauth/moveCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/moveCalendarEvent.ts
@@ -1,0 +1,49 @@
+import { axiosClient } from "../../util/axiosClient";
+import type { AxiosResponse } from "axios";
+import type {
+  AuthParamsType,
+  googleOauthMoveCalendarEventFunction,
+  googleOauthMoveCalendarEventOutputType,
+  googleOauthMoveCalendarEventParamsType,
+} from "../../autogen/types";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants";
+
+const moveCalendarEvent: googleOauthMoveCalendarEventFunction = async ({
+  params,
+  authParams,
+}: {
+  params: googleOauthMoveCalendarEventParamsType;
+  authParams: AuthParamsType;
+}): Promise<googleOauthMoveCalendarEventOutputType> => {
+  if (!authParams.authToken) {
+    return { success: false, error: MISSING_AUTH_TOKEN };
+  }
+
+  const { calendarId, eventId, destination } = params;
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/move`;
+
+  try {
+    const res: AxiosResponse = await axiosClient.post(
+      url,
+      {},
+      {
+        params: { destination },
+        headers: {
+          Authorization: `Bearer ${authParams.authToken}`,
+        },
+      },
+    );
+
+    return {
+      success: true,
+      eventId: res.data.id,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error moving event",
+    };
+  }
+};
+
+export default moveCalendarEvent;

--- a/src/actions/providers/google-oauth/updateCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/updateCalendarEvent.ts
@@ -31,7 +31,6 @@ const updateCalendarEvent: googleOauthUpdateCalendarEventFunction = async ({
     if (updates.location != undefined) body.location = updates.location;
     if (updates.attendees != undefined) body.attendees = updates.attendees.map(email => ({ email }));
     if (updates.status != undefined) body.status = updates.status;
-    if (updates.organizer != undefined) body.organizer = updates.organizer;
   }
 
   try {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2572,16 +2572,6 @@ actions:
               status:
                 type: string
                 description: The new status of the event (e.g., confirmed, cancelled)
-              organizer:
-                type: object
-                description: The new organizer of the event
-                properties:
-                  email:
-                    type: string
-                    description: The organizer's email address
-                  displayName:
-                    type: string
-                    description: The organizer's name
       output:
         type: object
         required: [success]
@@ -2621,6 +2611,35 @@ actions:
           error:
             type: string
             description: The error that occurred if the event was not deleted successfully    
+    moveCalendarEvent:
+      description: Moves an event to another calendar, i.e. changes an event's organizer.
+      scopes: [https://www.googleapis.com/auth/calendar]
+      parameters:
+        type: object
+        required: [calendarId, eventId, destination]
+        properties:
+          calendarId:
+            type: string
+            description: The ID of the source calendar containing the event
+          eventId:
+            type: string
+            description: The ID of the event to move
+          destination:
+            type: string
+            description: The ID of the destination calendar to move the event to
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the event was moved successfully
+          eventId:
+            type: string
+            description: The ID of the moved event in the destination calendar
+          error:
+            type: string
+            description: The error that occurred if the event was not moved successfully
     createSpreadsheet:
       description: Create a new Google Spreadsheet using OAuth authentication
       scopes: []

--- a/tests/google-oauth/testListCalendarEvents.ts
+++ b/tests/google-oauth/testListCalendarEvents.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 async function runTest() {
   const result = await runAction(
     "listCalendarEvents",
     "googleOauth",
-    { authToken: "auth-token-with-calendar-scope-here" },
-    { calendarId: "primary", query: "optional-query-here", maxResults: 2 },
+    { authToken: process.env.GOOGLE_OAUTH_TOKEN },
+    { 
+      //calendarId: "3a58a7f80c9adaec6a702c633074028819a1afb276a4a71a426d19f839bb1806@group.calendar.google.com", 
+      calendarId: "c_9a07134ac35093f256190066da3f65a075c321a7a1cb2e6848168d815d5f3602@group.calendar.google.com",
+      query: "move", 
+      maxResults: 3
+    },
   );
 
   assert(result, "Response should not be null");
@@ -16,7 +24,6 @@ async function runTest() {
   const first = result.events[0];
   if (first) {
     assert(typeof first.id === "string" && first.id.length > 0, "Event should have an id");
-    assert(typeof first.title === "string", "Event should have a title");
     assert(typeof first.status === "string", "Event should have a status");
     assert(typeof first.url === "string", "Event should have a url");
     assert(typeof first.start === "string", "Event should have a start");

--- a/tests/google-oauth/testListCalendarEvents.ts
+++ b/tests/google-oauth/testListCalendarEvents.ts
@@ -10,8 +10,7 @@ async function runTest() {
     "googleOauth",
     { authToken: process.env.GOOGLE_OAUTH_TOKEN },
     { 
-      //calendarId: "3a58a7f80c9adaec6a702c633074028819a1afb276a4a71a426d19f839bb1806@group.calendar.google.com", 
-      calendarId: "c_9a07134ac35093f256190066da3f65a075c321a7a1cb2e6848168d815d5f3602@group.calendar.google.com",
+      calendarId: process.env.GOOGLE_CALENDAR_ID || "primary",
       query: "move", 
       maxResults: 3
     },

--- a/tests/google-oauth/testMoveCalendarEvent.ts
+++ b/tests/google-oauth/testMoveCalendarEvent.ts
@@ -12,7 +12,7 @@ async function runTest() {
     {
       calendarId: process.env.GOOGLE_CALENDAR_ID || "primary",
       eventId: process.env.GOOGLE_EVENT_ID,
-      destination: process.env.GOOGLE_CALENDAR_DESINATION_ID,
+      destination: process.env.GOOGLE_CALENDAR_DESTINATION_ID,
     },
   );
 

--- a/tests/google-oauth/testMoveCalendarEvent.ts
+++ b/tests/google-oauth/testMoveCalendarEvent.ts
@@ -6,21 +6,22 @@ dotenv.config();
 
 async function runTest() {
   const result = await runAction(
-    "listCalendars",
+    "moveCalendarEvent",
     "googleOauth",
     { authToken: process.env.GOOGLE_OAUTH_TOKEN },
-    { maxResults: 5 }, // optional
+    {
+      calendarId: process.env.GOOGLE_CALENDAR_ID || "primary",
+      eventId: process.env.GOOGLE_EVENT_ID,
+      destination: process.env.GOOGLE_CALENDAR_DESINATION_ID,
+    },
   );
 
+  console.log("Response: ", result);
   assert(result, "Response should not be null");
   assert(result.success, "Success should be true");
-  assert(Array.isArray(result.calendars), "Calendars should be an array");
-  if (result.calendars.length > 0) {
-    assert(result.calendars[0].id, "Calendar should have an id");
-    assert(result.calendars[0].summary, "Calendar should have a summary");
-  }
-  console.log(`Successfully listed ${result.calendars.length} calendars`);
-  console.log("Response: ", result);
+  assert(typeof result.eventId === "string" && result.eventId.length > 0, "Should return eventId");
+  assert(typeof result.eventUrl === "string" && result.eventUrl.length > 0, "Should return eventUrl");
+  console.log(`Successfully moved event: ${result.eventId}`);
 }
 
 runTest().catch((error) => {

--- a/tests/google-oauth/testUpdateCalendarEvent.ts
+++ b/tests/google-oauth/testUpdateCalendarEvent.ts
@@ -1,14 +1,18 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app";
+import dotenv from "dotenv";
+
+
+dotenv.config();
 
 async function runTest() {
   const result = await runAction(
     "updateCalendarEvent",
     "googleOauth",
-    { authToken: "auth-token-with-calendar-scope-here" },
+    { authToken: process.env.GOOGLE_OAUTH_TOKEN },
     {
-      calendarId: "primary",
-      eventId: "event-id-here", 
+      calendarId: process.env.GOOGLE_CALENDAR_ID || "primary",
+      eventId: process.env.GOOGLE_CALENDAR_EVENT_ID, 
       updates: {
         title: "Updated Event Title",
         description: "Updated event description",


### PR DESCRIPTION
implements calendar section in https://docs.google.com/spreadsheets/d/1zFmIEZP6n_-7mQIBNNCIk16o7kyHFN1pc5r4ZUYlMCQ/edit?gid=0#gid=0

- edits update event (implementation incorrectly tried to update organizer, but API actually doesn't let you)
- adds move action to move an event to a destination calendar
  - this process updates the organizer 
  - covers case in document where user wants to takeover someone's event who has left the org
  - note that the user must have the correct permissions to move the event
  - https://developers.google.com/workspace/calendar/api/v3/reference/events/move

```
lindali@Lindas-MacBook-Air actions-sdk % npm run test tests/google-oauth/testMoveCalendarEvent.ts

> @credal/actions@0.1.99 test
> npx ts-node -r tsconfig-paths/register --project tsconfig.json tests/google-oauth/testMoveCalendarEvent.ts

Response:  {
  success: true,
  eventId: '2cques3j9n1mlkipl0f18h4jr0',
}
Successfully moved event: 2cques3j9n1mlkipl0f18h4jr0
``` 