### PR TITLE
tweak the forge import and pray

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/snowflake/auth/getSnowflakeConnection.ts
+++ b/src/actions/providers/snowflake/auth/getSnowflakeConnection.ts
@@ -1,7 +1,7 @@
 import type { AuthParamsType } from "../../../autogen/types.js";
 import type { Connection } from "snowflake-sdk";
 import snowflake from "snowflake-sdk";
-import * as forge from "node-forge";
+import forge from "node-forge";
 
 const getPrivateKeyCorrectFormat = (privateKey: string): string => {
   try {


### PR DESCRIPTION
Somehow in staging/prod (but not locally), snowflake actions break with the error:
`Error processing private key: TypeError: Cannot read properties of undefined (reading 'decode')                                                                       at getPrivateKeyCorrectFormat (file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/auth/getSnowflakeConnection.js:15:34)                at getSnowflakeConnection (file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/auth/getSnowflakeConnection.js:40:47)                    at file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/runSnowflakeQuery.js:39:24                                                       at Generator.next (<anonymous>)                                                                                                                               
    at file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/runSnowflakeQuery.js:7:71                                                        at new Promise (<anonymous>)                                                                                                                                      at __awaiter (file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/runSnowflakeQuery.js:3:12)                                        
    at runSnowflakeQuery (file:///opt/app/node_modules/@credal/actions/dist/actions/providers/snowflake/runSnowflakeQuery.js:14:35)                               
    at file:///opt/app/node_modules/@credal/actions/dist/actions/invoke.js:22:16                                                                                  
    at Generator.next (<anonymous>)`

Because I can't test this locally, I'm just tweaking and seeing if things work in staging.