### PR TITLE
Add timerange to gcal list calendar events query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -3420,6 +3420,16 @@ export const googleOauthListCalendarEventsDefinition: ActionTemplate = {
         type: "integer",
         description: "Maximum number of events to return, defaults to 250",
       },
+      timeMin: {
+        type: "string",
+        description:
+          "Optional lower bound (exclusive) for an event's end time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.",
+      },
+      timeMax: {
+        type: "string",
+        description:
+          "Optional upper bound (exclusive) for an event's start time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.",
+      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1812,6 +1812,18 @@ export const googleOauthListCalendarEventsParamsSchema = z.object({
   calendarId: z.string().describe("The ID of the calendar to list events from"),
   query: z.string().describe("Optional free-text search query to filter events").optional(),
   maxResults: z.number().int().describe("Maximum number of events to return, defaults to 250").optional(),
+  timeMin: z
+    .string()
+    .describe(
+      "Optional lower bound (exclusive) for an event's end time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.",
+    )
+    .optional(),
+  timeMax: z
+    .string()
+    .describe(
+      "Optional upper bound (exclusive) for an event's start time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.",
+    )
+    .optional(),
 });
 
 export type googleOauthListCalendarEventsParamsType = z.infer<typeof googleOauthListCalendarEventsParamsSchema>;

--- a/src/actions/providers/google-oauth/listCalendarEvents.ts
+++ b/src/actions/providers/google-oauth/listCalendarEvents.ts
@@ -19,7 +19,7 @@ const listCalendarEvents: googleOauthListCalendarEventsFunction = async ({
     return { success: false, error: MISSING_AUTH_TOKEN, events: [] };
   }
 
-  const { calendarId, query, maxResults } = params;
+  const { calendarId, query, maxResults, timeMin, timeMax } = params;
   const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`;
   const allEvents: googleOauthListCalendarEventsOutputType["events"] = [];
   let pageToken: string | undefined = undefined;
@@ -38,6 +38,8 @@ const listCalendarEvents: googleOauthListCalendarEventsFunction = async ({
           maxResults: Math.min(250, max - fetchedCount), // Google API max is 250
           singleEvents: true,
           orderBy: "startTime",
+          timeMin,
+          timeMax,
         },
       });
       const { items = [], nextPageToken = undefined } = res.data;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2411,6 +2411,12 @@ actions:
           maxResults:
             type: integer
             description: Maximum number of events to return, defaults to 250
+          timeMin:
+            type: string
+            description: Optional lower bound (exclusive) for an event's end time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.
+          timeMax:
+            type: string
+            description: Optional upper bound (exclusive) for an event's start time to filter by. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z.
       output:
         type: object
         required: [success, events]


### PR DESCRIPTION
add `timeMin` and `timeMax` to the query

Tested by:

```
% npm run test tests/google-oauth/testListCalendarEvents.ts

> @credal/actions@0.2.24 test
> node --loader ts-node/esm tests/google-oauth/testListCalendarEvents.ts

(node:63413) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63413) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:63413) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
Successfully found 2 events
Response:  {
  success: true,
  events: [
    {
      id: '37jaodju9r4tl1epp0muvr2t4o_20250630',
      status: 'confirmed',
      url: 'https://www.google.com/calendar/event?eid=MzdqYW9kanU5cjR0bDFlcHAwbXV2cjJ0NG9fMjAyNTA2MzAgcmljaGFyZEBjcmVkYWwuYWk',
      title: 'Office',
      description: undefined,
      location: undefined,
      start: '2025-06-30',
      end: '2025-07-01',
      attendees: [],
      organizer: [Object],
      hangoutLink: undefined,
      created: '2024-12-01T16:35:42.000Z',
      updated: '2024-12-01T16:35:42.666Z'
    },
    {
      id: '5nptchlupb0lq9obvmuu7doq8v_20250630',
      status: 'confirmed',
      url: 'https://www.google.com/calendar/event?eid=NW5wdGNobHVwYjBscTlvYnZtdXU3ZG9xOHZfMjAyNTA2MzAgcmljaGFyZEBjcmVkYWwuYWk',
      title: 'Richard Support On Call',
      description: undefined,
      location: undefined,
      start: '2025-06-30',
      end: '2025-07-07',
      attendees: [Array],
      organizer: [Object],
      hangoutLink: undefined,
      created: '2024-12-27T01:55:27.000Z',
      updated: '2025-04-22T18:33:01.342Z'
    }
  ]
}
```