### PR TITLE
[Integer] - Should use number not integer - we don't have a cast for it in app as it's not a typescript type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.36",
+      "version": "0.2.37",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -2892,7 +2892,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["index"],
                       properties: {
                         index: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based index in the document where to insert the text",
                         },
                       },
@@ -2976,7 +2976,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                               description: "The font family of the text",
                             },
                             weight: {
-                              type: "integer",
+                              type: "number",
                               description: "The weight of the font",
                             },
                           },
@@ -2993,11 +2993,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3021,11 +3021,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3054,17 +3054,17 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           required: ["index"],
                           properties: {
                             index: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based index in the document",
                             },
                           },
                         },
                         rowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based row index",
                         },
                         columnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based column index",
                         },
                       },
@@ -3097,17 +3097,17 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           required: ["index"],
                           properties: {
                             index: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based index in the document",
                             },
                           },
                         },
                         rowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based row index",
                         },
                         columnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based column index",
                         },
                       },
@@ -3140,17 +3140,17 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           required: ["index"],
                           properties: {
                             index: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based index in the document",
                             },
                           },
                         },
                         rowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based row index",
                         },
                         columnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based column index",
                         },
                       },
@@ -3179,17 +3179,17 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           required: ["index"],
                           properties: {
                             index: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based index in the document",
                             },
                           },
                         },
                         rowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based row index",
                         },
                         columnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based column index",
                         },
                       },
@@ -3213,11 +3213,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3325,11 +3325,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3376,11 +3376,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3404,7 +3404,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["index"],
                       properties: {
                         index: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based index in the document",
                         },
                       },
@@ -3471,7 +3471,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           description: "The left page margin",
                         },
                         pageNumberStart: {
-                          type: "integer",
+                          type: "number",
                           description: "The page number from which to start counting",
                         },
                         pageSize: {
@@ -3572,7 +3572,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           description: "The top border of the cells",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns that the cell spans",
                         },
                         contentAlignment: {
@@ -3596,7 +3596,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                           description: "The top padding of the cells",
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows that the cell spans",
                         },
                       },
@@ -3621,27 +3621,27 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                               required: ["index"],
                               properties: {
                                 index: {
-                                  type: "integer",
+                                  type: "number",
                                   description: "The zero-based index in the document",
                                 },
                               },
                             },
                             rowIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based row index",
                             },
                             columnIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based column index",
                             },
                           },
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows that the range should span",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns that the range should span",
                         },
                       },
@@ -3675,27 +3675,27 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                               required: ["index"],
                               properties: {
                                 index: {
-                                  type: "integer",
+                                  type: "number",
                                   description: "The zero-based index in the document",
                                 },
                               },
                             },
                             rowIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based row index",
                             },
                             columnIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based column index",
                             },
                           },
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows that the range should span",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns that the range should span",
                         },
                       },
@@ -3729,27 +3729,27 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                               required: ["index"],
                               properties: {
                                 index: {
-                                  type: "integer",
+                                  type: "number",
                                   description: "The zero-based index in the document",
                                 },
                               },
                             },
                             rowIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based row index",
                             },
                             columnIndex: {
-                              type: "integer",
+                              type: "number",
                               description: "The zero-based column index",
                             },
                           },
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows that the range should span",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns that the range should span",
                         },
                       },
@@ -3777,11 +3777,11 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["startIndex", "endIndex"],
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based starting index of the range",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based ending index of the range (exclusive)",
                         },
                       },
@@ -3843,7 +3843,7 @@ export const googleOauthUpdateDocDefinition: ActionTemplate = {
                       required: ["index"],
                       properties: {
                         index: {
-                          type: "integer",
+                          type: "number",
                           description: "The zero-based index in the document",
                         },
                       },
@@ -4008,7 +4008,7 @@ export const googleOauthListCalendarsDefinition: ActionTemplate = {
     required: [],
     properties: {
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "Maximum number of calendars to return, defaults to 250",
       },
     },
@@ -4064,7 +4064,7 @@ export const googleOauthListCalendarEventsDefinition: ActionTemplate = {
         description: "Optional free-text search query to filter events",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "Maximum number of events to return, defaults to 250",
       },
       timeMin: {
@@ -4338,19 +4338,19 @@ export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {
               type: "object",
               properties: {
                 rowCount: {
-                  type: "integer",
+                  type: "number",
                   description: "The number of rows in the sheet",
                 },
                 columnCount: {
-                  type: "integer",
+                  type: "number",
                   description: "The number of columns in the sheet",
                 },
                 frozenRowCount: {
-                  type: "integer",
+                  type: "number",
                   description: "The number of frozen rows",
                 },
                 frozenColumnCount: {
-                  type: "integer",
+                  type: "number",
                   description: "The number of frozen columns",
                 },
               },
@@ -4402,7 +4402,7 @@ export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {
           type: "object",
           properties: {
             sheetId: {
-              type: "integer",
+              type: "number",
               description: "The ID of the sheet",
             },
             title: {
@@ -4410,7 +4410,7 @@ export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {
               description: "The title of the sheet",
             },
             index: {
-              type: "integer",
+              type: "number",
               description: "The index of the sheet",
             },
           },
@@ -4460,11 +4460,11 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                           type: "object",
                           properties: {
                             rowCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The number of rows in the sheet",
                             },
                             columnCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The number of columns in the sheet",
                             },
                           },
@@ -4483,7 +4483,7 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                   type: "object",
                   properties: {
                     sheetId: {
-                      type: "integer",
+                      type: "number",
                       description: "The ID of the sheet to delete",
                     },
                   },
@@ -4501,23 +4501,23 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                       type: "object",
                       properties: {
                         sheetId: {
-                          type: "integer",
+                          type: "number",
                           description: "The ID of the sheet",
                         },
                         startRowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The start row (0-based, inclusive)",
                         },
                         endRowIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The end row (0-based, exclusive)",
                         },
                         startColumnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The start column (0-based, inclusive)",
                         },
                         endColumnIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The end column (0-based, exclusive)",
                         },
                       },
@@ -4570,7 +4570,7 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                       type: "object",
                       properties: {
                         sheetId: {
-                          type: "integer",
+                          type: "number",
                           description: "The ID of the sheet to update",
                         },
                         title: {
@@ -4581,19 +4581,19 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                           type: "object",
                           properties: {
                             rowCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The new number of rows",
                             },
                             columnCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The new number of columns",
                             },
                             frozenRowCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The number of frozen rows",
                             },
                             frozenColumnCount: {
-                              type: "integer",
+                              type: "number",
                               description: "The number of frozen columns",
                             },
                           },
@@ -4711,7 +4711,7 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                                   description: "The font family",
                                 },
                                 fontSize: {
-                                  type: "integer",
+                                  type: "number",
                                   description: "The size of the font in points",
                                 },
                                 bold: {
@@ -4779,7 +4779,7 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                       type: "object",
                       properties: {
                         sheetId: {
-                          type: "integer",
+                          type: "number",
                           description: "The ID of the newly created sheet",
                         },
                         title: {
@@ -4787,7 +4787,7 @@ export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
                           description: "The title of the new sheet",
                         },
                         index: {
-                          type: "integer",
+                          type: "number",
                           description: "The index of the new sheet",
                         },
                       },
@@ -4911,7 +4911,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The object ID for the created slide",
                     },
                     insertionIndex: {
-                      type: "integer",
+                      type: "number",
                       description: "The 0-based index where the new slide should be inserted",
                     },
                     slideLayoutReference: {
@@ -4967,11 +4967,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The object ID for the created table",
                     },
                     rows: {
-                      type: "integer",
+                      type: "number",
                       description: "Number of rows in the table",
                     },
                     columns: {
-                      type: "integer",
+                      type: "number",
                       description: "Number of columns in the table",
                     },
                     elementProperties: {
@@ -5000,7 +5000,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The text to be inserted",
                     },
                     insertionIndex: {
-                      type: "integer",
+                      type: "number",
                       description: "The index where the text will be inserted",
                     },
                   },
@@ -5025,7 +5025,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "Whether to insert the rows below the reference cell",
                     },
                     number: {
-                      type: "integer",
+                      type: "number",
                       description: "The number of rows to insert",
                     },
                     cellLocation: {
@@ -5054,7 +5054,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "Whether to insert the columns to the right of the reference cell",
                     },
                     number: {
-                      type: "integer",
+                      type: "number",
                       description: "The number of columns to insert",
                     },
                     cellLocation: {
@@ -5216,7 +5216,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       },
                     },
                     insertionIndex: {
-                      type: "integer",
+                      type: "number",
                       description: "The 0-based index where the slides should be moved to",
                     },
                   },
@@ -5241,11 +5241,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The range of text to delete",
                       properties: {
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The starting index of the range (0-based)",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The ending index of the range (0-based)",
                         },
                       },
@@ -5322,7 +5322,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The ID of the Google Sheets spreadsheet containing the chart",
                     },
                     chartId: {
-                      type: "integer",
+                      type: "number",
                       description: "The ID of the specific chart in the spreadsheet",
                     },
                     elementProperties: {
@@ -5640,11 +5640,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The type of range",
                         },
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The start index for FROM_START_INDEX or FIXED_RANGE",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The end index for FIXED_RANGE",
                         },
                       },
@@ -5667,7 +5667,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                       description: "The ID of the Google Sheets spreadsheet containing the chart",
                     },
                     chartId: {
-                      type: "integer",
+                      type: "number",
                       description: "The ID of the chart within the spreadsheet",
                     },
                     containsText: {
@@ -5724,11 +5724,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The type of range",
                         },
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The start index for FROM_START_INDEX or FIXED_RANGE",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The end index for FIXED_RANGE",
                         },
                       },
@@ -5770,11 +5770,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The type of range",
                         },
                         startIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The start index for FROM_START_INDEX or FIXED_RANGE",
                         },
                         endIndex: {
-                          type: "integer",
+                          type: "number",
                           description: "The end index for FIXED_RANGE",
                         },
                       },
@@ -5819,11 +5819,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The starting cell location",
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows in the range",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns in the range",
                         },
                       },
@@ -5848,7 +5848,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                     columnIndices: {
                       type: "array",
                       items: {
-                        type: "integer",
+                        type: "number",
                       },
                       description: "The 0-based indices of the columns to update",
                     },
@@ -5881,7 +5881,7 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                     rowIndices: {
                       type: "array",
                       items: {
-                        type: "integer",
+                        type: "number",
                       },
                       description: "The 0-based indices of the rows to update",
                     },
@@ -5920,11 +5920,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The starting cell location",
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows in the range",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns in the range",
                         },
                       },
@@ -5955,11 +5955,11 @@ export const googleOauthUpdatePresentationDefinition: ActionTemplate = {
                           description: "The starting cell location",
                         },
                         rowSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of rows in the range",
                         },
                         columnSpan: {
-                          type: "integer",
+                          type: "number",
                           description: "The number of columns in the range",
                         },
                       },
@@ -6194,7 +6194,7 @@ export const googleOauthSearchDriveByKeywordsDefinition: ActionTemplate = {
         },
       },
       limit: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of files to return",
       },
     },
@@ -6254,7 +6254,7 @@ export const googleOauthGetDriveFileContentByIdDefinition: ActionTemplate = {
         description: "The ID of the file to get content from",
       },
       limit: {
-        type: "integer",
+        type: "number",
         description: "The character limit for the file content",
       },
     },
@@ -6276,7 +6276,7 @@ export const googleOauthGetDriveFileContentByIdDefinition: ActionTemplate = {
         description: "The name of the file",
       },
       fileLength: {
-        type: "integer",
+        type: "number",
         description: "The length of the file content prior to truncating",
       },
       error: {
@@ -6296,7 +6296,7 @@ export const googleOauthListGroupsDefinition: ActionTemplate = {
     required: [],
     properties: {
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of groups to return (max allowed is 200)",
       },
     },
@@ -6408,7 +6408,7 @@ export const googleOauthListGroupMembersDefinition: ActionTemplate = {
         description: "The group's email address or unique group ID",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of members to return (max allowed is 200)",
       },
     },
@@ -6578,7 +6578,7 @@ export const googlemailSearchGmailMessagesDefinition: ActionTemplate = {
         description: 'Gmail search query (e.g. "from:alice subject:urgent")',
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "Maximum number of messages to return (optional)",
       },
     },
@@ -6648,7 +6648,7 @@ export const googlemailListGmailThreadsDefinition: ActionTemplate = {
         description: 'Gmail search query (e.g. "from:alice subject:project")',
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "Maximum number of threads to return",
       },
     },
@@ -6904,7 +6904,7 @@ export const oktaListOktaUserGroupsDefinition: ActionTemplate = {
         description: "The ID of the user whose groups are to be listed.",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of results to return.",
         minimum: 1,
       },
@@ -6968,7 +6968,7 @@ export const oktaListOktaGroupsDefinition: ActionTemplate = {
           "Optional search query to filter groups.\nThis field corresponds to the `search` query parameter in the Okta API's List Groups operation.\nFor detailed information on constructing search queries and available filter expressions, refer to the Okta API documentation:\nhttps://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroups!in=query&path=search&t=request\nExample: 'profile.name eq \"My Group\"'\n",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of results to return.",
         minimum: 1,
       },
@@ -7142,7 +7142,7 @@ export const oktaListOktaGroupMembersDefinition: ActionTemplate = {
         description: "The ID of the group whose members are to be listed.",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of results to return.",
         minimum: 1,
       },
@@ -7337,7 +7337,7 @@ export const oktaListOktaUsersDefinition: ActionTemplate = {
           "Optional search query to filter users.\nThis field corresponds to the `search` query parameter in the Okta API's List Users operation.\nFor detailed information on constructing search queries and available filter expressions, refer to the Okta API documentation:\nhttps://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers!in=query&path=search&t=request\nExample: 'profile.email eq \"my_user@example.com\"'\n",
       },
       maxResults: {
-        type: "integer",
+        type: "number",
         description: "The maximum number of results to return.",
         minimum: 1,
       },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1554,10 +1554,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     text: z.string().describe("The text to insert"),
                     location: z
                       .object({
-                        index: z
-                          .number()
-                          .int()
-                          .describe("The zero-based index in the document where to insert the text"),
+                        index: z.number().describe("The zero-based index in the document where to insert the text"),
                       })
                       .describe("The location where the text will be inserted"),
                   })
@@ -1600,7 +1597,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                         weightedFontFamily: z
                           .object({
                             fontFamily: z.string().describe("The font family of the text").optional(),
-                            weight: z.number().int().describe("The weight of the font").optional(),
+                            weight: z.number().describe("The weight of the font").optional(),
                           })
                           .describe("The font family and weight of the text")
                           .optional(),
@@ -1609,8 +1606,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     fields: z.string().describe("The fields that should be updated"),
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range of text to style")
                       .optional(),
@@ -1622,8 +1619,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                   .object({
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range of content to delete"),
                   })
@@ -1635,10 +1632,10 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     tableCellLocation: z
                       .object({
                         tableStartLocation: z
-                          .object({ index: z.number().int().describe("The zero-based index in the document") })
+                          .object({ index: z.number().describe("The zero-based index in the document") })
                           .describe("The location where the table starts"),
-                        rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                        columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                        rowIndex: z.number().describe("The zero-based row index").optional(),
+                        columnIndex: z.number().describe("The zero-based column index").optional(),
                       })
                       .describe("The location where the table row will be inserted"),
                     insertBelow: z.boolean().describe("Whether to insert the row below the reference row"),
@@ -1651,10 +1648,10 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     tableCellLocation: z
                       .object({
                         tableStartLocation: z
-                          .object({ index: z.number().int().describe("The zero-based index in the document") })
+                          .object({ index: z.number().describe("The zero-based index in the document") })
                           .describe("The location where the table starts"),
-                        rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                        columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                        rowIndex: z.number().describe("The zero-based row index").optional(),
+                        columnIndex: z.number().describe("The zero-based column index").optional(),
                       })
                       .describe("The location where the table column will be inserted"),
                     insertRight: z
@@ -1669,10 +1666,10 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     tableCellLocation: z
                       .object({
                         tableStartLocation: z
-                          .object({ index: z.number().int().describe("The zero-based index in the document") })
+                          .object({ index: z.number().describe("The zero-based index in the document") })
                           .describe("The location where the table starts"),
-                        rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                        columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                        rowIndex: z.number().describe("The zero-based row index").optional(),
+                        columnIndex: z.number().describe("The zero-based column index").optional(),
                       })
                       .describe("The location of the row to delete"),
                   })
@@ -1684,10 +1681,10 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     tableCellLocation: z
                       .object({
                         tableStartLocation: z
-                          .object({ index: z.number().int().describe("The zero-based index in the document") })
+                          .object({ index: z.number().describe("The zero-based index in the document") })
                           .describe("The location where the table starts"),
-                        rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                        columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                        rowIndex: z.number().describe("The zero-based row index").optional(),
+                        columnIndex: z.number().describe("The zero-based column index").optional(),
                       })
                       .describe("The location of the column to delete"),
                   })
@@ -1698,8 +1695,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                   .object({
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range of paragraphs to update"),
                     paragraphStyle: z
@@ -1769,8 +1766,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                   .object({
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range of paragraphs to bullet"),
                     bulletPreset: z
@@ -1802,8 +1799,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                   .object({
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range of paragraphs to remove bullets from"),
                   })
@@ -1813,7 +1810,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                 insertPageBreak: z
                   .object({
                     location: z
-                      .object({ index: z.number().int().describe("The zero-based index in the document") })
+                      .object({ index: z.number().describe("The zero-based index in the document") })
                       .describe("The location at which to insert the page break"),
                   })
                   .describe("Inserts a page break"),
@@ -1844,11 +1841,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                         marginBottom: z.object({}).catchall(z.any()).describe("The bottom page margin").optional(),
                         marginRight: z.object({}).catchall(z.any()).describe("The right page margin").optional(),
                         marginLeft: z.object({}).catchall(z.any()).describe("The left page margin").optional(),
-                        pageNumberStart: z
-                          .number()
-                          .int()
-                          .describe("The page number from which to start counting")
-                          .optional(),
+                        pageNumberStart: z.number().describe("The page number from which to start counting").optional(),
                         pageSize: z
                           .object({
                             width: z.object({}).catchall(z.any()).describe("The width of the page").optional(),
@@ -1906,7 +1899,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                           .describe("The right border of the cells")
                           .optional(),
                         borderTop: z.object({}).catchall(z.any()).describe("The top border of the cells").optional(),
-                        columnSpan: z.number().int().describe("The number of columns that the cell spans").optional(),
+                        columnSpan: z.number().describe("The number of columns that the cell spans").optional(),
                         contentAlignment: z
                           .string()
                           .describe("The alignment of the content within the cells")
@@ -1927,7 +1920,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                           .describe("The right padding of the cells")
                           .optional(),
                         paddingTop: z.object({}).catchall(z.any()).describe("The top padding of the cells").optional(),
-                        rowSpan: z.number().int().describe("The number of rows that the cell spans").optional(),
+                        rowSpan: z.number().describe("The number of rows that the cell spans").optional(),
                       })
                       .describe("The style to apply to the cells"),
                     fields: z.string().describe("The fields that should be updated"),
@@ -1936,14 +1929,14 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                         tableCellLocation: z
                           .object({
                             tableStartLocation: z
-                              .object({ index: z.number().int().describe("The zero-based index in the document") })
+                              .object({ index: z.number().describe("The zero-based index in the document") })
                               .describe("The location where the table starts"),
-                            rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                            columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                            rowIndex: z.number().describe("The zero-based row index").optional(),
+                            columnIndex: z.number().describe("The zero-based column index").optional(),
                           })
                           .describe("The location of the table cell"),
-                        rowSpan: z.number().int().describe("The number of rows that the range should span"),
-                        columnSpan: z.number().int().describe("The number of columns that the range should span"),
+                        rowSpan: z.number().describe("The number of rows that the range should span"),
+                        columnSpan: z.number().describe("The number of columns that the range should span"),
                       })
                       .describe("The table range to apply the style to"),
                   })
@@ -1957,14 +1950,14 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                         tableCellLocation: z
                           .object({
                             tableStartLocation: z
-                              .object({ index: z.number().int().describe("The zero-based index in the document") })
+                              .object({ index: z.number().describe("The zero-based index in the document") })
                               .describe("The location where the table starts"),
-                            rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                            columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                            rowIndex: z.number().describe("The zero-based row index").optional(),
+                            columnIndex: z.number().describe("The zero-based column index").optional(),
                           })
                           .describe("The location of the table cell"),
-                        rowSpan: z.number().int().describe("The number of rows that the range should span"),
-                        columnSpan: z.number().int().describe("The number of columns that the range should span"),
+                        rowSpan: z.number().describe("The number of rows that the range should span"),
+                        columnSpan: z.number().describe("The number of columns that the range should span"),
                       })
                       .describe("The table range to merge"),
                   })
@@ -1978,14 +1971,14 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                         tableCellLocation: z
                           .object({
                             tableStartLocation: z
-                              .object({ index: z.number().int().describe("The zero-based index in the document") })
+                              .object({ index: z.number().describe("The zero-based index in the document") })
                               .describe("The location where the table starts"),
-                            rowIndex: z.number().int().describe("The zero-based row index").optional(),
-                            columnIndex: z.number().int().describe("The zero-based column index").optional(),
+                            rowIndex: z.number().describe("The zero-based row index").optional(),
+                            columnIndex: z.number().describe("The zero-based column index").optional(),
                           })
                           .describe("The location of the table cell"),
-                        rowSpan: z.number().int().describe("The number of rows that the range should span"),
-                        columnSpan: z.number().int().describe("The number of columns that the range should span"),
+                        rowSpan: z.number().describe("The number of rows that the range should span"),
+                        columnSpan: z.number().describe("The number of columns that the range should span"),
                       })
                       .describe("The table range to unmerge"),
                   })
@@ -1997,8 +1990,8 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                     name: z.string().describe("The name of the range"),
                     range: z
                       .object({
-                        startIndex: z.number().int().describe("The zero-based starting index of the range"),
-                        endIndex: z.number().int().describe("The zero-based ending index of the range (exclusive)"),
+                        startIndex: z.number().describe("The zero-based starting index of the range"),
+                        endIndex: z.number().describe("The zero-based ending index of the range (exclusive)"),
                       })
                       .describe("The range to name"),
                   })
@@ -2021,7 +2014,7 @@ export const googleOauthUpdateDocParamsSchema = z.object({
                 insertInlineImage: z
                   .object({
                     location: z
-                      .object({ index: z.number().int().describe("The zero-based index in the document") })
+                      .object({ index: z.number().describe("The zero-based index in the document") })
                       .describe("The location at which to insert the image"),
                     uri: z.string().describe("The image URI"),
                     objectSize: z
@@ -2116,7 +2109,7 @@ export type googleOauthScheduleCalendarMeetingFunction = ActionFunction<
 >;
 
 export const googleOauthListCalendarsParamsSchema = z.object({
-  maxResults: z.number().int().describe("Maximum number of calendars to return, defaults to 250").optional(),
+  maxResults: z.number().describe("Maximum number of calendars to return, defaults to 250").optional(),
 });
 
 export type googleOauthListCalendarsParamsType = z.infer<typeof googleOauthListCalendarsParamsSchema>;
@@ -2139,7 +2132,7 @@ export type googleOauthListCalendarsFunction = ActionFunction<
 export const googleOauthListCalendarEventsParamsSchema = z.object({
   calendarId: z.string().describe("The ID of the calendar to list events from"),
   query: z.string().describe("Optional free-text search query to filter events").optional(),
-  maxResults: z.number().int().describe("Maximum number of events to return, defaults to 250").optional(),
+  maxResults: z.number().describe("Maximum number of events to return, defaults to 250").optional(),
   timeMin: z
     .string()
     .describe(
@@ -2277,10 +2270,10 @@ export const googleOauthCreateSpreadsheetParamsSchema = z.object({
         title: z.string().describe("The title of the sheet").optional(),
         gridProperties: z
           .object({
-            rowCount: z.number().int().describe("The number of rows in the sheet").optional(),
-            columnCount: z.number().int().describe("The number of columns in the sheet").optional(),
-            frozenRowCount: z.number().int().describe("The number of frozen rows").optional(),
-            frozenColumnCount: z.number().int().describe("The number of frozen columns").optional(),
+            rowCount: z.number().describe("The number of rows in the sheet").optional(),
+            columnCount: z.number().describe("The number of columns in the sheet").optional(),
+            frozenRowCount: z.number().describe("The number of frozen rows").optional(),
+            frozenColumnCount: z.number().describe("The number of frozen columns").optional(),
           })
           .optional(),
       }),
@@ -2306,9 +2299,9 @@ export const googleOauthCreateSpreadsheetOutputSchema = z.object({
   sheets: z
     .array(
       z.object({
-        sheetId: z.number().int().describe("The ID of the sheet").optional(),
+        sheetId: z.number().describe("The ID of the sheet").optional(),
         title: z.string().describe("The title of the sheet").optional(),
-        index: z.number().int().describe("The index of the sheet").optional(),
+        index: z.number().describe("The index of the sheet").optional(),
       }),
     )
     .describe("Information about the created sheets")
@@ -2342,8 +2335,8 @@ export const googleOauthUpdateSpreadsheetParamsSchema = z.object({
                           title: z.string().describe("The title of the new sheet").optional(),
                           gridProperties: z
                             .object({
-                              rowCount: z.number().int().describe("The number of rows in the sheet").optional(),
-                              columnCount: z.number().int().describe("The number of columns in the sheet").optional(),
+                              rowCount: z.number().describe("The number of rows in the sheet").optional(),
+                              columnCount: z.number().describe("The number of columns in the sheet").optional(),
                             })
                             .optional(),
                         })
@@ -2355,7 +2348,7 @@ export const googleOauthUpdateSpreadsheetParamsSchema = z.object({
               z
                 .object({
                   deleteSheet: z
-                    .object({ sheetId: z.number().int().describe("The ID of the sheet to delete").optional() })
+                    .object({ sheetId: z.number().describe("The ID of the sheet to delete").optional() })
                     .optional(),
                 })
                 .describe("Delete a sheet"),
@@ -2365,15 +2358,11 @@ export const googleOauthUpdateSpreadsheetParamsSchema = z.object({
                     .object({
                       range: z
                         .object({
-                          sheetId: z.number().int().describe("The ID of the sheet").optional(),
-                          startRowIndex: z.number().int().describe("The start row (0-based, inclusive)").optional(),
-                          endRowIndex: z.number().int().describe("The end row (0-based, exclusive)").optional(),
-                          startColumnIndex: z
-                            .number()
-                            .int()
-                            .describe("The start column (0-based, inclusive)")
-                            .optional(),
-                          endColumnIndex: z.number().int().describe("The end column (0-based, exclusive)").optional(),
+                          sheetId: z.number().describe("The ID of the sheet").optional(),
+                          startRowIndex: z.number().describe("The start row (0-based, inclusive)").optional(),
+                          endRowIndex: z.number().describe("The end row (0-based, exclusive)").optional(),
+                          startColumnIndex: z.number().describe("The start column (0-based, inclusive)").optional(),
+                          endColumnIndex: z.number().describe("The end column (0-based, exclusive)").optional(),
                         })
                         .optional(),
                       rows: z
@@ -2406,14 +2395,14 @@ export const googleOauthUpdateSpreadsheetParamsSchema = z.object({
                     .object({
                       properties: z
                         .object({
-                          sheetId: z.number().int().describe("The ID of the sheet to update").optional(),
+                          sheetId: z.number().describe("The ID of the sheet to update").optional(),
                           title: z.string().describe("The new title of the sheet").optional(),
                           gridProperties: z
                             .object({
-                              rowCount: z.number().int().describe("The new number of rows").optional(),
-                              columnCount: z.number().int().describe("The new number of columns").optional(),
-                              frozenRowCount: z.number().int().describe("The number of frozen rows").optional(),
-                              frozenColumnCount: z.number().int().describe("The number of frozen columns").optional(),
+                              rowCount: z.number().describe("The new number of rows").optional(),
+                              columnCount: z.number().describe("The new number of columns").optional(),
+                              frozenRowCount: z.number().describe("The number of frozen rows").optional(),
+                              frozenColumnCount: z.number().describe("The number of frozen columns").optional(),
                             })
                             .optional(),
                         })
@@ -2481,7 +2470,7 @@ export const googleOauthUpdateSpreadsheetParamsSchema = z.object({
                                     })
                                     .optional(),
                                   fontFamily: z.string().describe("The font family").optional(),
-                                  fontSize: z.number().int().describe("The size of the font in points").optional(),
+                                  fontSize: z.number().describe("The size of the font in points").optional(),
                                   bold: z.boolean().describe("Whether the text is bold").optional(),
                                   italic: z.boolean().describe("Whether the text is italic").optional(),
                                   strikethrough: z
@@ -2539,9 +2528,9 @@ export const googleOauthUpdateSpreadsheetOutputSchema = z.object({
                 .object({
                   properties: z
                     .object({
-                      sheetId: z.number().int().describe("The ID of the newly created sheet").optional(),
+                      sheetId: z.number().describe("The ID of the newly created sheet").optional(),
                       title: z.string().describe("The title of the new sheet").optional(),
-                      index: z.number().int().describe("The index of the new sheet").optional(),
+                      index: z.number().describe("The index of the new sheet").optional(),
                     })
                     .optional(),
                 })
@@ -2617,7 +2606,6 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     objectId: z.string().describe("The object ID for the created slide").optional(),
                     insertionIndex: z
                       .number()
-                      .int()
                       .describe("The 0-based index where the new slide should be inserted")
                       .optional(),
                     slideLayoutReference: z
@@ -2644,8 +2632,8 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                 createTable: z
                   .object({
                     objectId: z.string().describe("The object ID for the created table").optional(),
-                    rows: z.number().int().describe("Number of rows in the table"),
-                    columns: z.number().int().describe("Number of columns in the table"),
+                    rows: z.number().describe("Number of rows in the table"),
+                    columns: z.number().describe("Number of columns in the table"),
                     elementProperties: z
                       .object({})
                       .catchall(z.any())
@@ -2659,7 +2647,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                   .object({
                     objectId: z.string().describe("The object ID of the shape or table cell"),
                     text: z.string().describe("The text to be inserted"),
-                    insertionIndex: z.number().int().describe("The index where the text will be inserted").optional(),
+                    insertionIndex: z.number().describe("The index where the text will be inserted").optional(),
                   })
                   .describe("Inserts text into a shape or table cell"),
               }),
@@ -2668,7 +2656,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                   .object({
                     tableObjectId: z.string().describe("The table to insert rows into"),
                     insertBelow: z.boolean().describe("Whether to insert the rows below the reference cell"),
-                    number: z.number().int().describe("The number of rows to insert").optional(),
+                    number: z.number().describe("The number of rows to insert").optional(),
                     cellLocation: z
                       .object({})
                       .catchall(z.any())
@@ -2684,7 +2672,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     insertRight: z
                       .boolean()
                       .describe("Whether to insert the columns to the right of the reference cell"),
-                    number: z.number().int().describe("The number of columns to insert").optional(),
+                    number: z.number().describe("The number of columns to insert").optional(),
                     cellLocation: z
                       .object({})
                       .catchall(z.any())
@@ -2749,7 +2737,6 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     slideObjectIds: z.array(z.string()).describe("The IDs of the slides to reorder"),
                     insertionIndex: z
                       .number()
-                      .int()
                       .describe("The 0-based index where the slides should be moved to")
                       .optional(),
                   })
@@ -2761,8 +2748,8 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     objectId: z.string().describe("The object ID of the shape or table cell"),
                     textRange: z
                       .object({
-                        startIndex: z.number().int().describe("The starting index of the range (0-based)").optional(),
-                        endIndex: z.number().int().describe("The ending index of the range (0-based)").optional(),
+                        startIndex: z.number().describe("The starting index of the range (0-based)").optional(),
+                        endIndex: z.number().describe("The ending index of the range (0-based)").optional(),
                       })
                       .describe("The range of text to delete")
                       .optional(),
@@ -2800,7 +2787,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                   .object({
                     objectId: z.string().describe("The object ID for the created chart").optional(),
                     spreadsheetId: z.string().describe("The ID of the Google Sheets spreadsheet containing the chart"),
-                    chartId: z.number().int().describe("The ID of the specific chart in the spreadsheet"),
+                    chartId: z.number().describe("The ID of the specific chart in the spreadsheet"),
                     elementProperties: z
                       .object({})
                       .catchall(z.any())
@@ -2961,10 +2948,9 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                           .optional(),
                         startIndex: z
                           .number()
-                          .int()
                           .describe("The start index for FROM_START_INDEX or FIXED_RANGE")
                           .optional(),
-                        endIndex: z.number().int().describe("The end index for FIXED_RANGE").optional(),
+                        endIndex: z.number().describe("The end index for FIXED_RANGE").optional(),
                       })
                       .describe("The range of text to style (defaults to all text if unspecified)")
                       .optional(),
@@ -2975,7 +2961,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                 replaceAllShapesWithSheetsChart: z
                   .object({
                     spreadsheetId: z.string().describe("The ID of the Google Sheets spreadsheet containing the chart"),
-                    chartId: z.number().int().describe("The ID of the chart within the spreadsheet"),
+                    chartId: z.number().describe("The ID of the chart within the spreadsheet"),
                     containsText: z
                       .object({
                         text: z.string().describe("The text the shape must contain to be replaced"),
@@ -3005,10 +2991,9 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                           .optional(),
                         startIndex: z
                           .number()
-                          .int()
                           .describe("The start index for FROM_START_INDEX or FIXED_RANGE")
                           .optional(),
-                        endIndex: z.number().int().describe("The end index for FIXED_RANGE").optional(),
+                        endIndex: z.number().describe("The end index for FIXED_RANGE").optional(),
                       })
                       .describe("The range of text to delete bullets from (defaults to all text if unspecified)")
                       .optional(),
@@ -3036,10 +3021,9 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                           .optional(),
                         startIndex: z
                           .number()
-                          .int()
                           .describe("The start index for FROM_START_INDEX or FIXED_RANGE")
                           .optional(),
-                        endIndex: z.number().int().describe("The end index for FIXED_RANGE").optional(),
+                        endIndex: z.number().describe("The end index for FIXED_RANGE").optional(),
                       })
                       .describe("The range of text to apply the style to (defaults to all paragraphs if unspecified)")
                       .optional(),
@@ -3065,8 +3049,8 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     tableRange: z
                       .object({
                         location: z.object({}).catchall(z.any()).describe("The starting cell location").optional(),
-                        rowSpan: z.number().int().describe("The number of rows in the range").optional(),
-                        columnSpan: z.number().int().describe("The number of columns in the range").optional(),
+                        rowSpan: z.number().describe("The number of rows in the range").optional(),
+                        columnSpan: z.number().describe("The number of columns in the range").optional(),
                       })
                       .describe(
                         "The range of cells whose border should be updated (defaults to the entire table if unspecified)",
@@ -3079,7 +3063,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                 updateTableColumnProperties: z
                   .object({
                     objectId: z.string().describe("The object ID of the table"),
-                    columnIndices: z.array(z.number().int()).describe("The 0-based indices of the columns to update"),
+                    columnIndices: z.array(z.number()).describe("The 0-based indices of the columns to update"),
                     tableColumnProperties: z
                       .object({})
                       .catchall(z.any())
@@ -3096,7 +3080,7 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                 updateTableRowProperties: z
                   .object({
                     objectId: z.string().describe("The object ID of the table"),
-                    rowIndices: z.array(z.number().int()).describe("The 0-based indices of the rows to update"),
+                    rowIndices: z.array(z.number()).describe("The 0-based indices of the rows to update"),
                     tableRowProperties: z
                       .object({})
                       .catchall(z.any())
@@ -3116,8 +3100,8 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     tableRange: z
                       .object({
                         location: z.object({}).catchall(z.any()).describe("The starting cell location").optional(),
-                        rowSpan: z.number().int().describe("The number of rows in the range").optional(),
-                        columnSpan: z.number().int().describe("The number of columns in the range").optional(),
+                        rowSpan: z.number().describe("The number of rows in the range").optional(),
+                        columnSpan: z.number().describe("The number of columns in the range").optional(),
                       })
                       .describe("The range of cells to merge"),
                   })
@@ -3130,8 +3114,8 @@ export const googleOauthUpdatePresentationParamsSchema = z.object({
                     tableRange: z
                       .object({
                         location: z.object({}).catchall(z.any()).describe("The starting cell location").optional(),
-                        rowSpan: z.number().int().describe("The number of rows in the range").optional(),
-                        columnSpan: z.number().int().describe("The number of columns in the range").optional(),
+                        rowSpan: z.number().describe("The number of rows in the range").optional(),
+                        columnSpan: z.number().describe("The number of columns in the range").optional(),
                       })
                       .describe("The range of cells to unmerge"),
                   })
@@ -3246,7 +3230,7 @@ export type googleOauthUpdatePresentationFunction = ActionFunction<
 
 export const googleOauthSearchDriveByKeywordsParamsSchema = z.object({
   keywords: z.array(z.string()).describe("List of keywords to search for in file contents."),
-  limit: z.number().int().describe("The maximum number of files to return").optional(),
+  limit: z.number().describe("The maximum number of files to return").optional(),
 });
 
 export type googleOauthSearchDriveByKeywordsParamsType = z.infer<typeof googleOauthSearchDriveByKeywordsParamsSchema>;
@@ -3276,7 +3260,7 @@ export type googleOauthSearchDriveByKeywordsFunction = ActionFunction<
 
 export const googleOauthGetDriveFileContentByIdParamsSchema = z.object({
   fileId: z.string().describe("The ID of the file to get content from"),
-  limit: z.number().int().describe("The character limit for the file content"),
+  limit: z.number().describe("The character limit for the file content"),
 });
 
 export type googleOauthGetDriveFileContentByIdParamsType = z.infer<
@@ -3287,7 +3271,7 @@ export const googleOauthGetDriveFileContentByIdOutputSchema = z.object({
   success: z.boolean().describe("Whether the file content was retrieved successfully"),
   content: z.string().describe("The content of the file").optional(),
   fileName: z.string().describe("The name of the file").optional(),
-  fileLength: z.number().int().describe("The length of the file content prior to truncating").optional(),
+  fileLength: z.number().describe("The length of the file content prior to truncating").optional(),
   error: z.string().describe("Error message if file content retrieval failed").optional(),
 });
 
@@ -3301,7 +3285,7 @@ export type googleOauthGetDriveFileContentByIdFunction = ActionFunction<
 >;
 
 export const googleOauthListGroupsParamsSchema = z.object({
-  maxResults: z.number().int().describe("The maximum number of groups to return (max allowed is 200)").optional(),
+  maxResults: z.number().describe("The maximum number of groups to return (max allowed is 200)").optional(),
 });
 
 export type googleOauthListGroupsParamsType = z.infer<typeof googleOauthListGroupsParamsSchema>;
@@ -3354,7 +3338,7 @@ export type googleOauthGetGroupFunction = ActionFunction<
 
 export const googleOauthListGroupMembersParamsSchema = z.object({
   groupKey: z.string().describe("The group's email address or unique group ID"),
-  maxResults: z.number().int().describe("The maximum number of members to return (max allowed is 200)").optional(),
+  maxResults: z.number().describe("The maximum number of members to return (max allowed is 200)").optional(),
 });
 
 export type googleOauthListGroupMembersParamsType = z.infer<typeof googleOauthListGroupMembersParamsSchema>;
@@ -3442,7 +3426,7 @@ export type googleOauthDeleteGroupMemberFunction = ActionFunction<
 
 export const googlemailSearchGmailMessagesParamsSchema = z.object({
   query: z.string().describe('Gmail search query (e.g. "from:alice subject:urgent")'),
-  maxResults: z.number().int().describe("Maximum number of messages to return (optional)").optional(),
+  maxResults: z.number().describe("Maximum number of messages to return (optional)").optional(),
 });
 
 export type googlemailSearchGmailMessagesParamsType = z.infer<typeof googlemailSearchGmailMessagesParamsSchema>;
@@ -3473,7 +3457,7 @@ export type googlemailSearchGmailMessagesFunction = ActionFunction<
 
 export const googlemailListGmailThreadsParamsSchema = z.object({
   query: z.string().describe('Gmail search query (e.g. "from:alice subject:project")'),
-  maxResults: z.number().int().describe("Maximum number of threads to return").optional(),
+  maxResults: z.number().describe("Maximum number of threads to return").optional(),
 });
 
 export type googlemailListGmailThreadsParamsType = z.infer<typeof googlemailListGmailThreadsParamsSchema>;
@@ -3570,7 +3554,7 @@ export type oktaGetOktaUserFunction = ActionFunction<
 
 export const oktaListOktaUserGroupsParamsSchema = z.object({
   userId: z.string().describe("The ID of the user whose groups are to be listed."),
-  maxResults: z.number().int().gte(1).describe("The maximum number of results to return.").optional(),
+  maxResults: z.number().gte(1).describe("The maximum number of results to return.").optional(),
 });
 
 export type oktaListOktaUserGroupsParamsType = z.infer<typeof oktaListOktaUserGroupsParamsSchema>;
@@ -3606,7 +3590,7 @@ export const oktaListOktaGroupsParamsSchema = z.object({
       "Optional search query to filter groups.\nThis field corresponds to the `search` query parameter in the Okta API's List Groups operation.\nFor detailed information on constructing search queries and available filter expressions, refer to the Okta API documentation:\nhttps://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroups!in=query&path=search&t=request\nExample: 'profile.name eq \"My Group\"'\n",
     )
     .optional(),
-  maxResults: z.number().int().gte(1).describe("The maximum number of results to return.").optional(),
+  maxResults: z.number().gte(1).describe("The maximum number of results to return.").optional(),
 });
 
 export type oktaListOktaGroupsParamsType = z.infer<typeof oktaListOktaGroupsParamsSchema>;
@@ -3689,7 +3673,7 @@ export type oktaGetOktaGroupFunction = ActionFunction<
 
 export const oktaListOktaGroupMembersParamsSchema = z.object({
   groupId: z.string().describe("The ID of the group whose members are to be listed."),
-  maxResults: z.number().int().gte(1).describe("The maximum number of results to return.").optional(),
+  maxResults: z.number().gte(1).describe("The maximum number of results to return.").optional(),
 });
 
 export type oktaListOktaGroupMembersParamsType = z.infer<typeof oktaListOktaGroupMembersParamsSchema>;
@@ -3801,7 +3785,7 @@ export const oktaListOktaUsersParamsSchema = z.object({
       "Optional search query to filter users.\nThis field corresponds to the `search` query parameter in the Okta API's List Users operation.\nFor detailed information on constructing search queries and available filter expressions, refer to the Okta API documentation:\nhttps://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers!in=query&path=search&t=request\nExample: 'profile.email eq \"my_user@example.com\"'\n",
     )
     .optional(),
-  maxResults: z.number().int().gte(1).describe("The maximum number of results to return.").optional(),
+  maxResults: z.number().gte(1).describe("The maximum number of results to return.").optional(),
 });
 
 export type oktaListOktaUsersParamsType = z.infer<typeof oktaListOktaUsersParamsSchema>;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1699,7 +1699,7 @@ actions:
                           required: [index]
                           properties:
                             index:
-                              type: integer
+                              type: number
                               description: The zero-based index in the document where to insert the text
                 - type: object
                   required: [updateTextStyle]
@@ -1760,7 +1760,7 @@ actions:
                                   type: string
                                   description: The font family of the text
                                 weight:
-                                  type: integer
+                                  type: number
                                   description: The weight of the font
                         fields:
                           type: string
@@ -1771,10 +1771,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                 - type: object
                   required: [deleteContentRange]
@@ -1790,10 +1790,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                 - type: object
                   required: [insertTableRow]
@@ -1814,13 +1814,13 @@ actions:
                               required: [index]
                               properties:
                                 index:
-                                  type: integer
+                                  type: number
                                   description: The zero-based index in the document
                             rowIndex:
-                              type: integer
+                              type: number
                               description: The zero-based row index
                             columnIndex:
-                              type: integer
+                              type: number
                               description: The zero-based column index
                         insertBelow:
                           type: boolean
@@ -1844,13 +1844,13 @@ actions:
                               required: [index]
                               properties:
                                 index:
-                                  type: integer
+                                  type: number
                                   description: The zero-based index in the document
                             rowIndex:
-                              type: integer
+                              type: number
                               description: The zero-based row index
                             columnIndex:
-                              type: integer
+                              type: number
                               description: The zero-based column index
                         insertRight:
                           type: boolean
@@ -1874,13 +1874,13 @@ actions:
                               required: [index]
                               properties:
                                 index:
-                                  type: integer
+                                  type: number
                                   description: The zero-based index in the document
                             rowIndex:
-                              type: integer
+                              type: number
                               description: The zero-based row index
                             columnIndex:
-                              type: integer
+                              type: number
                               description: The zero-based column index
                 - type: object
                   required: [deleteTableColumn]
@@ -1901,13 +1901,13 @@ actions:
                               required: [index]
                               properties:
                                 index:
-                                  type: integer
+                                  type: number
                                   description: The zero-based index in the document
                             rowIndex:
-                              type: integer
+                              type: number
                               description: The zero-based row index
                             columnIndex:
-                              type: integer
+                              type: number
                               description: The zero-based column index
                 - type: object
                   required: [updateParagraphStyle]
@@ -1923,10 +1923,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                         paragraphStyle:
                           type: object
@@ -2004,10 +2004,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                         bulletPreset:
                           type: string
@@ -2046,10 +2046,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                 - type: object
                   required: [insertPageBreak]
@@ -2065,7 +2065,7 @@ actions:
                           required: [index]
                           properties:
                             index:
-                              type: integer
+                              type: number
                               description: The zero-based index in the document
                 - type: object
                   required: [updateDocumentStyle]
@@ -2113,7 +2113,7 @@ actions:
                               type: object
                               description: The left page margin
                             pageNumberStart:
-                              type: integer
+                              type: number
                               description: The page number from which to start counting
                             pageSize:
                               type: object
@@ -2183,7 +2183,7 @@ actions:
                               type: object
                               description: The top border of the cells
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns that the cell spans
                             contentAlignment:
                               type: string
@@ -2201,7 +2201,7 @@ actions:
                               type: object
                               description: The top padding of the cells
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows that the cell spans
                         fields:
                           type: string
@@ -2222,19 +2222,19 @@ actions:
                                   required: [index]
                                   properties:
                                     index:
-                                      type: integer
+                                      type: number
                                       description: The zero-based index in the document
                                 rowIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based row index
                                 columnIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based column index
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows that the range should span
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns that the range should span
                 - type: object
                   required: [mergeTableCells]
@@ -2260,19 +2260,19 @@ actions:
                                   required: [index]
                                   properties:
                                     index:
-                                      type: integer
+                                      type: number
                                       description: The zero-based index in the document
                                 rowIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based row index
                                 columnIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based column index
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows that the range should span
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns that the range should span
                 - type: object
                   required: [unmergeTableCells]
@@ -2298,19 +2298,19 @@ actions:
                                   required: [index]
                                   properties:
                                     index:
-                                      type: integer
+                                      type: number
                                       description: The zero-based index in the document
                                 rowIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based row index
                                 columnIndex:
-                                  type: integer
+                                  type: number
                                   description: The zero-based column index
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows that the range should span
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns that the range should span
                 - type: object
                   required: [createNamedRange]
@@ -2329,10 +2329,10 @@ actions:
                           required: [startIndex, endIndex]
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The zero-based starting index of the range
                             endIndex:
-                              type: integer
+                              type: number
                               description: The zero-based ending index of the range (exclusive)
                 - type: object
                   required: [deleteNamedRange]
@@ -2373,7 +2373,7 @@ actions:
                           required: [index]
                           properties:
                             index:
-                              type: integer
+                              type: number
                               description: The zero-based index in the document
                         uri:
                           type: string
@@ -2481,7 +2481,7 @@ actions:
         required: []
         properties:
           maxResults:
-            type: integer
+            type: number
             description: Maximum number of calendars to return, defaults to 250
       output:
         type: object
@@ -2520,7 +2520,7 @@ actions:
             type: string
             description: Optional free-text search query to filter events
           maxResults:
-            type: integer
+            type: number
             description: Maximum number of events to return, defaults to 250
           timeMin:
             type: string
@@ -2716,16 +2716,16 @@ actions:
                   type: object
                   properties:
                     rowCount:
-                      type: integer
+                      type: number
                       description: The number of rows in the sheet
                     columnCount:
-                      type: integer
+                      type: number
                       description: The number of columns in the sheet
                     frozenRowCount:
-                      type: integer
+                      type: number
                       description: The number of frozen rows
                     frozenColumnCount:
-                      type: integer
+                      type: number
                       description: The number of frozen columns
           properties:
             type: object
@@ -2761,13 +2761,13 @@ actions:
               type: object
               properties:
                 sheetId:
-                  type: integer
+                  type: number
                   description: The ID of the sheet
                 title:
                   type: string
                   description: The title of the sheet
                 index:
-                  type: integer
+                  type: number
                   description: The index of the sheet
           error:
             type: string
@@ -2804,10 +2804,10 @@ actions:
                               type: object
                               properties:
                                 rowCount:
-                                  type: integer
+                                  type: number
                                   description: The number of rows in the sheet
                                 columnCount:
-                                  type: integer
+                                  type: number
                                   description: The number of columns in the sheet
                 - type: object
                   description: Delete a sheet
@@ -2816,7 +2816,7 @@ actions:
                       type: object
                       properties:
                         sheetId:
-                          type: integer
+                          type: number
                           description: The ID of the sheet to delete
                 - type: object
                   description: Update cells in a range
@@ -2828,19 +2828,19 @@ actions:
                           type: object
                           properties:
                             sheetId:
-                              type: integer
+                              type: number
                               description: The ID of the sheet
                             startRowIndex:
-                              type: integer
+                              type: number
                               description: The start row (0-based, inclusive)
                             endRowIndex:
-                              type: integer
+                              type: number
                               description: The end row (0-based, exclusive)
                             startColumnIndex:
-                              type: integer
+                              type: number
                               description: The start column (0-based, inclusive)
                             endColumnIndex:
-                              type: integer
+                              type: number
                               description: The end column (0-based, exclusive)
                         rows:
                           type: array
@@ -2873,7 +2873,7 @@ actions:
                           type: object
                           properties:
                             sheetId:
-                              type: integer
+                              type: number
                               description: The ID of the sheet to update
                             title:
                               type: string
@@ -2882,16 +2882,16 @@ actions:
                               type: object
                               properties:
                                 rowCount:
-                                  type: integer
+                                  type: number
                                   description: The new number of rows
                                 columnCount:
-                                  type: integer
+                                  type: number
                                   description: The new number of columns
                                 frozenRowCount:
-                                  type: integer
+                                  type: number
                                   description: The number of frozen rows
                                 frozenColumnCount:
-                                  type: integer
+                                  type: number
                                   description: The number of frozen columns
                         fields:
                           type: string
@@ -2978,7 +2978,7 @@ actions:
                                       type: string
                                       description: The font family
                                     fontSize:
-                                      type: integer
+                                      type: number
                                       description: The size of the font in points
                                     bold:
                                       type: boolean
@@ -3022,13 +3022,13 @@ actions:
                           type: object
                           properties:
                             sheetId:
-                              type: integer
+                              type: number
                               description: The ID of the newly created sheet
                             title:
                               type: string
                               description: The title of the new sheet
                             index:
-                              type: integer
+                              type: number
                               description: The index of the new sheet
           error:
             type: string
@@ -3111,7 +3111,7 @@ actions:
                           type: string
                           description: The object ID for the created slide
                         insertionIndex:
-                          type: integer
+                          type: number
                           description: The 0-based index where the new slide should be inserted
                         slideLayoutReference:
                           type: object
@@ -3149,10 +3149,10 @@ actions:
                           type: string
                           description: The object ID for the created table
                         rows:
-                          type: integer
+                          type: number
                           description: Number of rows in the table
                         columns:
-                          type: integer
+                          type: number
                           description: Number of columns in the table
                         elementProperties:
                           type: object
@@ -3172,7 +3172,7 @@ actions:
                           type: string
                           description: The text to be inserted
                         insertionIndex:
-                          type: integer
+                          type: number
                           description: The index where the text will be inserted
                 - type: object
                   required: [insertTableRows]
@@ -3189,7 +3189,7 @@ actions:
                           type: boolean
                           description: Whether to insert the rows below the reference cell
                         number:
-                          type: integer
+                          type: number
                           description: The number of rows to insert
                         cellLocation:
                           type: object
@@ -3209,7 +3209,7 @@ actions:
                           type: boolean
                           description: Whether to insert the columns to the right of the reference cell
                         number:
-                          type: integer
+                          type: number
                           description: The number of columns to insert
                         cellLocation:
                           type: object
@@ -3319,7 +3319,7 @@ actions:
                           items:
                             type: string
                         insertionIndex:
-                          type: integer
+                          type: number
                           description: The 0-based index where the slides should be moved to
                 - type: object
                   required: [deleteText]
@@ -3337,10 +3337,10 @@ actions:
                           description: The range of text to delete
                           properties:
                             startIndex:
-                              type: integer
+                              type: number
                               description: The starting index of the range (0-based)
                             endIndex:
-                              type: integer
+                              type: number
                               description: The ending index of the range (0-based)
                 - type: object
                   required: [createImage]
@@ -3391,7 +3391,7 @@ actions:
                           type: string
                           description: The ID of the Google Sheets spreadsheet containing the chart
                         chartId:
-                          type: integer
+                          type: number
                           description: The ID of the specific chart in the spreadsheet
                         elementProperties:
                           type: object
@@ -3607,10 +3607,10 @@ actions:
                               enum: [ALL, FROM_START_INDEX, FIXED_RANGE]
                               description: The type of range
                             startIndex:
-                              type: integer
+                              type: number
                               description: The start index for FROM_START_INDEX or FIXED_RANGE
                             endIndex:
-                              type: integer
+                              type: number
                               description: The end index for FIXED_RANGE
                 - type: object
                   required: [replaceAllShapesWithSheetsChart]
@@ -3624,7 +3624,7 @@ actions:
                           type: string
                           description: The ID of the Google Sheets spreadsheet containing the chart
                         chartId:
-                          type: integer
+                          type: number
                           description: The ID of the chart within the spreadsheet
                         containsText:
                           type: object
@@ -3666,10 +3666,10 @@ actions:
                               enum: [ALL, FROM_START_INDEX, FIXED_RANGE]
                               description: The type of range
                             startIndex:
-                              type: integer
+                              type: number
                               description: The start index for FROM_START_INDEX or FIXED_RANGE
                             endIndex:
-                              type: integer
+                              type: number
                               description: The end index for FIXED_RANGE
                 - type: object
                   required: [updateParagraphStyle]
@@ -3697,10 +3697,10 @@ actions:
                               enum: [ALL, FROM_START_INDEX, FIXED_RANGE]
                               description: The type of range
                             startIndex:
-                              type: integer
+                              type: number
                               description: The start index for FROM_START_INDEX or FIXED_RANGE
                             endIndex:
-                              type: integer
+                              type: number
                               description: The end index for FIXED_RANGE
                 - type: object
                   required: [updateTableBorderProperties]
@@ -3731,10 +3731,10 @@ actions:
                               type: object
                               description: The starting cell location
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows in the range
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns in the range
                 - type: object
                   required: [updateTableColumnProperties]
@@ -3750,7 +3750,7 @@ actions:
                         columnIndices:
                           type: array
                           items:
-                            type: integer
+                            type: number
                           description: The 0-based indices of the columns to update
                         tableColumnProperties:
                           type: object
@@ -3772,7 +3772,7 @@ actions:
                         rowIndices:
                           type: array
                           items:
-                            type: integer
+                            type: number
                           description: The 0-based indices of the rows to update
                         tableRowProperties:
                           type: object
@@ -3799,10 +3799,10 @@ actions:
                               type: object
                               description: The starting cell location
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows in the range
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns in the range
                 - type: object
                   required: [unmergeTableCells]
@@ -3823,10 +3823,10 @@ actions:
                               type: object
                               description: The starting cell location
                             rowSpan:
-                              type: integer
+                              type: number
                               description: The number of rows in the range
                             columnSpan:
-                              type: integer
+                              type: number
                               description: The number of columns in the range
                 - type: object
                   required: [groupObjects]
@@ -3978,7 +3978,7 @@ actions:
             items:
               type: string
           limit:
-            type: integer
+            type: number
             description: The maximum number of files to return
       output:
         type: object
@@ -4020,7 +4020,7 @@ actions:
             type: string
             description: The ID of the file to get content from
           limit:
-            type: integer
+            type: number
             description: The character limit for the file content
       output:
         type: object
@@ -4036,7 +4036,7 @@ actions:
             type: string
             description: The name of the file
           fileLength: 
-            type: integer
+            type: number
             description: The length of the file content prior to truncating
           error:
             type: string
@@ -4050,7 +4050,7 @@ actions:
         required: []
         properties:
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of groups to return (max allowed is 200)
       output:
         type: object
@@ -4130,7 +4130,7 @@ actions:
             type: string
             description: The group's email address or unique group ID
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of members to return (max allowed is 200)
       output:
         type: object
@@ -4252,7 +4252,7 @@ actions:
             type: string
             description: Gmail search query (e.g. "from:alice subject:urgent")
           maxResults:
-            type: integer
+            type: number
             description: Maximum number of messages to return (optional)
       output:
         type: object
@@ -4302,7 +4302,7 @@ actions:
             type: string
             description: Gmail search query (e.g. "from:alice subject:project")
           maxResults:
-            type: integer
+            type: number
             description: Maximum number of threads to return
       output:
         type: object
@@ -4493,7 +4493,7 @@ actions:
             type: string
             description: The ID of the user whose groups are to be listed.
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of results to return.
             minimum: 1
       output:
@@ -4549,7 +4549,7 @@ actions:
               https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroups!in=query&path=search&t=request
               Example: 'profile.name eq "My Group"'
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of results to return.
             minimum: 1
       output:
@@ -4688,7 +4688,7 @@ actions:
             type: string
             description: The ID of the group whose members are to be listed.
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of results to return.
             minimum: 1
       output:
@@ -4847,7 +4847,7 @@ actions:
               https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers!in=query&path=search&t=request
               Example: 'profile.email eq "my_user@example.com"'
           maxResults:
-            type: integer
+            type: number
             description: The maximum number of results to return.
             minimum: 1
       output:


### PR DESCRIPTION

- Strangely works when testing via the node env but not in the app 
- Should maintain usage in the app - right now if it sees a field as an integer it treats it as a string 
<img width="580" alt="Screenshot 2025-07-08 at 5 39 15 PM" src="https://github.com/user-attachments/assets/861f96cd-a37e-4573-b379-ad9feeeefc1a" />
