### PR TITLE
Reduce noise in the github search response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.42",
+      "version": "0.2.43",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/github/searchRepository.ts
+++ b/src/actions/providers/github/searchRepository.ts
@@ -107,7 +107,7 @@ const searchRepository: githubSearchRepositoryFunction = async ({
   const codeResults: SearchCodeResult[] = codeResultsResponse.data.items.slice(0, MAX_CODE_RESULTS).map(item => ({
     name: item.name,
     path: item.path,
-    sha: item.sha,
+    sha: item.sha.slice(0, 7),
     url: item.url,
     score: item.score,
     textMatches: item.text_matches

--- a/src/actions/providers/github/searchRepository.ts
+++ b/src/actions/providers/github/searchRepository.ts
@@ -74,11 +74,6 @@ const MAX_FILES_PER_PR = 5;
 const MAX_PATCH_LINES = 20;
 const MAX_FRAGMENT_LINES = 20;
 
-/**
- * TODO:
- * - the repo is hard coded. drop all the repo information
- * - drop the sha information, its just noise.
- */
 const searchRepository: githubSearchRepositoryFunction = async ({
   params,
   authParams,

--- a/src/actions/providers/github/searchRepository.ts
+++ b/src/actions/providers/github/searchRepository.ts
@@ -11,10 +11,6 @@ interface SearchCodeResult {
   path: string;
   sha: string;
   url: string;
-  repository: {
-    full_name: string;
-    html_url: string;
-  };
   score: number;
   textMatches: TextMatch[];
 }
@@ -78,6 +74,11 @@ const MAX_FILES_PER_PR = 5;
 const MAX_PATCH_LINES = 20;
 const MAX_FRAGMENT_LINES = 20;
 
+/**
+ * TODO:
+ * - the repo is hard coded. drop all the repo information
+ * - drop the sha information, its just noise.
+ */
 const searchRepository: githubSearchRepositoryFunction = async ({
   params,
   authParams,
@@ -108,10 +109,6 @@ const searchRepository: githubSearchRepositoryFunction = async ({
     path: item.path,
     sha: item.sha,
     url: item.url,
-    repository: {
-      full_name: item.repository.full_name,
-      html_url: item.repository.html_url,
-    },
     score: item.score,
     textMatches: item.text_matches
       ? item.text_matches.map(match => ({


### PR DESCRIPTION
1. Repo is hard coded in the query so this is totally moot
2. Sha is noise, doesnt seem to be used anywhere either, but decided to keep it for backcompat/so the AI can tell the user, but shorten it to the almost-always-safe github standard of 7 chars