### PR TITLE
[Actions] Add timeout to get file calls (some don't complete)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.51",
+      "version": "0.2.52",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/google-oauth/getDriveFileContentById.ts
+++ b/src/actions/providers/google-oauth/getDriveFileContentById.ts
@@ -1,4 +1,4 @@
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithTimeout } from "../../util/axiosClient.js";
 import mammoth from "mammoth";
 import type {
   AuthParamsType,
@@ -27,6 +27,7 @@ const getDriveFileContentById: googleOauthGetDriveFileContentByIdFunction = asyn
 
   const BASE_URL = "https://www.googleapis.com/drive/v3/files/";
   const { fileId, limit } = params;
+  const axiosClient = createAxiosClientWithTimeout(20000);
 
   try {
     // First, get file metadata to determine the file type and if it's in a shared drive

--- a/src/actions/util/axiosClient.ts
+++ b/src/actions/util/axiosClient.ts
@@ -15,8 +15,10 @@ export class ApiError extends Error {
 }
 
 /** Create a configured axios instance with interceptors */
-function createAxiosClient(): AxiosInstance {
-  const instance = axios.create();
+function createAxiosClient(timeout?: number): AxiosInstance {
+  const instance = axios.create({
+    timeout: timeout,
+  });
 
   instance.interceptors.request.use(
     config => {
@@ -57,3 +59,7 @@ function createAxiosClient(): AxiosInstance {
 }
 
 export const axiosClient = createAxiosClient();
+
+export function createAxiosClientWithTimeout(timeout: number): AxiosInstance {
+  return createAxiosClient(timeout);
+}


### PR DESCRIPTION

Some action calls were not completing around getFileContentById
- could be because the file is extremely large 
- almost all request finish in 2-3 seconds - so we're going to ignore any files over a very generous limit (20 seconds)