### PR TITLE
[Google Actions] Dont retry if timeout failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.53",
+      "version": "0.2.54",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/util/axiosClient.ts
+++ b/src/actions/util/axiosClient.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { AxiosError, AxiosInstance, AxiosResponse } from "axios";
+import type { AxiosInstance, AxiosResponse } from "axios";
+import type { AxiosError } from "axios";
 import axios from "axios";
 
 export class ApiError extends Error {
@@ -12,6 +13,10 @@ export class ApiError extends Error {
     this.status = status;
     this.data = data;
   }
+}
+
+export function isAxiosTimeoutError(error: unknown): boolean {
+  return error instanceof ApiError && !error.status && !error.data;
 }
 
 /** Create a configured axios instance with interceptors */


### PR DESCRIPTION
### Changes: 
- Noticed we were getting alot of actions that take ~40s
- Whats happening is that the original google call is timing out - and we try export as a backup, but that usually will fail with a timeout if the original does
- There's no reason to try both - so in this code we don't do that which should bring timeout to ~20s 