### PR TITLE
Have Slack action take in channelId optionally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.70",
+      "version": "0.2.71",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -615,11 +615,16 @@ export const slackGetChannelMessagesDefinition: ActionTemplate = {
   scopes: ["channels:history"],
   parameters: {
     type: "object",
-    required: ["channelName", "oldest"],
+    required: ["oldest"],
     properties: {
+      channelId: {
+        type: "string",
+        description:
+          "The ID of the channel to get messages from. Either the channelId or channelName must be provided.",
+      },
       channelName: {
         type: "string",
-        description: "Name of the channel to summarize",
+        description: "Name of the channel to summarize. Either the channelId or channelName must be provided.",
       },
       oldest: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -361,7 +361,14 @@ export type slackSendMessageFunction = ActionFunction<
 >;
 
 export const slackGetChannelMessagesParamsSchema = z.object({
-  channelName: z.string().describe("Name of the channel to summarize"),
+  channelId: z
+    .string()
+    .describe("The ID of the channel to get messages from. Either the channelId or channelName must be provided.")
+    .optional(),
+  channelName: z
+    .string()
+    .describe("Name of the channel to summarize. Either the channelId or channelName must be provided.")
+    .optional(),
   oldest: z.string().describe("Only messages after this Unix timestamp will be included in results"),
 });
 

--- a/src/actions/providers/slack/getChannelMessages.ts
+++ b/src/actions/providers/slack/getChannelMessages.ts
@@ -28,21 +28,28 @@ const getChannelMessages: slackGetChannelMessagesFunction = async ({
   }
 
   const client = new WebClient(authParams.authToken);
-  const { channelName, oldest } = params;
+  const { channelId: inputChannelId, channelName, oldest } = params;
+  if (!inputChannelId && !channelName) {
+    throw Error("Either channelId or channelName must be provided");
+  }
 
-  const allChannels = await getSlackChannels(client);
-  const channel = allChannels.find(channel => channel.name === channelName && channel.is_private === false);
+  let channelId = inputChannelId;
+  if (!channelId) {
+    const allChannels = await getSlackChannels(client);
+    const channel = allChannels.find(channel => channel.name === channelName && channel.is_private === false);
 
-  if (!channel || !channel.id) {
-    throw Error(`Channel with name ${channelName} not found`);
+    if (!channel || !channel.id) {
+      throw Error(`Channel with name ${channelName} not found`);
+    }
+    channelId = channel.id;
   }
 
   const messages = await client.conversations.history({
-    channel: channel.id,
+    channel: channelId,
     oldest: oldest,
   });
   if (!messages.ok) {
-    throw Error(`Failed to fetch messages from channel ${channel.name}`);
+    throw Error(`Failed to fetch messages from channel ${channelName}, channelId: ${channelId}`);
   }
 
   return {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -428,11 +428,14 @@ actions:
         - channels:history
       parameters:
         type: object
-        required: [channelName, oldest]
+        required: [oldest]
         properties:
+          channelId:
+            type: string
+            description: The ID of the channel to get messages from. Either the channelId or channelName must be provided.
           channelName:
             type: string
-            description: Name of the channel to summarize
+            description: Name of the channel to summarize. Either the channelId or channelName must be provided.
           oldest:
             type: string
             description: Only messages after this Unix timestamp will be included in results

--- a/tests/slack/testSlackGetChannelMessages.ts
+++ b/tests/slack/testSlackGetChannelMessages.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 async function runTest() {
   const params = {
@@ -7,7 +10,7 @@ async function runTest() {
     oldest: "insert-oldest-timestamp",
   };
   const authParams = {
-    authToken: "insert-oauth-access-token",
+    authToken: process.env.SLACK_AUTH_TOKEN,
   };
 
   try {


### PR DESCRIPTION
Allow getChannelMessages to directly take in a `channelId` for perf gain

Ran `npm run test tests/slack/testSlackGetChannelMessages.ts` with `channelId` only and `channelName` only