### PR TITLE
[Google Calender/Email] Add in these actions

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -97,6 +97,8 @@ import {
   googleOauthUpdateCalendarEventOutputSchema,
   googleOauthDeleteCalendarEventParamsSchema,
   googleOauthDeleteCalendarEventOutputSchema,
+  googleOauthEditAGoogleCalendarEventParamsSchema,
+  googleOauthEditAGoogleCalendarEventOutputSchema,
   googleOauthCreatePresentationParamsSchema,
   googleOauthCreatePresentationOutputSchema,
   googleOauthUpdatePresentationParamsSchema,
@@ -312,6 +314,7 @@ import listCalendars from "./providers/google-oauth/listCalendars.js";
 import listCalendarEvents from "./providers/google-oauth/listCalendarEvents.js";
 import updateCalendarEvent from "./providers/google-oauth/updateCalendarEvent.js";
 import deleteCalendarEvent from "./providers/google-oauth/deleteCalendarEvent.js";
+import editAGoogleCalendarEvent from "./providers/google-oauth/editAGoogleCalendarEvent.js";
 import createSpreadsheet from "./providers/google-oauth/createSpreadsheet.js";
 import updateSpreadsheet from "./providers/google-oauth/updateSpreadsheet.js";
 import createPresentation from "./providers/google-oauth/createPresentation.js";
@@ -769,6 +772,11 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: deleteCalendarEvent,
       paramsSchema: googleOauthDeleteCalendarEventParamsSchema,
       outputSchema: googleOauthDeleteCalendarEventOutputSchema,
+    },
+    editAGoogleCalendarEvent: {
+      fn: editAGoogleCalendarEvent,
+      paramsSchema: googleOauthEditAGoogleCalendarEventParamsSchema,
+      outputSchema: googleOauthEditAGoogleCalendarEventOutputSchema,
     },
     listGroups: {
       fn: listGroups,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4589,6 +4589,94 @@ export const googleOauthUpdateCalendarEventDefinition: ActionTemplate = {
   name: "updateCalendarEvent",
   provider: "googleOauth",
 };
+export const googleOauthEditAGoogleCalendarEventDefinition: ActionTemplate = {
+  description: "Edit an existing Google Calendar event using OAuth authentication",
+  scopes: ["https://www.googleapis.com/auth/calendar"],
+  parameters: {
+    type: "object",
+    required: ["calendarId", "eventId"],
+    properties: {
+      calendarId: {
+        type: "string",
+        description: "The ID of the calendar containing the event",
+      },
+      eventId: {
+        type: "string",
+        description: "The ID of the event to edit",
+      },
+      title: {
+        type: "string",
+        description: "The new title/summary of the event",
+      },
+      description: {
+        type: "string",
+        description: "The new description of the event",
+      },
+      start: {
+        type: "string",
+        description: "The new start date/time (RFC3339 timestamp)",
+      },
+      end: {
+        type: "string",
+        description: "The new end date/time (RFC3339 timestamp)",
+      },
+      location: {
+        type: "string",
+        description: "The new location of the event",
+      },
+      attendees: {
+        type: "array",
+        description: "The new list of attendees (replaces existing attendees)",
+        items: {
+          type: "string",
+          description: "The email address of the attendee",
+        },
+      },
+      status: {
+        type: "string",
+        description: "The new status of the event (confirmed, tentative, cancelled)",
+      },
+      organizer: {
+        type: "object",
+        description: "The new organizer of the event",
+        properties: {
+          email: {
+            type: "string",
+            description: "The organizer's email address",
+          },
+          displayName: {
+            type: "string",
+            description: "The organizer's display name",
+          },
+        },
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the event was edited successfully",
+      },
+      eventId: {
+        type: "string",
+        description: "The ID of the edited event",
+      },
+      eventUrl: {
+        type: "string",
+        description: "The URL to access the edited event",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the event was not edited successfully",
+      },
+    },
+  },
+  name: "editAGoogleCalendarEvent",
+  provider: "googleOauth",
+};
 export const googleOauthDeleteCalendarEventDefinition: ActionTemplate = {
   description: "Delete an event from a Google Calendar using OAuth authentication",
   scopes: ["https://www.googleapis.com/auth/calendar"],
@@ -7216,7 +7304,7 @@ export const googlemailSendGmailDefinition: ActionTemplate = {
       },
       content: {
         type: "string",
-        description: "Email body content (plain text or HTML)",
+        description: "Email body content in HTML format",
       },
       threadId: {
         type: "string",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -7218,6 +7218,10 @@ export const googlemailSendGmailDefinition: ActionTemplate = {
         type: "string",
         description: "Email body content (plain text or HTML)",
       },
+      threadId: {
+        type: "string",
+        description: "Optional thread ID to reply to an existing email thread",
+      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2368,6 +2368,48 @@ export type googleOauthUpdateCalendarEventFunction = ActionFunction<
   googleOauthUpdateCalendarEventOutputType
 >;
 
+export const googleOauthEditAGoogleCalendarEventParamsSchema = z.object({
+  calendarId: z.string().describe("The ID of the calendar containing the event"),
+  eventId: z.string().describe("The ID of the event to edit"),
+  title: z.string().describe("The new title/summary of the event").optional(),
+  description: z.string().describe("The new description of the event").optional(),
+  start: z.string().describe("The new start date/time (RFC3339 timestamp)").optional(),
+  end: z.string().describe("The new end date/time (RFC3339 timestamp)").optional(),
+  location: z.string().describe("The new location of the event").optional(),
+  attendees: z
+    .array(z.string().describe("The email address of the attendee"))
+    .describe("The new list of attendees (replaces existing attendees)")
+    .optional(),
+  status: z.string().describe("The new status of the event (confirmed, tentative, cancelled)").optional(),
+  organizer: z
+    .object({
+      email: z.string().describe("The organizer's email address").optional(),
+      displayName: z.string().describe("The organizer's display name").optional(),
+    })
+    .describe("The new organizer of the event")
+    .optional(),
+});
+
+export type googleOauthEditAGoogleCalendarEventParamsType = z.infer<
+  typeof googleOauthEditAGoogleCalendarEventParamsSchema
+>;
+
+export const googleOauthEditAGoogleCalendarEventOutputSchema = z.object({
+  success: z.boolean().describe("Whether the event was edited successfully"),
+  eventId: z.string().describe("The ID of the edited event").optional(),
+  eventUrl: z.string().describe("The URL to access the edited event").optional(),
+  error: z.string().describe("The error that occurred if the event was not edited successfully").optional(),
+});
+
+export type googleOauthEditAGoogleCalendarEventOutputType = z.infer<
+  typeof googleOauthEditAGoogleCalendarEventOutputSchema
+>;
+export type googleOauthEditAGoogleCalendarEventFunction = ActionFunction<
+  googleOauthEditAGoogleCalendarEventParamsType,
+  AuthParamsType,
+  googleOauthEditAGoogleCalendarEventOutputType
+>;
+
 export const googleOauthDeleteCalendarEventParamsSchema = z.object({
   calendarId: z.string().describe("The ID of the calendar containing the event"),
   eventId: z.string().describe("The ID of the event to delete"),
@@ -3709,7 +3751,7 @@ export const googlemailSendGmailParamsSchema = z.object({
   cc: z.array(z.string()).describe("List of CC recipient email addresses (optional)").optional(),
   bcc: z.array(z.string()).describe("List of BCC recipient email addresses (optional)").optional(),
   subject: z.string().describe("Email subject line"),
-  content: z.string().describe("Email body content (plain text or HTML)"),
+  content: z.string().describe("Email body content in HTML format"),
   threadId: z.string().describe("Optional thread ID to reply to an existing email thread").optional(),
 });
 

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -3710,6 +3710,7 @@ export const googlemailSendGmailParamsSchema = z.object({
   bcc: z.array(z.string()).describe("List of BCC recipient email addresses (optional)").optional(),
   subject: z.string().describe("Email subject line"),
   content: z.string().describe("Email body content (plain text or HTML)"),
+  threadId: z.string().describe("Optional thread ID to reply to an existing email thread").optional(),
 });
 
 export type googlemailSendGmailParamsType = z.infer<typeof googlemailSendGmailParamsSchema>;

--- a/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
@@ -1,0 +1,58 @@
+import { axiosClient } from "../../util/axiosClient.js";
+import type { AxiosResponse } from "axios";
+import type {
+  AuthParamsType,
+  googleOauthEditAGoogleCalendarEventFunction,
+  googleOauthEditAGoogleCalendarEventOutputType,
+  googleOauthEditAGoogleCalendarEventParamsType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+
+const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = async ({
+  params,
+  authParams,
+}: {
+  params: googleOauthEditAGoogleCalendarEventParamsType;
+  authParams: AuthParamsType;
+}): Promise<googleOauthEditAGoogleCalendarEventOutputType> => {
+  if (!authParams.authToken) {
+    return { success: false, error: MISSING_AUTH_TOKEN, eventId: "", eventUrl: "" };
+  }
+
+  const { calendarId, eventId, title, description, start, end, location, attendees, status, organizer } = params;
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
+
+  const body: Record<string, unknown> = {};
+  if (title !== undefined) body.summary = title;
+  if (description !== undefined) body.description = description;
+  if (start !== undefined) body.start = { dateTime: start };
+  if (end !== undefined) body.end = { dateTime: end };
+  if (location !== undefined) body.location = location;
+  if (attendees !== undefined) body.attendees = attendees.map(email => ({ email }));
+  if (status !== undefined) body.status = status;
+  if (organizer !== undefined) body.organizer = organizer;
+
+  try {
+    const res: AxiosResponse = await axiosClient.patch(url, body, {
+      headers: {
+        Authorization: `Bearer ${authParams.authToken}`,
+      },
+    });
+
+    const { id, htmlLink } = res.data;
+    return {
+      success: true,
+      eventId: id,
+      eventUrl: htmlLink,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error editing event",
+      eventId: "",
+      eventUrl: "",
+    };
+  }
+};
+
+export default editAGoogleCalendarEvent;

--- a/src/actions/providers/googlemail/sendGmail.ts
+++ b/src/actions/providers/googlemail/sendGmail.ts
@@ -18,7 +18,7 @@ const sendGmail: googlemailSendGmailFunction = async ({
     return { success: false, error: MISSING_AUTH_TOKEN };
   }
 
-  const { to, cc, bcc, subject, content } = params;
+  const { to, cc, bcc, subject, content, threadId } = params;
 
   try {
     // Create the email message in RFC 2822 format
@@ -40,6 +40,7 @@ const sendGmail: googlemailSendGmailFunction = async ({
     // Add subject
     message += `Subject: ${subject}\r\n`;
     message += `Content-Type: text/html; charset=utf-8\r\n`;
+    message += `MIME-Version: 1.0\r\n`;
     message += `\r\n`;
     message += content;
 
@@ -50,11 +51,17 @@ const sendGmail: googlemailSendGmailFunction = async ({
       .replace(/\//g, "_")
       .replace(/=+$/, "");
 
+    const requestBody: { raw: string; threadId?: string } = {
+      raw: encodedMessage,
+    };
+
+    if (threadId) {
+      requestBody.threadId = threadId;
+    }
+
     const response = await axiosClient.post(
       "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-      {
-        raw: encodedMessage,
-      },
+      requestBody,
       {
         headers: {
           Authorization: `Bearer ${authParams.authToken}`,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -4600,7 +4600,10 @@ actions:
             description: Email subject line
           content:
             type: string
-            description: Email body content (plain text or HTML)
+            description: Email body content in HTML format
+          threadId:
+            type: string
+            description: Optional thread ID to reply to an existing email thread
       output:
         type: object
         required: [success]

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2787,6 +2787,69 @@ actions:
           error:
             type: string
             description: The error that occurred if the event was not updated successfully
+    editAGoogleCalendarEvent:
+      description: Edit an existing Google Calendar event using OAuth authentication
+      scopes: [https://www.googleapis.com/auth/calendar]
+      parameters:
+        type: object
+        required: [calendarId, eventId]
+        properties:
+          calendarId:
+            type: string
+            description: The ID of the calendar containing the event
+          eventId:
+            type: string
+            description: The ID of the event to edit
+          title:
+            type: string
+            description: The new title/summary of the event
+          description:
+            type: string
+            description: The new description of the event
+          start:
+            type: string
+            description: The new start date/time (RFC3339 timestamp)
+          end:
+            type: string
+            description: The new end date/time (RFC3339 timestamp)
+          location:
+            type: string
+            description: The new location of the event
+          attendees:
+            type: array
+            description: The new list of attendees (replaces existing attendees)
+            items:
+              type: string
+              description: The email address of the attendee
+          status:
+            type: string
+            description: The new status of the event (confirmed, tentative, cancelled)
+          organizer:
+            type: object
+            description: The new organizer of the event
+            properties:
+              email:
+                type: string
+                description: The organizer's email address
+              displayName:
+                type: string
+                description: The organizer's display name
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the event was edited successfully
+          eventId:
+            type: string
+            description: The ID of the edited event
+          eventUrl:
+            type: string
+            description: The URL to access the edited event
+          error:
+            type: string
+            description: The error that occurred if the event was not edited successfully
     deleteCalendarEvent:
       description: Delete an event from a Google Calendar using OAuth authentication
       scopes: [https://www.googleapis.com/auth/calendar]

--- a/tests/google-oauth/testEditAGoogleCalendarEvent.ts
+++ b/tests/google-oauth/testEditAGoogleCalendarEvent.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+async function runTest() {
+  const result = await runAction(
+    "editAGoogleCalendarEvent",
+    "googleOauth",
+    { authToken: process.env.GOOGLE_OAUTH_EDIT_EVENT_SCOPE },
+    {
+      calendarId: "primary",
+      eventId: "19ta0khreli30ib22n2c2717vd", 
+      title: "Edited Event Title",
+      description: "Edited event description",
+      start: new Date(Date.now() + 3600 * 1000).toISOString(),
+      end: new Date(Date.now() + 2 * 3600 * 1000).toISOString(),
+      location: "Conference Room A",
+      attendees: ["colleague@example.com", "manager@example.com"],
+      status: "confirmed",
+    },
+  );
+
+  assert(result, "Response should not be null");
+  assert(result.success, "Success should be true");
+  assert(typeof result.eventId === "string" && result.eventId.length > 0, "Should return eventId");
+  assert(typeof result.eventUrl === "string" && result.eventUrl.length > 0, "Should return eventUrl");
+  console.log(`Successfully edited event: ${result.eventId}`);
+  console.log("Response: ", result);
+}
+
+runTest().catch((error) => {
+  console.error("Test failed:", error);
+  if (error.response) {
+    console.error("API response:", error.response.data);
+    console.error("Status code:", error.response.status);
+  }
+  process.exit(1);
+});

--- a/tests/google-oauth/testListCalendarEvents.ts
+++ b/tests/google-oauth/testListCalendarEvents.ts
@@ -1,12 +1,22 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
 
 async function runTest() {
+
+  const now = new Date();
+  const weekBeg = new Date(now.setDate(now.getDate() - now.getDay())); // Sunday 00:00
+  weekBeg.setHours(0, 0, 0, 0);
+  const weekEnd = new Date(+weekBeg + 7 * 864e5);
+
+
   const result = await runAction(
     "listCalendarEvents",
     "googleOauth",
-    { authToken: "auth-token-with-calendar-scope-here" },
-    { calendarId: "primary", query: "optional-query-here", maxResults: 2 },
+    { authToken: process.env.GOOGLE_OAUTH_LIST_EVENT_SCOPE },
+    { calendarId: "primary", query: "", maxResults: 50, timeMin: weekBeg.toISOString(), timeMax: weekEnd.toISOString() },
   );
 
   assert(result, "Response should not be null");

--- a/tests/googlemail/testSendGmail.ts
+++ b/tests/googlemail/testSendGmail.ts
@@ -13,7 +13,7 @@ async function runTest() {
     cc: ["cc@example.com"], // optional field
     bcc: ["bcc@example.com"], // optional field
     subject: "Test Email from Gmail API",
-    content: "This is a test email sent through the Gmail API. Please ignore this message.",
+    content: "<html><body><h1>Test Email</h1><p>This is a <strong>test email</strong> sent through the Gmail API with <em>HTML content</em>. Please ignore this message.</p></body></html>",
   };
 
   const result = await runAction(


### PR DESCRIPTION
### Action Updates:
- Google sendGmail action now accepts HTML as a param over typical text content 
- Google sendGmail now has an optional threadId so it can be used to reply to threads

## New Actions:
- Google Calendar action - ability to edit a existing google calendar event