### PR TITLE
[Resend HTML] param resolution fails for html param name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -3167,7 +3167,7 @@ export const resendSendEmailHtmlDefinition: ActionTemplate = {
   scopes: [],
   parameters: {
     type: "object",
-    required: ["to", "subject", "html"],
+    required: ["to", "subject", "content"],
     properties: {
       to: {
         type: "string",
@@ -3177,9 +3177,9 @@ export const resendSendEmailHtmlDefinition: ActionTemplate = {
         type: "string",
         description: "The subject of the email",
       },
-      html: {
+      content: {
         type: "string",
-        description: "The HTML content of the email",
+        description: "The HTML content of the email to be sent",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1667,7 +1667,7 @@ export type resendSendEmailFunction = ActionFunction<
 export const resendSendEmailHtmlParamsSchema = z.object({
   to: z.string().describe("The email address to send the email to"),
   subject: z.string().describe("The subject of the email"),
-  html: z.string().describe("The HTML content of the email"),
+  content: z.string().describe("The HTML content of the email to be sent"),
 });
 
 export type resendSendEmailHtmlParamsType = z.infer<typeof resendSendEmailHtmlParamsSchema>;

--- a/src/actions/providers/resend/sendEmailHtml.ts
+++ b/src/actions/providers/resend/sendEmailHtml.ts
@@ -23,7 +23,7 @@ const sendEmailHtml: resendSendEmailHtmlFunction = async ({
       bcc: authParams.emailBcc,
       to: params.to,
       subject: params.subject,
-      html: params.html,
+      html: params.content,
     });
 
     if (result.error) {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1784,7 +1784,7 @@ actions:
       scopes: []
       parameters:
         type: object
-        required: [to, subject, html]
+        required: [to, subject, content]
         properties:
           to:
             type: string
@@ -1792,9 +1792,9 @@ actions:
           subject:
             type: string
             description: The subject of the email
-          html:
+          content:
             type: string
-            description: The HTML content of the email
+            description: The HTML content of the email to be sent
       output:
         type: object
         required: [success]

--- a/tests/resend/testResendSendEmailHtml.ts
+++ b/tests/resend/testResendSendEmailHtml.ts
@@ -13,7 +13,7 @@ async function runTest() {
     {
       to: "insert-during-testing",
       subject: "Test HTML Email",
-      html: "<h1>This is a test HTML email</h1><p>This email contains <strong>HTML content</strong>.</p>",
+      content: "<h1>This is a test HTML email</h1><p>This email contains <strong>HTML content</strong>.</p>",
     },
   );
   console.log(result);


### PR DESCRIPTION
- Some reason the LLM fails when the param name is Html 
- However have a similar action tha works fine when the param name is content (which is more relevant) 
- Adding in this fix now