### PR TITLE
Option to use Channel ID for all Slack actions with fallback for channel Name

### DIFF
--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -551,8 +551,12 @@ export const slackArchiveChannelDefinition: ActionTemplate = {
   scopes: ["channels:manage"],
   parameters: {
     type: "object",
-    required: ["channelName"],
+    required: [],
     properties: {
+      channelId: {
+        type: "string",
+        description: "The ID of the channel to archive",
+      },
       channelName: {
         type: "string",
         description: "The name of the channel to archive",
@@ -581,8 +585,12 @@ export const slackSendMessageDefinition: ActionTemplate = {
   scopes: ["chat:write"],
   parameters: {
     type: "object",
-    required: ["channelName", "message"],
+    required: ["message"],
     properties: {
+      channelId: {
+        type: "string",
+        description: "The ID of the channel to send the message to",
+      },
       channelName: {
         type: "string",
         description: "The name of the Slack channel to send the message to (e.g. general, alerts)",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -325,7 +325,8 @@ export type slackCreateChannelFunction = ActionFunction<
 >;
 
 export const slackArchiveChannelParamsSchema = z.object({
-  channelName: z.string().describe("The name of the channel to archive"),
+  channelId: z.string().describe("The ID of the channel to archive").optional(),
+  channelName: z.string().describe("The name of the channel to archive").optional(),
 });
 
 export type slackArchiveChannelParamsType = z.infer<typeof slackArchiveChannelParamsSchema>;
@@ -343,7 +344,11 @@ export type slackArchiveChannelFunction = ActionFunction<
 >;
 
 export const slackSendMessageParamsSchema = z.object({
-  channelName: z.string().describe("The name of the Slack channel to send the message to (e.g. general, alerts)"),
+  channelId: z.string().describe("The ID of the channel to send the message to").optional(),
+  channelName: z
+    .string()
+    .describe("The name of the Slack channel to send the message to (e.g. general, alerts)")
+    .optional(),
   message: z.string().describe("The message content to send to Slack. Can include markdown formatting."),
 });
 

--- a/src/actions/providers/slack/archiveChannel.ts
+++ b/src/actions/providers/slack/archiveChannel.ts
@@ -21,18 +21,21 @@ const archiveChannel: slackArchiveChannelFunction = async ({
 
   try {
     const client = new WebClient(authParams.authToken);
-    const { channelName } = params;
+    const { channelId: inputChannelId, channelName } = params;
+    if (!inputChannelId && !channelName) {
+      throw Error("Either channelId or channelName must be provided");
+    }
 
     const allChannels = await getSlackChannels(client);
-    const channel = allChannels.find(channel => channel.name == channelName);
+    const channelId = inputChannelId ?? allChannels.find(channel => channel.name == channelName)?.id;
 
-    if (!channel || !channel.id) {
+    if (!channelId) {
       throw Error(`Channel with name ${channelName} not found`);
     }
 
-    await client.conversations.join({ channel: channel.id });
+    await client.conversations.join({ channel: channelId });
 
-    const result = await client.conversations.archive({ channel: channel.id });
+    const result = await client.conversations.archive({ channel: channelId });
     if (!result.ok) {
       return {
         success: false,

--- a/src/actions/providers/slack/getChannelMessages.ts
+++ b/src/actions/providers/slack/getChannelMessages.ts
@@ -36,7 +36,7 @@ const getChannelMessages: slackGetChannelMessagesFunction = async ({
   let channelId = inputChannelId;
   if (!channelId) {
     const allChannels = await getSlackChannels(client);
-    const channel = allChannels.find(channel => channel.name === channelName && channel.is_private === false);
+    const channel = allChannels.find(channel => channel.name === channelName);
 
     if (!channel || !channel.id) {
       throw Error(`Channel with name ${channelName} not found`);

--- a/src/actions/providers/slack/helpers.ts
+++ b/src/actions/providers/slack/helpers.ts
@@ -10,6 +10,7 @@ export async function getSlackChannels(client: WebClient): Promise<ChannelWithId
   const allChannelsIterable = await client.paginate("conversations.list", {
     exclude_archived: true,
     limit,
+    types: "public_channel,private_channel",
   });
 
   for await (const page of allChannelsIterable as AsyncIterable<ConversationsListResponse>) {

--- a/src/actions/providers/slack/sendMessage.ts
+++ b/src/actions/providers/slack/sendMessage.ts
@@ -20,19 +20,23 @@ const sendMessage: slackSendMessageFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
+  const { channelId: inputChannelId, channelName, message } = params;
+  if (!inputChannelId && !channelName) {
+    throw Error("Either channelId or channelName must be provided");
+  }
+
   const client = new WebClient(authParams.authToken);
-  const { channelName, message } = params;
 
   const allChannels = await getSlackChannels(client);
-  const channel = allChannels.find(channel => channel.name == channelName);
+  const channelId = inputChannelId ?? allChannels.find(channel => channel.name == channelName)?.id;
 
-  if (!channel || !channel.id) {
+  if (!channelId) {
     throw Error(`Channel with name ${channelName} not found`);
   }
 
   try {
     await client.chat.postMessage({
-      channel: channel.id,
+      channel: channelId,
       blocks: [
         {
           type: "section",

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -383,8 +383,11 @@ actions:
         - channels:manage
       parameters:
         type: object
-        required: [channelName]
+        required: []
         properties:
+          channelId:
+            type: string
+            description: The ID of the channel to archive
           channelName:
             type: string
             description: The name of the channel to archive
@@ -404,8 +407,11 @@ actions:
         - chat:write
       parameters:
         type: object
-        required: [channelName, message]
+        required: [message]
         properties:
+          channelId:
+            type: string
+            description: The ID of the channel to send the message to
           channelName:
             type: string
             description: The name of the Slack channel to send the message to (e.g. general, alerts)

--- a/tests/slack/testSlackArchiveChannel.ts
+++ b/tests/slack/testSlackArchiveChannel.ts
@@ -9,23 +9,47 @@ async function runTest() {
     "archiveChannel",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { channelName: process.env.SLACK_TEST_CHANNEL_NAME },
+    { channelName: process.env.SLACK_TEST_PUBLIC_CHANNEL_NAME },
   );
   const result2 = await runAction(
     "archiveChannel",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { channelId: process.env.SLACK_TEST_CHANNEL_ID },
+    { channelId: process.env.SLACK_TEST_PUBLIC_CHANNEL_ID },
   );
-  assert(result1, "Response should not be null");
-  assert(result1.success, "Channel archiving should be successful");
-  console.log(
-    "Archive Channel Test Response 1: " + JSON.stringify(result1, null, 2),
+  const result3 = await runAction(
+    "archiveChannel",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelName: process.env.SLACK_TEST_PRIVATE_CHANNEL_NAME },
   );
-  assert(result2, "Response should not be null");
-  assert(result2.success, "Channel archiving should be successful");
+  const result4 = await runAction(
+    "archiveChannel",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelId: process.env.SLACK_TEST_PRIVATE_CHANNEL_ID },
+  );
+  
+  assert(result1, "Public channel name response should not be null");
+  assert(result1.success, "Public channel name archiving should be successful");
+  assert(result2, "Public channel ID response should not be null");
+  assert(result2.success, "Public channel ID archiving should be successful");
+  assert(result3, "Private channel name response should not be null");
+  assert(result3.success, "Private channel name archiving should be successful");
+  assert(result4, "Private channel ID response should not be null");
+  assert(result4.success, "Private channel ID archiving should be successful");
+  
   console.log(
-    "Archive Channel Test Response 2: " + JSON.stringify(result2, null, 2),
+    "Archive Channel Test Response 1 (public name): " + JSON.stringify(result1, null, 2),
+  );
+  console.log(
+    "Archive Channel Test Response 2 (public ID): " + JSON.stringify(result2, null, 2),
+  );
+  console.log(
+    "Archive Channel Test Response 3 (private name): " + JSON.stringify(result3, null, 2),
+  );
+  console.log(
+    "Archive Channel Test Response 4 (private ID): " + JSON.stringify(result4, null, 2),
   );
 }
 

--- a/tests/slack/testSlackArchiveChannel.ts
+++ b/tests/slack/testSlackArchiveChannel.ts
@@ -5,16 +5,27 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-  const result = await runAction(
+  const result1 = await runAction(
     "archiveChannel",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
     { channelName: process.env.SLACK_TEST_CHANNEL_NAME },
   );
-  assert(result, "Response should not be null");
-  assert(result.success, "Channel archiving should be successful");
+  const result2 = await runAction(
+    "archiveChannel",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelId: process.env.SLACK_TEST_CHANNEL_ID },
+  );
+  assert(result1, "Response should not be null");
+  assert(result1.success, "Channel archiving should be successful");
   console.log(
-    "Archive Channel Test Response: " + JSON.stringify(result, null, 2),
+    "Archive Channel Test Response 1: " + JSON.stringify(result1, null, 2),
+  );
+  assert(result2, "Response should not be null");
+  assert(result2.success, "Channel archiving should be successful");
+  console.log(
+    "Archive Channel Test Response 2: " + JSON.stringify(result2, null, 2),
   );
 }
 

--- a/tests/slack/testSlackCreateChannel.ts
+++ b/tests/slack/testSlackCreateChannel.ts
@@ -5,24 +5,46 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-  const channelName = "test-channel-" + Math.floor(Math.random() * 10000);
-  console.log("Creating channel: " + channelName);
-  const result = await runAction(
+  const publicChannelName = "test-channel-123";
+  const privateChannelName = "test-private-channel-123";
+  
+  console.log("Creating public channel: " + publicChannelName);
+  const result1 = await runAction(
     "createChannel",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
     {
-      channelName,
+      channelName: publicChannelName,
       isPrivate: false,
     },
   );
 
-  assert(result, "Response should not be null");
-  assert(result.success, "Channel creation should be successful");
-  assert(result.channelId, "Response should contain channelId");
-  assert(result.channelUrl, "Response should contain channelUrl");
+  console.log("Creating private channel: " + privateChannelName);
+  const result2 = await runAction(
+    "createChannel",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    {
+      channelName: privateChannelName,
+      isPrivate: true,
+    },
+  );
+
+  assert(result1, "Public channel response should not be null");
+  assert(result1.success, "Public channel creation should be successful");
+  assert(result1.channelId, "Public channel response should contain channelId");
+  assert(result1.channelUrl, "Public channel response should contain channelUrl");
+  
+  assert(result2, "Private channel response should not be null");
+  assert(result2.success, "Private channel creation should be successful");
+  assert(result2.channelId, "Private channel response should contain channelId");
+  assert(result2.channelUrl, "Private channel response should contain channelUrl");
+  
   console.log(
-    "Create channel test response: " + JSON.stringify(result, null, 2),
+    "Create public channel test response: " + JSON.stringify(result1, null, 2),
+  );
+  console.log(
+    "Create private channel test response: " + JSON.stringify(result2, null, 2),
   );
 }
 

--- a/tests/slack/testSlackGetChannelMessages.ts
+++ b/tests/slack/testSlackGetChannelMessages.ts
@@ -5,8 +5,6 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-  const channelName = process.env.SLACK_TEST_CHANNEL_NAME;
-  const channelId = process.env.SLACK_TEST_CHANNEL_ID;
   const oldest = "1723996800";
   const authParams = {
     authToken: process.env.SLACK_AUTH_TOKEN,
@@ -17,24 +15,47 @@ async function runTest() {
       "getChannelMessages",
       "slack",
       authParams,
-      { channelId, oldest },
+      { channelId: process.env.SLACK_TEST_PUBLIC_CHANNEL_ID, oldest },
     );
     const result2 = await runAction(
       "getChannelMessages",
       "slack",
       authParams,
-      { channelName, oldest },
+      { channelName: process.env.SLACK_TEST_PUBLIC_CHANNEL_NAME, oldest },
+    );
+    const result3 = await runAction(
+      "getChannelMessages",
+      "slack",
+      authParams,
+      { channelId: process.env.SLACK_TEST_PRIVATE_CHANNEL_ID, oldest },
+    );
+    const result4 = await runAction(
+      "getChannelMessages",
+      "slack",
+      authParams,
+      { channelName: process.env.SLACK_TEST_PRIVATE_CHANNEL_NAME, oldest },
     );
 
-    assert(result1, "Response should not be null");
-    assert(result1.messages, "Response should contain messages");
-    assert(result2, "Response should not be null");
-    assert(result2.messages, "Response should contain messages");
+    assert(result1, "Public channel ID response should not be null");
+    assert(result1.messages, "Public channel ID response should contain messages");
+    assert(result2, "Public channel name response should not be null");
+    assert(result2.messages, "Public channel name response should contain messages");
+    assert(result3, "Private channel ID response should not be null");
+    assert(result3.messages, "Private channel ID response should contain messages");
+    assert(result4, "Private channel name response should not be null");
+    assert(result4.messages, "Private channel name response should contain messages");
+    
     console.log(
-      "Test passed! with messages: " + JSON.stringify(result1.messages, null, 2),
+      "Test passed! Public channel ID messages: " + JSON.stringify(result1.messages, null, 2),
     );
     console.log(
-      "Test passed! with messages: " + JSON.stringify(result2.messages, null, 2),
+      "Test passed! Public channel name messages: " + JSON.stringify(result2.messages, null, 2),
+    );
+    console.log(
+      "Test passed! Private channel ID messages: " + JSON.stringify(result3.messages, null, 2),
+    );
+    console.log(
+      "Test passed! Private channel name messages: " + JSON.stringify(result4.messages, null, 2),
     );
   } catch (error) {
     console.error("Test failed:", error);

--- a/tests/slack/testSlackGetChannelMessages.ts
+++ b/tests/slack/testSlackGetChannelMessages.ts
@@ -5,26 +5,36 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-  const params = {
-    channelName: process.env.SLACK_TEST_CHANNEL_NAME,
-    oldest: "1723996800",
-  };
+  const channelName = process.env.SLACK_TEST_CHANNEL_NAME;
+  const channelId = process.env.SLACK_TEST_CHANNEL_ID;
+  const oldest = "1723996800";
   const authParams = {
     authToken: process.env.SLACK_AUTH_TOKEN,
   };
 
   try {
-    const result = await runAction(
+    const result1 = await runAction(
       "getChannelMessages",
       "slack",
       authParams,
-      params,
+      { channelId, oldest },
+    );
+    const result2 = await runAction(
+      "getChannelMessages",
+      "slack",
+      authParams,
+      { channelName, oldest },
     );
 
-    assert(result, "Response should not be null");
-    assert(result.messages, "Response should contain messages");
+    assert(result1, "Response should not be null");
+    assert(result1.messages, "Response should contain messages");
+    assert(result2, "Response should not be null");
+    assert(result2.messages, "Response should contain messages");
     console.log(
-      "Test passed! with messages: " + JSON.stringify(result.messages, null, 2),
+      "Test passed! with messages: " + JSON.stringify(result1.messages, null, 2),
+    );
+    console.log(
+      "Test passed! with messages: " + JSON.stringify(result2.messages, null, 2),
     );
   } catch (error) {
     console.error("Test failed:", error);

--- a/tests/slack/testSlackSendMessage.ts
+++ b/tests/slack/testSlackSendMessage.ts
@@ -5,16 +5,25 @@ import dotenv from "dotenv";
 dotenv.config();
 
 async function runTest() {
-  const result = await runAction(
+  const result1 = await runAction(
     "sendMessage",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
     { channelName: process.env.SLACK_TEST_CHANNEL_NAME, message: "Hello world" },
   );
-  assert(result, "Response should not be null");
-  assert(result.success, "Message sending should be successful");
+  const result2 = await runAction(
+    "sendMessage",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelId: process.env.SLACK_TEST_CHANNEL_ID, message: "Hello world" },
+  );
+  assert(result1, "Response should not be null");
+  assert(result1.success, "Message sending should be successful");
+  assert(result2, "Response should not be null");
+  assert(result2.success, "Message sending should be successful");
   console.log(
-    "Send Message Test Response: " + JSON.stringify(result, null, 2),
+    "Send Message Test Response 1: " + JSON.stringify(result1, null, 2),
+    "Send Message Test Response 2: " + JSON.stringify(result2, null, 2)
   );
 }
 

--- a/tests/slack/testSlackSendMessage.ts
+++ b/tests/slack/testSlackSendMessage.ts
@@ -9,21 +9,41 @@ async function runTest() {
     "sendMessage",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { channelName: process.env.SLACK_TEST_CHANNEL_NAME, message: "Hello world" },
+    { channelName: process.env.SLACK_TEST_PUBLIC_CHANNEL_NAME, message: "Hello world" },
   );
   const result2 = await runAction(
     "sendMessage",
     "slack",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { channelId: process.env.SLACK_TEST_CHANNEL_ID, message: "Hello world" },
+    { channelId: process.env.SLACK_TEST_PUBLIC_CHANNEL_ID, message: "Hello world" },
   );
-  assert(result1, "Response should not be null");
-  assert(result1.success, "Message sending should be successful");
-  assert(result2, "Response should not be null");
-  assert(result2.success, "Message sending should be successful");
+  const result3 = await runAction(
+    "sendMessage",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelName: process.env.SLACK_TEST_PRIVATE_CHANNEL_NAME, message: "Hello world" },
+  );
+  const result4 = await runAction(
+    "sendMessage",
+    "slack",
+    { authToken: process.env.SLACK_AUTH_TOKEN },
+    { channelId: process.env.SLACK_TEST_PRIVATE_CHANNEL_ID, message: "Hello world" },
+  );
+  
+  assert(result1, "Public channel name response should not be null");
+  assert(result1.success, "Public channel name message sending should be successful");
+  assert(result2, "Public channel ID response should not be null");
+  assert(result2.success, "Public channel ID message sending should be successful");
+  assert(result3, "Private channel name response should not be null");
+  assert(result3.success, "Private channel name message sending should be successful");
+  assert(result4, "Private channel ID response should not be null");
+  assert(result4.success, "Private channel ID message sending should be successful");
+  
   console.log(
-    "Send Message Test Response 1: " + JSON.stringify(result1, null, 2),
-    "Send Message Test Response 2: " + JSON.stringify(result2, null, 2)
+    "Send Message Test Response 1 (public name): " + JSON.stringify(result1, null, 2),
+    "Send Message Test Response 2 (public ID): " + JSON.stringify(result2, null, 2),
+    "Send Message Test Response 3 (private name): " + JSON.stringify(result3, null, 2),
+    "Send Message Test Response 4 (private ID): " + JSON.stringify(result4, null, 2)
   );
 }
 


### PR DESCRIPTION
Included tests with private/public and channelID/channelName permutations