### PR TITLE
Always include Case Number in searchable fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.90",
+      "version": "0.2.91",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/salesforce/searchSalesforceRecords.ts
+++ b/src/actions/providers/salesforce/searchSalesforceRecords.ts
@@ -15,7 +15,7 @@ const searchSalesforceRecords: salesforceSearchSalesforceRecordsFunction = async
 }): Promise<salesforceSearchSalesforceRecordsOutputType> => {
   const { authToken, baseUrl } = authParams;
   const { keyword, recordType, fieldsToSearch } = params;
-  const searchFields = Array.from(new Set([...fieldsToSearch, "Id"]));
+  const searchFields = Array.from(new Set([...fieldsToSearch, "Id", "CaseNumber"]));
 
   if (!authToken || !baseUrl) {
     return {


### PR DESCRIPTION
Case Number is often used to ID cases in Salesforce. 