### PR TITLE
Accept salesforce searches with dashes in the keyword

### DIFF
--- a/src/actions/providers/salesforce/searchSalesforceRecords.ts
+++ b/src/actions/providers/salesforce/searchSalesforceRecords.ts
@@ -23,10 +23,17 @@ const searchSalesforceRecords: salesforceSearchSalesforceRecordsFunction = async
       error: "authToken and baseUrl are required for Salesforce API",
     };
   }
+  
   const maxLimit = 25;
   const dateFieldExists = searchFields.includes("CreatedDate");
+  
+  // Escape special characters for SOSL search
+  const escapedKeyword = keyword
+    .replace(/"/g, '\\"')    // Escape quotes
+    .replace(/-/g, '\\-');   // Escape dashes
+  
   const url = `${baseUrl}/services/data/v64.0/search/?q=${encodeURIComponent(
-    `FIND {${keyword}} RETURNING ${recordType} (${searchFields.join(", ") + (dateFieldExists ? " ORDER BY CreatedDate DESC" : "")}) LIMIT ${params.limit && params.limit <= maxLimit ? params.limit : maxLimit}`,
+    `FIND {${escapedKeyword}} RETURNING ${recordType} (${searchFields.join(", ") + (dateFieldExists ? " ORDER BY CreatedDate DESC" : "")}) LIMIT ${params.limit && params.limit <= maxLimit ? params.limit : maxLimit}`,
   )}`;
 
   try {

--- a/tests/salesforce/testSearchSalesforceRecords.ts
+++ b/tests/salesforce/testSearchSalesforceRecords.ts
@@ -27,6 +27,24 @@ async function runTest() {
   assert.strictEqual(regularQueryResult.success, true);
   assert.equal(salesforceSearchSalesforceRecordsOutputSchema.safeParse(regularQueryResult).success, true);
   assert.equal(regularQueryResult.searchRecords.length, 1);
+
+  const dashKeywordResult = await runAction(
+    "searchSalesforceRecords",
+    "salesforce",
+    {
+      authToken,
+      baseUrl,
+    },
+    {
+      keyword: "health-company",
+      recordType: "Account",
+      fieldsToSearch: ["Name"],
+      limit: 1
+    }
+  );
+  assert.strictEqual(dashKeywordResult.success, true);
+  assert.equal(salesforceSearchSalesforceRecordsOutputSchema.safeParse(dashKeywordResult).success, true);
+  
   console.log("All tests passed!");
 }
 


### PR DESCRIPTION
Right now, if you put a dash into the keyword parameter of the salesforce search actions the action fails. This escapes the character properly.