### PR TITLE
Fix google drive search actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.91",
+  "version": "0.2.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.91",
+      "version": "0.2.92",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.91",
+  "version": "0.2.92",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/google-oauth/searchDriveByKeywords.ts
+++ b/src/actions/providers/google-oauth/searchDriveByKeywords.ts
@@ -23,19 +23,36 @@ const searchDriveByKeywords: googleOauthSearchDriveByKeywordsFunction = async ({
   // Build the query: fullText contains 'keyword1' or fullText contains 'keyword2' ...
   const query = keywords.map(kw => `fullText contains '${kw.replace(/'/g, "\\'")}'`).join(" or ");
 
-  const url = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
-    query,
-  )}&fields=files(id,name,mimeType,webViewLink)&supportsAllDrives=true&includeItemsFromAllDrives=true&corpora=allDrives`;
-
   try {
-    const res = await axiosClient.get(url, {
+    const allDrivesUrl = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
+      query,
+    )}&fields=files(id,name,mimeType,webViewLink)&supportsAllDrives=true&includeItemsFromAllDrives=true&corpora=allDrives&pageSize=1000`;
+
+    const allDrivesRes = axiosClient.get(allDrivesUrl, {
       headers: {
         Authorization: `Bearer ${authParams.authToken}`,
       },
     });
 
+    // need to search domain wide separately because the allDrives search doesn't include domain wide files
+    const orgWideUrl = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
+      query,
+    )}&fields=files(id,name,mimeType,webViewLink)&corpora=domain&pageSize=1000`;
+
+    const orgWideRes = axiosClient.get(orgWideUrl, {
+      headers: {
+        Authorization: `Bearer ${authParams.authToken}`,
+      },
+    });
+
+    const results = await Promise.all([allDrivesRes, orgWideRes]);
+    const relevantResults = results
+      .map(result => result.data.files)
+      .flat()
+      .filter(Boolean);
+
     const files =
-      res.data.files?.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
+      relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
         id: file.id || "",
         name: file.name || "",
         mimeType: file.mimeType || "",

--- a/src/actions/providers/google-oauth/searchDriveByQuery.ts
+++ b/src/actions/providers/google-oauth/searchDriveByQuery.ts
@@ -103,7 +103,10 @@ const searchAllDrivesAtOnce = async (
   });
 
   const results = await Promise.all([allDrivesRes, orgWideRes]);
-  const relevantResults = results.map(result => result.data.files).flat();
+  const relevantResults = results
+    .map(result => result.data.files)
+    .flat()
+    .filter(Boolean);
   const files =
     relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
       id: file.id || "",

--- a/src/actions/providers/google-oauth/searchDriveByQuery.ts
+++ b/src/actions/providers/google-oauth/searchDriveByQuery.ts
@@ -79,18 +79,33 @@ const searchAllDrivesAtOnce = async (
   limit?: number,
   orderByQuery?: string,
 ): Promise<googleOauthSearchDriveByQueryOutputType> => {
-  const url = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
+  const allDrivesUrl = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
     query,
   )}&fields=files(id,name,mimeType,webViewLink)&supportsAllDrives=true&includeItemsFromAllDrives=true&corpora=allDrives&pageSize=1000${orderByQuery ? `&orderBy=${encodeURIComponent(orderByQuery)}` : ""}`;
 
-  const res = await axiosClient.get(url, {
+  const allDrivesRes = axiosClient.get(allDrivesUrl, {
     headers: {
       Authorization: `Bearer ${authToken}`,
     },
   });
 
+  // need to search domain wide separately because the allDrives search doesn't include domain wide files
+  const orgWideUrl = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
+    query,
+  )}&fields=files(id,name,mimeType,webViewLink)&corpora=domain&pageSize=1000${
+    orderByQuery ? `&orderBy=${encodeURIComponent(orderByQuery)}` : ""
+  }`;
+
+  const orgWideRes = axiosClient.get(orgWideUrl, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+
+  const results = await Promise.all([allDrivesRes, orgWideRes]);
+  const relevantResults = results.map(result => result.data.files).flat();
   const files =
-    res.data.files?.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
+    relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
       id: file.id || "",
       name: file.name || "",
       mimeType: file.mimeType || "",
@@ -116,22 +131,41 @@ const searchAllDrivesIndividually = async (
   const drives = await getAllDrives(authToken);
   let allFiles: Array<DriveFile> = [];
 
-  // Search each drive individually
-  for (const drive of drives) {
-    try {
-      const driveFiles = await searchSingleDrive(query, drive.id, authToken, orderByQuery);
-      // Filter out images and folders before adding to results
-      const readableDriveFiles = filterReadableFiles(driveFiles);
-      allFiles = allFiles.concat(readableDriveFiles);
+  const domainUrl =
+    `https://www.googleapis.com/drive/v3/files?` +
+    `q=${encodeURIComponent(query)}&` +
+    `fields=files(id,name,mimeType,webViewLink),nextPageToken&` +
+    `corpora=domain&` +
+    `pageSize=1000${orderByQuery ? `&orderBy=${encodeURIComponent(orderByQuery)}` : ""}`;
 
-      // If we have a limit and we've reached it, break early
-      if (limit && allFiles.length >= limit) {
-        break;
+  const domainDriveFunction = async () => {
+    const domainRes = await axiosClient.get(domainUrl, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+    const domainFiles =
+      domainRes.data.files?.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
+        id: file.id || "",
+        name: file.name || "",
+        mimeType: file.mimeType || "",
+        url: file.webViewLink || "",
+      })) ?? [];
+    allFiles = allFiles.concat(domainFiles.slice(0, limit));
+  };
+
+  // Search each drive individually
+  await Promise.allSettled([
+    domainDriveFunction(),
+    ...drives.map(async drive => {
+      try {
+        const driveFiles = await searchSingleDrive(query, drive.id, authToken, orderByQuery);
+        // Filter out images and folders before adding to results
+        const readableDriveFiles = filterReadableFiles(driveFiles);
+        allFiles = allFiles.concat(readableDriveFiles.slice(0, limit));
+      } catch (error) {
+        console.error(`Error searching drive ${drive.name} (${drive.id}):`, error);
       }
-    } catch (error) {
-      console.error(`Error searching drive ${drive.name} (${drive.id}):`, error);
-    }
-  }
+    }),
+  ]);
 
   return {
     success: true,

--- a/tests/google-oauth/testSearchDriveByKeywordsAndGetFileContent.ts
+++ b/tests/google-oauth/testSearchDriveByKeywordsAndGetFileContent.ts
@@ -1,6 +1,8 @@
 import type { googleOauthSearchDriveByKeywordsAndGetFileContentParamsType } from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
+import dotenv from "dotenv";
+dotenv.config();
 
 /**
  * Test for searching Google Drive by keywords and getting file content
@@ -15,7 +17,8 @@ async function runTest() {
       authToken: process.env.GOOGLE_ACTIONS_ACCESS_TOKEN!,
     },
     {
-      searchQuery: "akul engineering",
+      searchQuery: "Neon pigeons",
+      searchDriveByDrive: false,
     } as googleOauthSearchDriveByKeywordsAndGetFileContentParamsType
   );
 


### PR DESCRIPTION
Previously, we were only including files that the user had shared directly in search results. This now includes files that are available in the org but not explicitly shared with the user.