### PR TITLE
Slack error fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.92",
+      "version": "0.2.93",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -337,8 +337,8 @@ export const slackSendMessageParamsSchema = z.object({
 export type slackSendMessageParamsType = z.infer<typeof slackSendMessageParamsSchema>;
 
 export const slackSendMessageOutputSchema = z.object({
-  success: z.boolean().describe("Whether the email was sent successfully"),
-  error: z.string().describe("The error that occurred if the email was not sent successfully").optional(),
+  success: z.boolean().describe("Whether the message was sent successfully"),
+  error: z.string().describe("The error that occurred if the message was not sent successfully").optional(),
   messageId: z.string().describe("The ID of the message that was sent").optional(),
 });
 


### PR DESCRIPTION
Slack occasionally throws "invalid block" errors on this action. This seems to mean st is wrong with the markdown formatting or otherwise disallowed for a block. Fall back to the non block, plaintext API.