### PR TITLE
Fix gdrive search limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.93",
+  "version": "0.2.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.93",
+      "version": "0.2.94",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.93",
+  "version": "0.2.94",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/google-oauth/searchDriveByKeywords.ts
+++ b/src/actions/providers/google-oauth/searchDriveByKeywords.ts
@@ -48,8 +48,8 @@ const searchDriveByKeywords: googleOauthSearchDriveByKeywordsFunction = async ({
     const results = await Promise.all([allDrivesRes, orgWideRes]);
     const relevantResults = results
       .map(result => result.data.files)
-      .flat()
-      .filter(Boolean);
+      .filter(Boolean)
+      .map(files => limit ? files.slice(0, limit) : files).flat();
 
     const files =
       relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
@@ -59,7 +59,7 @@ const searchDriveByKeywords: googleOauthSearchDriveByKeywordsFunction = async ({
         url: file.webViewLink || "",
       })) || [];
 
-    return { success: true, files: limit ? files.splice(0, limit) : files };
+    return { success: true, files };
   } catch (error) {
     console.error("Error searching Google Drive", error);
     return {

--- a/src/actions/providers/google-oauth/searchDriveByKeywords.ts
+++ b/src/actions/providers/google-oauth/searchDriveByKeywords.ts
@@ -49,7 +49,8 @@ const searchDriveByKeywords: googleOauthSearchDriveByKeywordsFunction = async ({
     const relevantResults = results
       .map(result => result.data.files)
       .filter(Boolean)
-      .map(files => limit ? files.slice(0, limit) : files).flat();
+      .map(files => (limit ? files.slice(0, limit) : files))
+      .flat();
 
     const files =
       relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({

--- a/src/actions/providers/google-oauth/searchDriveByQuery.ts
+++ b/src/actions/providers/google-oauth/searchDriveByQuery.ts
@@ -105,10 +105,12 @@ const searchAllDrivesAtOnce = async (
   const results = await Promise.all([allDrivesRes, orgWideRes]);
   const relevantResults = results
     .map(result => result.data.files)
-    .flat()
-    .filter(Boolean);
+    .filter(Boolean)
+
+  const relevantResultsFlat = relevantResults.map(result => limit ? result.slice(0, limit) : result).flat();
+
   const files =
-    relevantResults.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
+    relevantResultsFlat.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({
       id: file.id || "",
       name: file.name || "",
       mimeType: file.mimeType || "",
@@ -120,7 +122,7 @@ const searchAllDrivesAtOnce = async (
 
   return {
     success: true,
-    files: limit ? readableFiles.slice(0, limit) : readableFiles,
+    files: readableFiles,
   };
 };
 

--- a/src/actions/providers/google-oauth/searchDriveByQuery.ts
+++ b/src/actions/providers/google-oauth/searchDriveByQuery.ts
@@ -103,11 +103,9 @@ const searchAllDrivesAtOnce = async (
   });
 
   const results = await Promise.all([allDrivesRes, orgWideRes]);
-  const relevantResults = results
-    .map(result => result.data.files)
-    .filter(Boolean)
+  const relevantResults = results.map(result => result.data.files).filter(Boolean);
 
-  const relevantResultsFlat = relevantResults.map(result => limit ? result.slice(0, limit) : result).flat();
+  const relevantResultsFlat = relevantResults.map(result => (limit ? result.slice(0, limit) : result)).flat();
 
   const files =
     relevantResultsFlat.map((file: { id?: string; name?: string; mimeType?: string; webViewLink?: string }) => ({


### PR DESCRIPTION
Apply the limit across each API call rather than in aggregate, as we have no way of reranking between the different calls.