### PR TITLE
Empty commit trufflehog test (#327)

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -5,17 +5,16 @@ on:
 
 jobs:
   TruffleHog:
+    # Run only when there is at least one changed file (skip empty PRs)
+    if: ${{ github.event.pull_request.changed_files > 0 }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    
-    - name: TruffleHog OSS
-      uses: trufflesecurity/trufflehog@v3.89.2
-      with:
-        path: ./
-        base: ${{ github.event.pull_request.base.ref }}
-        head: HEAD
-        extra_args: --debug
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS (fail on any detected secret)
+        uses: trufflesecurity/trufflehog@v3.89.2
+        with:
+          path: ./
+          extra_args: --debug

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ const result = await runAction(
 ```
 npm run test tests/testRunMathAction.ts
 ```
+## Secret Scanning (TruffleHog)
+
+We run TruffleHog on every pull request that actually changes at least one file.
+
+- Empty / metadata-only PRs are automatically skipped to avoid noisy false alarms.
+- Any real change is scanned if a secret-like credential is detected the job fails fast (so we can fix it before merging).
+
+The workflow lives at `.github/workflows/trufflehog.yml` and is intentionally minimal: skip empty PRs, scan everything else and fail on hits.


### PR DESCRIPTION
Before Fix:

<img width="1148" height="539" alt="TrufflehogEmptyError" src="https://github.com/user-attachments/assets/889c8f5f-9e2f-4742-8b79-8f08c12015b4" />

Screenshot after testing tufflehog with empty commit with updated changes:

<img width="905" height="466" alt="TrufflehogEmpty Updated Changes" src="https://github.com/user-attachments/assets/7ae0b4cb-ae49-4da7-aa68-c0bc075285f8" />

With Empty commit, no trufflehog scanning successful:

<img width="697" height="251" alt="Trufflehog NewChange" src="https://github.com/user-attachments/assets/bd489fc5-c9cd-48f9-bc63-6a0dbd89999b" />

Created test cases with fake access key:

<img width="932" height="290" alt="Trufflehog fake credential test" src="https://github.com/user-attachments/assets/dba37c3a-97b3-4c53-89ae-d638f1313530" />

Tested Trufflehog - showing error for detected secret:

<img width="960" height="613" alt="Trufflehog Error by adding Fake Secret keys" src="https://github.com/user-attachments/assets/3af0e49a-7866-4190-aa10-62a4c449f205" />

