### PR TITLE
[Calendar] update output schema to include day of week

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.107",
+      "version": "0.2.108",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4518,6 +4518,10 @@ export const googleOauthScheduleCalendarMeetingDefinition: ActionTemplate = {
         type: "string",
         description: "The URL to access the scheduled event",
       },
+      eventDayOfWeek: {
+        type: "string",
+        description: "The day of the week when the event is scheduled (e.g., Monday, Tuesday, etc.)",
+      },
       error: {
         type: "string",
         description: "The error that occurred if the meeting was not scheduled successfully",
@@ -4649,9 +4653,17 @@ export const googleOauthListCalendarEventsDefinition: ActionTemplate = {
               type: "string",
               description: "Start date/time (for timed events, RFC3339 timestamp)",
             },
+            startDayOfWeek: {
+              type: "string",
+              description: "The day of the week when the event starts (e.g., Monday, Tuesday, etc.)",
+            },
             end: {
               type: "string",
               description: "End date/time (for timed events, RFC3339 timestamp)",
+            },
+            endDayOfWeek: {
+              type: "string",
+              description: "The day of the week when the event ends (e.g., Monday, Tuesday, etc.)",
             },
             attendees: {
               type: "array",
@@ -4897,6 +4909,10 @@ export const googleOauthEditAGoogleCalendarEventDefinition: ActionTemplate = {
       eventUrl: {
         type: "string",
         description: "The URL to access the edited event",
+      },
+      eventDayOfWeek: {
+        type: "string",
+        description: "The day of the week when the edited event occurs (e.g., Monday, Tuesday, etc.)",
       },
       error: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2331,6 +2331,10 @@ export const googleOauthScheduleCalendarMeetingOutputSchema = z.object({
   success: z.boolean().describe("Whether the meeting was scheduled successfully"),
   eventId: z.string().describe("The ID of the event that was scheduled").optional(),
   eventUrl: z.string().describe("The URL to access the scheduled event").optional(),
+  eventDayOfWeek: z
+    .string()
+    .describe("The day of the week when the event is scheduled (e.g., Monday, Tuesday, etc.)")
+    .optional(),
   error: z.string().describe("The error that occurred if the meeting was not scheduled successfully").optional(),
 });
 
@@ -2397,7 +2401,15 @@ export const googleOauthListCalendarEventsOutputSchema = z.object({
           description: z.string().describe("Description of the event").optional(),
           location: z.string().describe("Geographic location of the event as free-form text").optional(),
           start: z.string().describe("Start date/time (for timed events, RFC3339 timestamp)").optional(),
+          startDayOfWeek: z
+            .string()
+            .describe("The day of the week when the event starts (e.g., Monday, Tuesday, etc.)")
+            .optional(),
           end: z.string().describe("End date/time (for timed events, RFC3339 timestamp)").optional(),
+          endDayOfWeek: z
+            .string()
+            .describe("The day of the week when the event ends (e.g., Monday, Tuesday, etc.)")
+            .optional(),
           attendees: z
             .array(
               z.object({
@@ -2522,6 +2534,10 @@ export const googleOauthEditAGoogleCalendarEventOutputSchema = z.object({
   success: z.boolean().describe("Whether the event was edited successfully"),
   eventId: z.string().describe("The ID of the edited event").optional(),
   eventUrl: z.string().describe("The URL to access the edited event").optional(),
+  eventDayOfWeek: z
+    .string()
+    .describe("The day of the week when the edited event occurs (e.g., Monday, Tuesday, etc.)")
+    .optional(),
   error: z.string().describe("The error that occurred if the event was not edited successfully").optional(),
 });
 

--- a/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
@@ -7,6 +7,7 @@ import type {
   googleOauthEditAGoogleCalendarEventParamsType,
 } from "../../autogen/types.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getDayOfWeek } from "../../../utils/datetime.js";
 
 const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = async ({
   params,
@@ -16,7 +17,7 @@ const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = as
   authParams: AuthParamsType;
 }): Promise<googleOauthEditAGoogleCalendarEventOutputType> => {
   if (!authParams.authToken) {
-    return { success: false, error: MISSING_AUTH_TOKEN, eventId: "", eventUrl: "" };
+    return { success: false, error: MISSING_AUTH_TOKEN, eventId: "", eventUrl: "", eventDayOfWeek: "" };
   }
 
   const { calendarId, eventId, title, description, start, end, location, attendees, status, organizer, timeZone } =
@@ -51,10 +52,15 @@ const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = as
     });
 
     const { id, htmlLink } = res.data;
+    // Get the event day of week from the start time (use provided start or fetch from response)
+    const eventDayOfWeek = start
+      ? getDayOfWeek(start)
+      : getDayOfWeek(res.data.start?.dateTime || res.data.start?.date || "");
     return {
       success: true,
       eventId: id,
       eventUrl: htmlLink,
+      eventDayOfWeek,
     };
   } catch (error) {
     return {
@@ -62,6 +68,7 @@ const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = as
       error: error instanceof Error ? error.message : "Unknown error editing event",
       eventId: "",
       eventUrl: "",
+      eventDayOfWeek: "",
     };
   }
 };

--- a/src/actions/providers/google-oauth/listCalendarEvents.ts
+++ b/src/actions/providers/google-oauth/listCalendarEvents.ts
@@ -7,6 +7,7 @@ import type {
   googleOauthListCalendarEventsParamsType,
 } from "../../autogen/types.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getDayOfWeek } from "../../../utils/datetime.js";
 
 const listCalendarEvents: googleOauthListCalendarEventsFunction = async ({
   params,
@@ -85,7 +86,9 @@ const listCalendarEvents: googleOauthListCalendarEventsFunction = async ({
             description,
             location,
             start: start?.dateTime || start?.date || "",
+            startDayOfWeek: getDayOfWeek(start?.dateTime || start?.date || ""),
             end: end?.dateTime || end?.date || "",
+            endDayOfWeek: getDayOfWeek(end?.dateTime || end?.date || ""),
             attendees: Array.isArray(attendees)
               ? attendees.map(({ email, displayName, responseStatus }) => ({
                   email,

--- a/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
+++ b/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../autogen/types.js";
 import { axiosClient } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getDayOfWeek } from "../../../utils/datetime.js";
 
 /**
  * Creates a new Google calendar event using OAuth authentication
@@ -90,6 +91,7 @@ const scheduleCalendarMeeting: googleOauthScheduleCalendarMeetingFunction = asyn
       success: true,
       eventId: response.data.id,
       eventUrl: response.data.htmlLink,
+      eventDayOfWeek: getDayOfWeek(start),
     };
   } catch (error) {
     console.error("Error scheduling calendar meeting", error);

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2736,6 +2736,9 @@ actions:
           eventUrl:
             type: string
             description: The URL to access the scheduled event
+          eventDayOfWeek:
+            type: string
+            description: The day of the week when the event is scheduled (e.g., Monday, Tuesday, etc.)
           error:
             type: string
             description: The error that occurred if the meeting was not scheduled successfully
@@ -2829,9 +2832,15 @@ actions:
                 start:
                   type: string
                   description: Start date/time (for timed events, RFC3339 timestamp)
+                startDayOfWeek:
+                  type: string
+                  description: The day of the week when the event starts (e.g., Monday, Tuesday, etc.)
                 end:
                   type: string
                   description: End date/time (for timed events, RFC3339 timestamp)
+                endDayOfWeek:
+                  type: string
+                  description: The day of the week when the event ends (e.g., Monday, Tuesday, etc.)
                 attendees:
                   type: array
                   description: List of attendees
@@ -3005,6 +3014,9 @@ actions:
           eventUrl:
             type: string
             description: The URL to access the edited event
+          eventDayOfWeek:
+            type: string
+            description: The day of the week when the edited event occurs (e.g., Monday, Tuesday, etc.)
           error:
             type: string
             description: The error that occurred if the event was not edited successfully

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -11,3 +11,10 @@ export function isBetweenDatetime(isoDatetime: string, isoStart: string, isoEnd:
 export function isValidIsoDatestring(isoDatetime: string): boolean {
   return isValid(parseISO(isoDatetime));
 }
+
+export const getDayOfWeek = (dateString: string): string => {
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  return days[date.getDay()];
+};

--- a/tests/google-oauth/testEditAGoogleCalendarEvent.ts
+++ b/tests/google-oauth/testEditAGoogleCalendarEvent.ts
@@ -26,7 +26,9 @@ async function runTest() {
   assert(result.success, "Success should be true");
   assert(typeof result.eventId === "string" && result.eventId.length > 0, "Should return eventId");
   assert(typeof result.eventUrl === "string" && result.eventUrl.length > 0, "Should return eventUrl");
+  assert(typeof result.eventDayOfWeek === "string", "Should return eventDayOfWeek");
   console.log(`Successfully edited event: ${result.eventId}`);
+  console.log("Event Day of Week: ", result.eventDayOfWeek);
   console.log("Response: ", result);
 }
 

--- a/tests/google-oauth/testGoogleScheduleMeeting.ts
+++ b/tests/google-oauth/testGoogleScheduleMeeting.ts
@@ -38,8 +38,11 @@ async function runTest() {
   // Validate the result
   assert(result.eventId, "Result should be successful");
   assert(result.success, "Result should contain an eventId");
+  assert(result.eventDayOfWeek, "Result should contain eventDayOfWeek");
+  assert(typeof result.eventDayOfWeek === "string", "eventDayOfWeek should be a string");
 
   console.log("Link to Google Calendar Event: ", result.eventUrl);
+  console.log("Event Day of Week: ", result.eventDayOfWeek);
 
   return result;
 }

--- a/tests/google-oauth/testListCalendarEvents.ts
+++ b/tests/google-oauth/testListCalendarEvents.ts
@@ -30,7 +30,9 @@ async function runTest() {
     assert(typeof first.status === "string", "Event should have a status");
     assert(typeof first.url === "string", "Event should have a url");
     assert(typeof first.start === "string", "Event should have a start");
+    assert(typeof first.startDayOfWeek === "string", "Event should have a startDayOfWeek");
     assert(typeof first.end === "string", "Event should have an end");
+    assert(typeof first.endDayOfWeek === "string", "Event should have an endDayOfWeek");
   }
 
   console.log(`Successfully found ${result.events.length} events`);


### PR DESCRIPTION
### Issue: 
- LLMs are bad at figuring out dates based on YYYY-MM-DD
- This is causing issues for the personal assistant agent in outputting dates
- Instead of relying on the LLM to resolve - manually put it in for agents