### PR TITLE
[Zendesk] Add retries to get around rate limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.108",
+  "version": "0.2.109",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.108",
+      "version": "0.2.109",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.108",
+  "version": "0.2.109",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -4,7 +4,7 @@ import type {
   zendeskAddCommentToTicketOutputType,
   zendeskAddCommentToTicketParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
@@ -21,6 +21,7 @@ const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 20000, retryCount: 5 });
 
   try {
     const response = await axiosClient.request({

--- a/src/actions/providers/zendesk/assignTicket.ts
+++ b/src/actions/providers/zendesk/assignTicket.ts
@@ -4,7 +4,7 @@ import type {
   zendeskAssignTicketOutputType,
   zendeskAssignTicketParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const updateTicketStatus: zendeskAssignTicketFunction = async ({
@@ -21,6 +21,7 @@ const updateTicketStatus: zendeskAssignTicketFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   await axiosClient.request({
     url: url,

--- a/src/actions/providers/zendesk/createZendeskTicket.ts
+++ b/src/actions/providers/zendesk/createZendeskTicket.ts
@@ -4,7 +4,7 @@ import type {
   zendeskCreateZendeskTicketOutputType,
   zendeskCreateZendeskTicketParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
@@ -29,6 +29,7 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   const response = await axiosClient.post(url, payload, {
     headers: {

--- a/src/actions/providers/zendesk/getTicketDetails.ts
+++ b/src/actions/providers/zendesk/getTicketDetails.ts
@@ -4,7 +4,7 @@ import type {
   zendeskGetTicketDetailsOutputType,
   zendeskGetTicketDetailsParamsType,
 } from "../../autogen/types.js";
-import { axiosClientWithRetries } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
@@ -22,7 +22,9 @@ const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  const response = await axiosClientWithRetries.request({
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
+
+  const response = await axiosClient.request({
     url: url,
     method: "GET",
     headers: {

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -4,7 +4,7 @@ import type {
   zendeskListZendeskTicketsOutputType,
   zendeskListZendeskTicketsParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
@@ -28,6 +28,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Add query parameters for filtering
   const queryParams = new URLSearchParams();

--- a/src/actions/providers/zendesk/searchZendeskByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskByQuery.ts
@@ -4,7 +4,7 @@ import type {
   zendeskSearchZendeskByQueryOutputType,
   zendeskSearchZendeskByQueryParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
@@ -23,6 +23,7 @@ const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Build search query parameters
   const queryParams = new URLSearchParams();

--- a/src/actions/providers/zendesk/updateTicketStatus.ts
+++ b/src/actions/providers/zendesk/updateTicketStatus.ts
@@ -4,7 +4,7 @@ import type {
   zendeskUpdateTicketStatusOutputType,
   zendeskUpdateTicketStatusParamsType,
 } from "../../autogen/types.js";
-import { axiosClient } from "../../util/axiosClient.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
 const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
@@ -21,6 +21,8 @@ const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
+
   await axiosClient.request({
     url: url,
     method: "PUT",

--- a/tests/zendesk/testZendeskGetTicketDetails.ts
+++ b/tests/zendesk/testZendeskGetTicketDetails.ts
@@ -1,21 +1,32 @@
 import { assert } from "node:console";
 import { runAction } from "../../src/app.js";
 
+import dotenv from "dotenv";
+dotenv.config();
+
 async function runTest() {
   const result = await runAction(
     "getTicketDetails",
     "zendesk",
     {
-      apiKey: "insert-your-api-key",
-      username: "insert-your-username",
-    }, // authParams
-    {
-      ticketId: "62",
-      subdomain: "credalai",
+      authToken: process.env.ZENDESK_TOKEN || "insert-your-token",
     },
+    {
+      ticketId: "40",
+      subdomain: "credalai",
+    }
   );
-  console.log(result);
-  assert(result.id !== "");
+
+  // Basic assertions
+  console.log("Ticket Id:", result.ticket.id);
+  console.log("Ticket Status:", result.ticket.status);
+
+  assert(result.ticket, "Ticket should be present");
+  assert(result.ticket.id, "Ticket should have an ID");
+  assert(result.ticket.subject, "Ticket should have a subject");
+  assert(result.ticket.status, "Ticket should have a status");
+
+  console.log("✅ All tests passed!");
 }
 
 runTest().catch(console.error);


### PR DESCRIPTION
## Rate limit changes
- Users are occasionally getting rate limited by zendesk endpoints
- Added in retry logic with exponential backoff to try and resolve the issue
- Occuring less with 3 retries (bumping to 5 to ensure the issues are resolved)