### PR TITLE
zod upgrade to 3.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.112",
+      "version": "0.2.113",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",
@@ -34,7 +34,7 @@
         "snowflake-sdk": "^2.0.2",
         "ts-node": "^10.9.2",
         "uuid": "^11.1.0",
-        "zod": "^3.24.1"
+        "zod": "^3.25.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
@@ -11185,9 +11185,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,
@@ -72,6 +72,6 @@
     "snowflake-sdk": "^2.0.2",
     "ts-node": "^10.9.2",
     "uuid": "^11.1.0",
-    "zod": "^3.24.1"
+    "zod": "^3.25.0"
   }
 }


### PR DESCRIPTION
## Context

We want to upgrade zod to v.3.25.0 in the `app` repo. However in doing so I am seeing some weird errors which seem like they have to do with a zod version mismatch between v3.25.0 in the app repo, and the lower version schemas imported from the `actions-sdk`.

## Changes

Upgrade zod version to 3.25.0, bump version


## Tested by 

`npx tsc`

`npm run test tests/math/testRunMathAction.ts`