### PR TITLE
[Firecrawl] add timeout to scrapeUrl action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.116",
+  "version": "0.2.117",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.116",
+      "version": "0.2.117",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.116",
+  "version": "0.2.117",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -3214,6 +3214,11 @@ export const firecrawlScrapeUrlDefinition: ActionTemplate = {
         type: "string",
         description: "The URL to scrape",
       },
+      waitMs: {
+        type: "number",
+        description: "Optional wait time in milliseconds before scraping the page",
+        minimum: 0,
+      },
     },
   },
   output: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1662,7 +1662,10 @@ export type firecrawlDeepResearchFunction = ActionFunction<
   firecrawlDeepResearchOutputType
 >;
 
-export const firecrawlScrapeUrlParamsSchema = z.object({ url: z.string().describe("The URL to scrape") });
+export const firecrawlScrapeUrlParamsSchema = z.object({
+  url: z.string().describe("The URL to scrape"),
+  waitMs: z.number().gte(0).describe("Optional wait time in milliseconds before scraping the page").optional(),
+});
 
 export type firecrawlScrapeUrlParamsType = z.infer<typeof firecrawlScrapeUrlParamsSchema>;
 

--- a/src/actions/providers/firecrawl/scrapeUrl.ts
+++ b/src/actions/providers/firecrawl/scrapeUrl.ts
@@ -18,7 +18,11 @@ const scrapeUrl: firecrawlScrapeUrlFunction = async ({
     apiKey: authParams.apiKey,
   });
 
-  const result = await firecrawl.scrapeUrl(params.url);
+  const result = await firecrawl.scrapeUrl(params.url, {
+    ...(params.waitMs !== undefined && {
+      actions: [{ type: "wait", milliseconds: params.waitMs }],
+    }),
+  });
 
   return firecrawlScrapeUrlOutputSchema.parse({
     content: result.success ? result.markdown : "",

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1836,6 +1836,10 @@ actions:
           url:
             type: string
             description: The URL to scrape
+          waitMs:
+            type: number
+            description: Optional wait time in milliseconds before scraping the page
+            minimum: 0
       output:
         type: object
         required: [content]

--- a/tests/firecrawl/testFirecrawlScrape.ts
+++ b/tests/firecrawl/testFirecrawlScrape.ts
@@ -11,6 +11,7 @@ async function runTest() {
     { apiKey: process.env.FIRECRAWL_API_KEY }, // authParams
     {
       url: "https://carbonenewyork.com",
+      waitMs: 2000, // Wait 2 seconds before scraping
     },
   );
   console.log(result);


### PR DESCRIPTION
- Add optional field timeout ms to firecrawl action
- This is required for a customer who wants to wait for dynamically loaded content.