### PR TITLE
[Gitlab] Param Type - Integer issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.124",
+  "version": "0.2.125",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.124",
+      "version": "0.2.125",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.124",
+  "version": "0.2.125",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -765,7 +765,7 @@ export const slackUserSearchSlackDefinition: ActionTemplate = {
         default: "latest",
       },
       limit: {
-        type: "integer",
+        type: "number",
         description:
           "Max matches to request (passed to Slack search; results are then hydrated and sorted newest-first).",
         minimum: 1,
@@ -4652,12 +4652,12 @@ export const googleOauthScheduleCalendarMeetingDefinition: ActionTemplate = {
             description: "How often the meeting repeats",
           },
           interval: {
-            type: "integer",
+            type: "number",
             minimum: 1,
             description: "The interval between recurrences (e.g., every 2 weeks)",
           },
           count: {
-            type: "integer",
+            type: "number",
             minimum: 1,
             description: "Number of occurrences after which to stop the recurrence",
           },
@@ -4677,7 +4677,7 @@ export const googleOauthScheduleCalendarMeetingDefinition: ActionTemplate = {
             type: "array",
             description: "Days of the month when the meeting occurs (for MONTHLY frequency)",
             items: {
-              type: "integer",
+              type: "number",
               minimum: 1,
               maximum: 31,
             },
@@ -11466,7 +11466,7 @@ export const githubGetBranchDefinition: ActionTemplate = {
                     description: "The commit URL",
                   },
                   comment_count: {
-                    type: "integer",
+                    type: "number",
                     description: "Number of comments on the commit",
                   },
                 },
@@ -11480,7 +11480,7 @@ export const githubGetBranchDefinition: ActionTemplate = {
                     type: "string",
                   },
                   id: {
-                    type: "integer",
+                    type: "number",
                   },
                   node_id: {
                     type: "string",
@@ -11505,7 +11505,7 @@ export const githubGetBranchDefinition: ActionTemplate = {
                     type: "string",
                   },
                   id: {
-                    type: "integer",
+                    type: "number",
                   },
                   node_id: {
                     type: "string",
@@ -12241,7 +12241,7 @@ export const gitlabGetFileContentDefinition: ActionTemplate = {
     required: ["project_id", "path"],
     properties: {
       project_id: {
-        type: "integer",
+        type: "number",
         description: "Numeric project ID in GitLab (unique per project)",
       },
       path: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -432,7 +432,6 @@ export const slackUserSearchSlackParamsSchema = z.object({
     .default("latest"),
   limit: z
     .number()
-    .int()
     .gte(1)
     .lte(100)
     .describe("Max matches to request (passed to Slack search; results are then hydrated and sorted newest-first).")
@@ -2398,15 +2397,15 @@ export const googleOauthScheduleCalendarMeetingParamsSchema = z.object({
   recurrence: z
     .object({
       frequency: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).describe("How often the meeting repeats").optional(),
-      interval: z.number().int().gte(1).describe("The interval between recurrences (e.g., every 2 weeks)").optional(),
-      count: z.number().int().gte(1).describe("Number of occurrences after which to stop the recurrence").optional(),
+      interval: z.number().gte(1).describe("The interval between recurrences (e.g., every 2 weeks)").optional(),
+      count: z.number().gte(1).describe("Number of occurrences after which to stop the recurrence").optional(),
       until: z.string().describe("End date for the recurrence in RFC3339 format (YYYY-MM-DD)").optional(),
       byDay: z
         .array(z.enum(["MO", "TU", "WE", "TH", "FR", "SA", "SU"]))
         .describe("Days of the week when the meeting occurs (for WEEKLY frequency)")
         .optional(),
       byMonthDay: z
-        .array(z.number().int().gte(1).lte(31))
+        .array(z.number().gte(1).lte(31))
         .describe("Days of the month when the meeting occurs (for MONTHLY frequency)")
         .optional(),
     })
@@ -5747,14 +5746,14 @@ export const githubGetBranchOutputSchema = z.object({
                 .describe("The commit tree")
                 .optional(),
               url: z.string().describe("The commit URL").optional(),
-              comment_count: z.number().int().describe("Number of comments on the commit").optional(),
+              comment_count: z.number().describe("Number of comments on the commit").optional(),
             })
             .describe("The git commit object")
             .optional(),
           author: z
             .object({
               login: z.string().optional(),
-              id: z.number().int().optional(),
+              id: z.number().optional(),
               node_id: z.string().optional(),
               avatar_url: z.string().optional(),
               html_url: z.string().optional(),
@@ -5766,7 +5765,7 @@ export const githubGetBranchOutputSchema = z.object({
           committer: z
             .object({
               login: z.string().optional(),
-              id: z.number().int().optional(),
+              id: z.number().optional(),
               node_id: z.string().optional(),
               avatar_url: z.string().optional(),
               html_url: z.string().optional(),
@@ -6103,7 +6102,7 @@ export type gitlabSearchGroupFunction = ActionFunction<
 >;
 
 export const gitlabGetFileContentParamsSchema = z.object({
-  project_id: z.number().int().describe("Numeric project ID in GitLab (unique per project)"),
+  project_id: z.number().describe("Numeric project ID in GitLab (unique per project)"),
   path: z.string().describe("The file path to get content from (e.g., src/index.js)"),
   ref: z
     .string()

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -544,7 +544,7 @@ actions:
               - all
             default: latest
           limit:
-            type: integer
+            type: number
             description: Max matches to request (passed to Slack search; results are then hydrated and sorted newest-first).
             minimum: 1
             maximum: 100
@@ -2849,11 +2849,11 @@ actions:
                 enum: [DAILY, WEEKLY, MONTHLY, YEARLY]
                 description: How often the meeting repeats
               interval:
-                type: integer
+                type: number
                 minimum: 1
                 description: The interval between recurrences (e.g., every 2 weeks)
               count:
-                type: integer
+                type: number
                 minimum: 1
                 description: Number of occurrences after which to stop the recurrence
               until:
@@ -2869,7 +2869,7 @@ actions:
                 type: array
                 description: Days of the month when the meeting occurs (for MONTHLY frequency)
                 items:
-                  type: integer
+                  type: number
                   minimum: 1
                   maximum: 31
       output:
@@ -7692,7 +7692,7 @@ actions:
                         type: string
                         description: The commit URL
                       comment_count:
-                        type: integer
+                        type: number
                         description: Number of comments on the commit
                   author:
                     type: object
@@ -7702,7 +7702,7 @@ actions:
                       login:
                         type: string
                       id:
-                        type: integer
+                        type: number
                       node_id:
                         type: string
                       avatar_url:
@@ -7719,7 +7719,7 @@ actions:
                       login:
                         type: string
                       id:
-                        type: integer
+                        type: number
                       node_id:
                         type: string
                       avatar_url:
@@ -8237,7 +8237,7 @@ actions:
         required: [project_id, path]
         properties:
           project_id:
-            type: integer
+            type: number
             description: Numeric project ID in GitLab (unique per project)
           path:
             type: string


### PR DESCRIPTION
### Changes: 
 - Fix types on gitlab action + other actions
 - They're using integer instead of number - parsed as string 
 - should enforce only valid types 