### PR TITLE
Standardize Action Output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.127",
+  "version": "0.2.128",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.127",
+      "version": "0.2.128",
       "license": "ISC",
       "dependencies": {
         "@credal/sdk": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.127",
+  "version": "0.2.128",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -7309,32 +7309,47 @@ export const googleOauthSearchDriveByKeywordsAndGetFileContentDefinition: Action
         type: "boolean",
         description: "Whether the search was successful",
       },
-      files: {
+      results: {
         type: "array",
         description: "List of files matching the search",
         items: {
           type: "object",
-          required: ["id", "name", "mimeType", "url"],
+          required: ["name", "url", "contents"],
           properties: {
-            id: {
-              type: "string",
-              description: "The file ID",
-            },
             name: {
               type: "string",
-              description: "The file name",
-            },
-            mimeType: {
-              type: "string",
-              description: "The MIME type of the file",
+              description: "The name of the file",
             },
             url: {
               type: "string",
-              description: "The web link to view the file",
+              description: "The URL of the file",
             },
-            content: {
-              type: "string",
-              description: "The data returned from the file, subject to fileSizeLimit",
+            contents: {
+              type: "object",
+              description: "The contents of the file",
+              required: ["id", "name", "mimeType", "url"],
+              properties: {
+                id: {
+                  type: "string",
+                  description: "The file ID",
+                },
+                name: {
+                  type: "string",
+                  description: "The file name",
+                },
+                mimeType: {
+                  type: "string",
+                  description: "The MIME type of the file",
+                },
+                url: {
+                  type: "string",
+                  description: "The web link to view the file",
+                },
+                content: {
+                  type: "string",
+                  description: "The data returned from the file, subject to fileSizeLimit",
+                },
+              },
             },
           },
         },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -12230,233 +12230,259 @@ export const gitlabSearchGroupDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["mergeRequests", "blobs"],
+    required: ["success"],
     properties: {
-      mergeRequests: {
+      success: {
+        type: "boolean",
+        description: "Whether the search operation was successful",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the search operation failed",
+      },
+      results: {
         type: "array",
-        description: "A list of merge requests that match the query",
+        description: "A list of search results that match the query",
         items: {
           type: "object",
-          required: ["metadata", "diffs"],
+          required: ["name", "url", "type", "contents"],
           properties: {
-            metadata: {
-              type: "object",
-              required: ["id", "iid", "project_id", "title", "web_url"],
-              description: "The metadata of the merge request",
-              properties: {
-                id: {
-                  type: "number",
-                  description: "The ID of the merge request",
-                },
-                iid: {
-                  type: "number",
-                  description: "The internal ID of the merge request",
-                },
-                project_id: {
-                  type: "number",
-                  description: "The ID of the project the merge request belongs to",
-                },
-                title: {
-                  type: "string",
-                  description: "The title of the merge request",
-                },
-                web_url: {
-                  type: "string",
-                  description: "The URL of the merge request",
-                },
-                description: {
-                  type: "string",
-                  description: "The description of the merge request",
-                },
-                author: {
+            name: {
+              type: "string",
+              description: "The name/title of the search result",
+            },
+            url: {
+              type: "string",
+              description: "The URL to view the result in GitLab",
+            },
+            type: {
+              type: "string",
+              enum: ["mergeRequest", "blob", "commit"],
+              description: "The type of search result",
+            },
+            contents: {
+              oneOf: [
+                {
                   type: "object",
-                  description: "The author of the merge request",
+                  description: "Merge request contents",
+                  required: ["metadata", "diffs"],
                   properties: {
-                    name: {
-                      type: "string",
-                      description: "The name of the author",
+                    metadata: {
+                      type: "object",
+                      required: ["id", "iid", "project_id", "title", "web_url"],
+                      description: "The metadata of the merge request",
+                      properties: {
+                        id: {
+                          type: "number",
+                          description: "The ID of the merge request",
+                        },
+                        iid: {
+                          type: "number",
+                          description: "The internal ID of the merge request",
+                        },
+                        project_id: {
+                          type: "number",
+                          description: "The ID of the project the merge request belongs to",
+                        },
+                        title: {
+                          type: "string",
+                          description: "The title of the merge request",
+                        },
+                        web_url: {
+                          type: "string",
+                          description: "The URL of the merge request",
+                        },
+                        description: {
+                          type: "string",
+                          description: "The description of the merge request",
+                        },
+                        author: {
+                          type: "object",
+                          description: "The author of the merge request",
+                          properties: {
+                            name: {
+                              type: "string",
+                              description: "The name of the author",
+                            },
+                          },
+                        },
+                        merged_at: {
+                          type: "string",
+                          description: "The date and time the merge request was merged",
+                        },
+                      },
+                    },
+                    diffs: {
+                      type: "array",
+                      description: "A list of diffs that match the query",
+                      items: {
+                        type: "object",
+                        required: ["old_path", "new_path", "diff", "new_file", "renamed_file", "deleted_file"],
+                        properties: {
+                          old_path: {
+                            type: "string",
+                            description: "The old path of the diff",
+                          },
+                          new_path: {
+                            type: "string",
+                            description: "The new path of the diff",
+                          },
+                          diff: {
+                            type: "string",
+                            description: "The contents of the diff",
+                          },
+                          new_file: {
+                            type: "boolean",
+                            description: "Whether the diff is a new file",
+                          },
+                          renamed_file: {
+                            type: "boolean",
+                            description: "Whether the diff is a renamed file",
+                          },
+                          deleted_file: {
+                            type: "boolean",
+                            description: "Whether the diff is a deleted file",
+                          },
+                          too_large: {
+                            type: "boolean",
+                            description: "Whether the diff is too large",
+                          },
+                        },
+                      },
                     },
                   },
                 },
-                merged_at: {
-                  type: "string",
-                  description: "The date and time the merge request was merged",
-                },
-              },
-            },
-            diffs: {
-              type: "array",
-              description: "A list of diffs that match the query",
-              items: {
-                type: "object",
-                required: ["old_path", "new_path", "diff", "new_file", "renamed_file", "deleted_file"],
-                properties: {
-                  old_path: {
-                    type: "string",
-                    description: "The old path of the diff",
-                  },
-                  new_path: {
-                    type: "string",
-                    description: "The new path of the diff",
-                  },
-                  diff: {
-                    type: "string",
-                    description: "The contents of the diff",
-                  },
-                  new_file: {
-                    type: "boolean",
-                    description: "Whether the diff is a new file",
-                  },
-                  renamed_file: {
-                    type: "boolean",
-                    description: "Whether the diff is a renamed file",
-                  },
-                  deleted_file: {
-                    type: "boolean",
-                    description: "Whether the diff is a deleted file",
-                  },
-                  too_large: {
-                    type: "boolean",
-                    description: "Whether the diff is too large",
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      blobs: {
-        type: "array",
-        description: "A list of blobs that match the query",
-        items: {
-          type: "object",
-          required: ["metadata", "diffs"],
-          properties: {
-            metadata: {
-              type: "object",
-              required: ["path", "basename", "data", "project_id", "ref", "startline", "filename", "web_url"],
-              properties: {
-                path: {
-                  type: "string",
-                  description: "The path of the blob",
-                },
-                basename: {
-                  type: "string",
-                  description: "The basename of the blob",
-                },
-                data: {
-                  type: "string",
-                  description: "The data of the blob",
-                },
-                project_id: {
-                  type: "number",
-                  description: "The ID of the project the blob belongs to",
-                },
-                ref: {
-                  type: "string",
-                  description: "The ref of the blob",
-                },
-                startline: {
-                  type: "number",
-                  description: "The start line of the blob",
-                },
-                filename: {
-                  type: "string",
-                  description: "The filename of the blob",
-                },
-                web_url: {
-                  type: "string",
-                  description: "The URL of the blob",
-                },
-              },
-            },
-            matchedMergeRequests: {
-              type: "array",
-              description: "A list of merge requests that match the blob",
-              items: {
-                type: "object",
-                required: ["title", "web_url"],
-                properties: {
-                  title: {
-                    type: "string",
-                    description: "The title of the merge request",
-                  },
-                  web_url: {
-                    type: "string",
-                    description: "The URL of the merge request",
-                  },
-                  author: {
-                    type: "object",
-                    description: "The author of the merge request",
-                  },
-                  merged_at: {
-                    type: "string",
-                    description: "The date and time the merge request was merged",
+                {
+                  type: "object",
+                  description: "Blob contents",
+                  required: ["metadata", "matchedMergeRequests"],
+                  properties: {
+                    metadata: {
+                      type: "object",
+                      required: ["path", "basename", "data", "project_id", "ref", "startline", "filename", "web_url"],
+                      properties: {
+                        path: {
+                          type: "string",
+                          description: "The path of the blob",
+                        },
+                        basename: {
+                          type: "string",
+                          description: "The basename of the blob",
+                        },
+                        data: {
+                          type: "string",
+                          description: "The data of the blob",
+                        },
+                        project_id: {
+                          type: "number",
+                          description: "The ID of the project the blob belongs to",
+                        },
+                        ref: {
+                          type: "string",
+                          description: "The ref of the blob",
+                        },
+                        startline: {
+                          type: "number",
+                          description: "The start line of the blob",
+                        },
+                        filename: {
+                          type: "string",
+                          description: "The filename of the blob",
+                        },
+                        web_url: {
+                          type: "string",
+                          description: "The URL of the blob",
+                        },
+                      },
+                    },
+                    matchedMergeRequests: {
+                      type: "array",
+                      description: "A list of merge requests that match the blob",
+                      items: {
+                        type: "object",
+                        required: ["title", "web_url"],
+                        properties: {
+                          title: {
+                            type: "string",
+                            description: "The title of the merge request",
+                          },
+                          web_url: {
+                            type: "string",
+                            description: "The URL of the merge request",
+                          },
+                          author: {
+                            type: "object",
+                            description: "The author of the merge request",
+                          },
+                          merged_at: {
+                            type: "string",
+                            description: "The date and time the merge request was merged",
+                          },
+                        },
+                      },
+                    },
                   },
                 },
-              },
-            },
-          },
-        },
-      },
-      commits: {
-        type: "array",
-        description: "A list of commits that match the query",
-        items: {
-          type: "object",
-          required: ["sha", "web_url", "message", "author", "created_at", "files"],
-          properties: {
-            sha: {
-              type: "string",
-              description: "The commit SHA",
-            },
-            web_url: {
-              type: "string",
-              description: "The URL to view the commit in GitLab",
-            },
-            message: {
-              type: "string",
-              description: "The full commit message",
-            },
-            author: {
-              type: "object",
-              required: ["name", "email"],
-              properties: {
-                name: {
-                  type: "string",
-                  description: "The name of the commit author",
-                },
-                email: {
-                  type: "string",
-                  description: "The email of the commit author",
-                },
-              },
-            },
-            created_at: {
-              type: "string",
-              description: "The date/time the commit was created",
-            },
-            files: {
-              type: "array",
-              description: "A list of files changed in the commit",
-              items: {
-                type: "object",
-                required: ["old_path", "new_path", "diff"],
-                properties: {
-                  old_path: {
-                    type: "string",
-                    description: "The old path of the file",
-                  },
-                  new_path: {
-                    type: "string",
-                    description: "The new path of the file",
-                  },
-                  diff: {
-                    type: "string",
-                    description: "The diff contents for the file",
+                {
+                  type: "object",
+                  description: "Commit contents",
+                  required: ["sha", "web_url", "message", "author", "created_at", "files"],
+                  properties: {
+                    sha: {
+                      type: "string",
+                      description: "The commit SHA",
+                    },
+                    web_url: {
+                      type: "string",
+                      description: "The URL to view the commit in GitLab",
+                    },
+                    message: {
+                      type: "string",
+                      description: "The full commit message",
+                    },
+                    author: {
+                      type: "object",
+                      required: ["name", "email"],
+                      properties: {
+                        name: {
+                          type: "string",
+                          description: "The name of the commit author",
+                        },
+                        email: {
+                          type: "string",
+                          description: "The email of the commit author",
+                        },
+                      },
+                    },
+                    created_at: {
+                      type: "string",
+                      description: "The date/time the commit was created",
+                    },
+                    files: {
+                      type: "array",
+                      description: "A list of files changed in the commit",
+                      items: {
+                        type: "object",
+                        required: ["old_path", "new_path", "diff"],
+                        properties: {
+                          old_path: {
+                            type: "string",
+                            description: "The old path of the file",
+                          },
+                          new_path: {
+                            type: "string",
+                            description: "The new path of the file",
+                          },
+                          diff: {
+                            type: "string",
+                            description: "The diff contents for the file",
+                          },
+                        },
+                      },
+                    },
                   },
                 },
-              },
+              ],
             },
           },
         },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -12637,7 +12637,7 @@ export const gitlabGetFileContentDefinition: ActionTemplate = {
         description: "The results of the file content",
         items: {
           type: "object",
-          required: ["name", "url", "content"],
+          required: ["name", "url", "contents"],
           properties: {
             name: {
               type: "string",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -7491,17 +7491,41 @@ export const googleOauthGetDriveFileContentByIdDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether the file content was retrieved successfully",
       },
-      content: {
-        type: "string",
-        description: "The content of the file",
-      },
-      fileName: {
-        type: "string",
-        description: "The name of the file",
-      },
-      fileLength: {
-        type: "number",
-        description: "The length of the file content prior to truncating",
+      results: {
+        type: "array",
+        description: "The results of the file content",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the file",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the file",
+            },
+            contents: {
+              type: "object",
+              description: "The contents of the file",
+              properties: {
+                content: {
+                  type: "string",
+                  description: "The content of the file",
+                },
+                fileName: {
+                  type: "string",
+                  description: "The name of the file",
+                },
+                fileLength: {
+                  type: "number",
+                  description: "The length of the file content prior to truncating",
+                },
+              },
+            },
+          },
+        },
       },
       error: {
         type: "string",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -3235,11 +3235,37 @@ export const firecrawlScrapeUrlDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["content"],
+    required: ["success"],
     properties: {
-      content: {
+      success: {
+        type: "boolean",
+        description: "Whether the operation was successful",
+      },
+      error: {
         type: "string",
-        description: "The content of the URL",
+        description: "Error message if the operation failed",
+      },
+      results: {
+        type: "array",
+        description: "The results of the scrape",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the result",
+            },
+            contents: {
+              type: "string",
+              description: "The content of the URL",
+            },
+          },
+        },
       },
     },
   },
@@ -9913,32 +9939,46 @@ export const salesforceSearchSalesforceRecordsDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether the records were successfully retrieved",
       },
-      searchRecords: {
+      results: {
         type: "array",
         description: "The records that match the search",
         items: {
           type: "object",
           description: "A record from Salesforce",
           properties: {
-            id: {
+            name: {
               type: "string",
-              description: "The Salesforce record ID",
+              description: "The name of the record",
             },
-            attributes: {
+            url: {
+              type: "string",
+              description: "The URL of the record",
+            },
+            contents: {
               type: "object",
-              description: "Metadata about the Salesforce record",
+              description: "The contents of the record",
               properties: {
-                type: {
+                id: {
                   type: "string",
-                  description: "The Salesforce object type",
+                  description: "The Salesforce record ID",
                 },
-                url: {
-                  type: "string",
-                  description: "The Salesforce record URL",
+                attributes: {
+                  type: "object",
+                  description: "Metadata about the Salesforce record",
+                  properties: {
+                    type: {
+                      type: "string",
+                      description: "The Salesforce object type",
+                    },
+                    url: {
+                      type: "string",
+                      description: "The Salesforce record URL",
+                    },
+                  },
+                  required: ["type", "url"],
+                  additionalProperties: true,
                 },
               },
-              required: ["type", "url"],
-              additionalProperties: true,
             },
           },
         },
@@ -9977,14 +10017,24 @@ export const salesforceGetSalesforceRecordsByQueryDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether the records were successfully retrieved",
       },
-      records: {
+      results: {
         type: "array",
-        description: "The retrieved records",
-        items: {
-          type: "object",
-          description: "A record from Salesforce",
-          additionalProperties: {
+        description: "Array of standardized results objects",
+        properties: {
+          name: {
             type: "string",
+            description: "The name of the record",
+          },
+          url: {
+            type: "string",
+            description: "The url of the record",
+          },
+          contents: {
+            type: "object",
+            description: "A record from Salesforce",
+            additionalProperties: {
+              type: "string",
+            },
           },
         },
       },
@@ -10528,50 +10578,71 @@ export const githubListPullRequestsDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["pullRequests"],
+    required: ["success"],
     properties: {
-      pullRequests: {
+      success: {
+        type: "boolean",
+        description: "Whether the operation was successful",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the operation was not successful",
+      },
+      results: {
         type: "array",
         description: "A list of pull requests in the repository",
         items: {
           type: "object",
           properties: {
-            number: {
-              type: "number",
-              description: "The number of the pull request",
-            },
-            title: {
+            name: {
               type: "string",
               description: "The title of the pull request",
-            },
-            state: {
-              type: "string",
-              description: "The state of the pull request (e.g., open, closed)",
             },
             url: {
               type: "string",
               description: "The URL of the pull request",
             },
-            createdAt: {
-              type: "string",
-              description: "The date and time when the pull request was created",
-            },
-            updatedAt: {
-              type: "string",
-              description: "The date and time when the pull request was last updated",
-            },
-            user: {
+            contents: {
               type: "object",
               properties: {
-                login: {
+                number: {
+                  type: "number",
+                  description: "The number of the pull request",
+                },
+                title: {
                   type: "string",
-                  description: "The username of the user who created the pull request",
+                  description: "The title of the pull request",
+                },
+                state: {
+                  type: "string",
+                  description: "The state of the pull request (e.g., open, closed)",
+                },
+                url: {
+                  type: "string",
+                  description: "The URL of the pull request",
+                },
+                createdAt: {
+                  type: "string",
+                  description: "The date and time when the pull request was created",
+                },
+                updatedAt: {
+                  type: "string",
+                  description: "The date and time when the pull request was last updated",
+                },
+                user: {
+                  type: "object",
+                  properties: {
+                    login: {
+                      type: "string",
+                      description: "The username of the user who created the pull request",
+                    },
+                  },
+                },
+                description: {
+                  type: "string",
+                  description: "The description of the pull request",
                 },
               },
-            },
-            description: {
-              type: "string",
-              description: "The description of the pull request",
             },
           },
         },
@@ -10892,21 +10963,43 @@ export const githubGetFileContentDefinition: ActionTemplate = {
         type: "string",
         description: "The error that occurred if the operation was not successful",
       },
-      content: {
-        type: "string",
-        description: "The decoded file content as a string",
-      },
-      size: {
-        type: "number",
-        description: "The size of the file in bytes",
-      },
-      name: {
-        type: "string",
-        description: "The name of the file",
-      },
-      htmlUrl: {
-        type: "string",
-        description: "The URL of the file in the Github UI",
+      results: {
+        type: "array",
+        description: "A list of Github files",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the file",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the file in the Github UI",
+            },
+            contents: {
+              type: "object",
+              properties: {
+                content: {
+                  type: "string",
+                  description: "The decoded file content as a string",
+                },
+                size: {
+                  type: "number",
+                  description: "The size of the file in bytes",
+                },
+                name: {
+                  type: "string",
+                  description: "The name of the file",
+                },
+                htmlUrl: {
+                  type: "string",
+                  description: "The URL of the file in the Github UI",
+                },
+              },
+            },
+          },
+        },
       },
     },
   },
@@ -10946,32 +11039,39 @@ export const githubListDirectoryDefinition: ActionTemplate = {
         type: "string",
         description: "Error message if the operation failed",
       },
-      content: {
+      results: {
         type: "array",
         description: "Array of directory contents",
         items: {
           type: "object",
-          required: ["name", "path", "type", "size", "htmlUrl"],
+          required: ["name", "url", "contents"],
           properties: {
             name: {
               type: "string",
               description: "The name of the file",
             },
-            path: {
-              type: "string",
-              description: "The path of the file",
-            },
-            type: {
-              type: "string",
-              description: "The type of the file",
-            },
-            size: {
-              type: "number",
-              description: "The size of the file in bytes",
-            },
-            htmlUrl: {
+            url: {
               type: "string",
               description: "The URL of the file in the Github UI",
+            },
+            contents: {
+              type: "object",
+              required: ["path", "type", "size"],
+              description: "The contents of the file",
+              properties: {
+                path: {
+                  type: "string",
+                  description: "The path of the file",
+                },
+                type: {
+                  type: "string",
+                  description: "The type of the file",
+                },
+                size: {
+                  type: "number",
+                  description: "The size of the file in bytes",
+                },
+              },
             },
           },
         },
@@ -11239,209 +11339,235 @@ export const githubSearchOrganizationDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["code", "commits", "issuesAndPullRequests"],
+    required: ["success"],
     properties: {
-      code: {
+      success: {
+        type: "boolean",
+        description: "Whether the operation was successful",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      results: {
         type: "array",
-        description: "A list of code results that match the query",
+        description: "Array of search results",
         items: {
           type: "object",
-          required: ["name", "path", "sha", "url", "score", "textMatches"],
+          required: ["name", "url", "type", "content"],
           properties: {
             name: {
               type: "string",
-              description: "The name of the file that had a match",
-            },
-            path: {
-              type: "string",
-              description: "The path of the file that had a match",
-            },
-            sha: {
-              type: "string",
-              description: "The SHA of the commit that had a match",
+              description: "The name of the result (file name, commit SHA, or issue/PR title)",
             },
             url: {
               type: "string",
-              description: "The URL of the file that had a match",
+              description: "The URL of the result",
             },
-            score: {
-              type: "number",
-              description: "The similarity score of the match",
+            type: {
+              type: "string",
+              enum: ["code", "commit", "issueOrPullRequest"],
+              description: "The type of the result",
             },
-            textMatches: {
-              type: "array",
-              description: "A list of text matches that match the query",
-              items: {
-                type: "object",
-                required: ["matches"],
-                properties: {
-                  object_url: {
-                    type: "string",
-                    description: "The URL of the object that had a match",
-                  },
-                  object_type: {
-                    type: "string",
-                    description: "The type of the object that had a match",
-                  },
-                  fragment: {
-                    type: "string",
-                    description: "The fragment of the text that had a match",
-                  },
-                  matches: {
-                    type: "array",
-                    description: "A list of matches that match the query",
-                    items: {
-                      type: "object",
-                      properties: {
-                        text: {
-                          type: "string",
-                          description: "The text that had a match",
-                        },
-                        indices: {
-                          type: "array",
-                          description: "The indices of the text that had a match",
-                          items: {
-                            type: "number",
+            content: {
+              oneOf: [
+                {
+                  type: "object",
+                  description: "Code result content",
+                  required: ["name", "path", "sha", "url", "score", "textMatches"],
+                  properties: {
+                    name: {
+                      type: "string",
+                      description: "The name of the file that had a match",
+                    },
+                    path: {
+                      type: "string",
+                      description: "The path of the file that had a match",
+                    },
+                    sha: {
+                      type: "string",
+                      description: "The SHA of the commit that had a match",
+                    },
+                    url: {
+                      type: "string",
+                      description: "The URL of the file that had a match",
+                    },
+                    score: {
+                      type: "number",
+                      description: "The similarity score of the match",
+                    },
+                    textMatches: {
+                      type: "array",
+                      description: "A list of text matches that match the query",
+                      items: {
+                        type: "object",
+                        required: ["matches"],
+                        properties: {
+                          object_url: {
+                            type: "string",
+                            description: "The URL of the object that had a match",
+                          },
+                          object_type: {
+                            type: "string",
+                            description: "The type of the object that had a match",
+                          },
+                          fragment: {
+                            type: "string",
+                            description: "The fragment of the text that had a match",
+                          },
+                          matches: {
+                            type: "array",
+                            description: "A list of matches that match the query",
+                            items: {
+                              type: "object",
+                              properties: {
+                                text: {
+                                  type: "string",
+                                  description: "The text that had a match",
+                                },
+                                indices: {
+                                  type: "array",
+                                  description: "The indices of the text that had a match",
+                                  items: {
+                                    type: "number",
+                                  },
+                                },
+                              },
+                            },
                           },
                         },
                       },
                     },
                   },
                 },
-              },
-            },
-          },
-        },
-      },
-      commits: {
-        type: "array",
-        description: "A list of commits that match the query",
-        items: {
-          type: "object",
-          required: ["sha", "url", "message", "author", "committer", "parents", "tree", "commitDate"],
-          properties: {
-            sha: {
-              type: "string",
-              description: "The SHA of the commit that had a match",
-            },
-            url: {
-              type: "string",
-              description: "The URL of the commit that had a match",
-            },
-            commit: {
-              type: "object",
-              required: ["message", "author", "score", "files"],
-              properties: {
-                author: {
+                {
                   type: "object",
-                  required: ["name", "email", "date"],
+                  description: "Commit result content",
+                  required: ["sha", "url", "message", "author", "committer", "parents", "tree", "commitDate"],
                   properties: {
-                    name: {
+                    sha: {
                       type: "string",
-                      description: "The name of the author",
+                      description: "The SHA of the commit that had a match",
                     },
-                    email: {
+                    url: {
                       type: "string",
-                      description: "The email of the author",
+                      description: "The URL of the commit that had a match",
                     },
-                    date: {
-                      type: "string",
-                      description: "The date of the commit",
+                    commit: {
+                      type: "object",
+                      required: ["message", "author", "score", "files"],
+                      properties: {
+                        author: {
+                          type: "object",
+                          required: ["name", "email", "date"],
+                          properties: {
+                            name: {
+                              type: "string",
+                              description: "The name of the author",
+                            },
+                            email: {
+                              type: "string",
+                              description: "The email of the author",
+                            },
+                            date: {
+                              type: "string",
+                              description: "The date of the commit",
+                            },
+                          },
+                        },
+                        message: {
+                          type: "string",
+                          description: "The message of the commit",
+                        },
+                      },
+                      score: {
+                        type: "number",
+                        description: "The score of the commit",
+                      },
+                      files: {
+                        type: "array",
+                        description: "A list of files that match the query",
+                        items: {
+                          type: "object",
+                          required: ["filename", "status", "patch"],
+                          properties: {
+                            filename: {
+                              type: "string",
+                              description: "The filename of the file",
+                            },
+                            status: {
+                              type: "string",
+                              description: "The status of the file",
+                            },
+                            patch: {
+                              type: "string",
+                              description: "The patch of the file",
+                            },
+                          },
+                        },
+                      },
                     },
                   },
                 },
-                message: {
-                  type: "string",
-                  description: "The message of the commit",
-                },
-              },
-              score: {
-                type: "number",
-                description: "The score of the commit",
-              },
-              files: {
-                type: "array",
-                description: "A list of files that match the query",
-                items: {
+                {
                   type: "object",
-                  required: ["filename", "status", "patch"],
+                  description: "Issue or pull request result content",
+                  required: ["title", "url", "state", "createdAt", "updatedAt", "user"],
                   properties: {
-                    filename: {
-                      type: "string",
-                      description: "The filename of the file",
+                    number: {
+                      type: "number",
+                      description: "The number of the issue or pull request",
                     },
-                    status: {
+                    title: {
                       type: "string",
-                      description: "The status of the file",
+                      description: "The title of the issue or pull request",
                     },
-                    patch: {
+                    html_url: {
                       type: "string",
-                      description: "The patch of the file",
+                      description: "The URL of the issue or pull request",
+                    },
+                    state: {
+                      type: "string",
+                      description: "The state of the issue or pull request",
+                      enum: ["open", "closed"],
+                    },
+                    isPullRequest: {
+                      type: "boolean",
+                      description: "Whether the issue or pull request is a pull request",
+                    },
+                    body: {
+                      type: "string",
+                      description: "The body of the issue or pull request",
+                    },
+                    score: {
+                      type: "number",
+                      description: "The score of the issue or pull request",
+                    },
+                    files: {
+                      type: "array",
+                      description: "A list of files that match the query",
+                      items: {
+                        type: "object",
+                        required: ["filename", "status"],
+                        properties: {
+                          filename: {
+                            type: "string",
+                            description: "The filename of the file",
+                          },
+                          status: {
+                            type: "string",
+                            description: "The status of the file",
+                          },
+                          patch: {
+                            type: "string",
+                            description: "The patch of the file",
+                          },
+                        },
+                      },
                     },
                   },
                 },
-              },
-            },
-          },
-        },
-      },
-      issuesAndPullRequests: {
-        type: "array",
-        description: "A list of issues and pull requests that match the query",
-        items: {
-          type: "object",
-          required: ["title", "url", "state", "createdAt", "updatedAt", "user"],
-          properties: {
-            number: {
-              type: "number",
-              description: "The number of the issue or pull request",
-            },
-            title: {
-              type: "string",
-              description: "The title of the issue or pull request",
-            },
-            html_url: {
-              type: "string",
-              description: "The URL of the issue or pull request",
-            },
-            state: {
-              type: "string",
-              description: "The state of the issue or pull request",
-              enum: ["open", "closed"],
-            },
-            isPullRequest: {
-              type: "boolean",
-              description: "Whether the issue or pull request is a pull request",
-            },
-            body: {
-              type: "string",
-              description: "The body of the issue or pull request",
-            },
-            score: {
-              type: "number",
-              description: "The score of the issue or pull request",
-            },
-            files: {
-              type: "array",
-              description: "A list of files that match the query",
-              items: {
-                type: "object",
-                required: ["filename", "status"],
-                properties: {
-                  filename: {
-                    type: "string",
-                    description: "The filename of the file",
-                  },
-                  status: {
-                    type: "string",
-                    description: "The status of the file",
-                  },
-                  patch: {
-                    type: "string",
-                    description: "The patch of the file",
-                  },
-                },
-              },
+              ],
             },
           },
         },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -12561,21 +12561,45 @@ export const gitlabGetFileContentDefinition: ActionTemplate = {
         type: "string",
         description: "The error that occurred if the operation was not successful",
       },
-      content: {
-        type: "string",
-        description: "The decoded file content as a string",
-      },
-      size: {
-        type: "number",
-        description: "The size of the file in bytes",
-      },
-      name: {
-        type: "string",
-        description: "The name of the file",
-      },
-      htmlUrl: {
-        type: "string",
-        description: "The URL of the file in the GitLab UI",
+      results: {
+        type: "array",
+        description: "The results of the file content",
+        items: {
+          type: "object",
+          required: ["name", "url", "content"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the file",
+            },
+            url: {
+              type: "string",
+              description: "The url of the file",
+            },
+            contents: {
+              type: "object",
+              required: ["content", "size", "name", "htmlUrl"],
+              properties: {
+                content: {
+                  type: "string",
+                  description: "The decoded file content as a string",
+                },
+                size: {
+                  type: "number",
+                  description: "The size of the file in bytes",
+                },
+                name: {
+                  type: "string",
+                  description: "The name of the file",
+                },
+                htmlUrl: {
+                  type: "string",
+                  description: "The URL of the file in the GitLab UI",
+                },
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1316,9 +1316,27 @@ export const jiraGetJiraTicketDetailsDefinition: ActionTemplate = {
         type: "string",
         description: "The error that occurred if the retrieval was unsuccessful",
       },
-      data: {
-        type: "object",
-        description: "The data of the Jira ticket",
+      results: {
+        type: "array",
+        description: "The results of the Jira ticket",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the result",
+            },
+            contents: {
+              type: "object",
+              description: "The data of the Jira ticket",
+            },
+          },
+        },
       },
     },
   },
@@ -1957,9 +1975,27 @@ export const jiraOrgGetJiraTicketDetailsDefinition: ActionTemplate = {
         type: "string",
         description: "The error that occurred if the retrieval was unsuccessful",
       },
-      data: {
-        type: "object",
-        description: "The data of the Jira ticket",
+      results: {
+        type: "array",
+        description: "The results of the Jira ticket",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the result",
+            },
+            contents: {
+              type: "object",
+              description: "The data of the Jira ticket",
+            },
+          },
+        },
       },
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1509,15 +1509,24 @@ export const jiraGetJiraIssuesByQueryDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether the records were successfully retrieved",
       },
-      records: {
-        type: "object",
-        description: "The result object containing issues",
-        properties: {
-          issues: {
-            type: "array",
-            description: "The retrieved Jira issues",
-            items: {
+      results: {
+        type: "array",
+        description: "The results of the Jira issues",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the result",
+            },
+            contents: {
               type: "object",
+              description: "The result object containing issues",
               required: [
                 "id",
                 "key",
@@ -2168,15 +2177,24 @@ export const jiraOrgGetJiraIssuesByQueryDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether the records were successfully retrieved",
       },
-      records: {
-        type: "object",
-        description: "The result object containing issues",
-        properties: {
-          issues: {
-            type: "array",
-            description: "The retrieved Jira issues",
-            items: {
+      results: {
+        type: "array",
+        description: "The results of the Jira issues",
+        items: {
+          type: "object",
+          required: ["name", "url", "contents"],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the result",
+            },
+            url: {
+              type: "string",
+              description: "The URL of the result",
+            },
+            contents: {
               type: "object",
+              description: "The result object containing issues",
               required: [
                 "id",
                 "key",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -787,55 +787,69 @@ export const slackUserSearchSlackDefinition: ActionTemplate = {
         description: "Hydrated search results (threads or small context windows), sorted by ts desc.",
         items: {
           type: "object",
-          required: ["channelId", "ts"],
+          required: ["name", "url", "contents"],
           properties: {
-            channelId: {
+            name: {
               type: "string",
-              description: "Slack channel/conversation ID (C…/G…/D… or name).",
+              description: "The name of the result",
             },
-            ts: {
+            url: {
               type: "string",
-              description: "Slack message timestamp of the hit (or thread root when hydrated as thread).",
+              description: "The URL of the result",
             },
-            text: {
-              type: "string",
-              description: "Message text of the anchor (hit or thread root).",
-            },
-            userEmail: {
-              type: "string",
-              description: "User email of the anchor message’s author (if available).",
-            },
-            userName: {
-              type: "string",
-              description: "User name of the anchor message’s author (if available).",
-            },
-            permalink: {
-              type: "string",
-              description: "A Slack permalink to the anchor (message or thread root), if resolvable.",
-            },
-            context: {
-              type: "array",
-              description:
-                "When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).",
-              items: {
-                type: "object",
-                required: ["ts"],
-                properties: {
-                  ts: {
-                    type: "string",
-                    description: "Timestamp of the contextual message.",
-                  },
-                  text: {
-                    type: "string",
-                    description: "Text of the contextual message.",
-                  },
-                  userEmail: {
-                    type: "string",
-                    description: "Author user email of the contextual message.",
-                  },
-                  userName: {
-                    type: "string",
-                    description: "Author user name of the contextual message.",
+            contents: {
+              type: "object",
+              required: ["channelId", "ts"],
+              properties: {
+                channelId: {
+                  type: "string",
+                  description: "Slack channel/conversation ID (C…/G…/D… or name).",
+                },
+                ts: {
+                  type: "string",
+                  description: "Slack message timestamp of the hit (or thread root when hydrated as thread).",
+                },
+                text: {
+                  type: "string",
+                  description: "Message text of the anchor (hit or thread root).",
+                },
+                userEmail: {
+                  type: "string",
+                  description: "User email of the anchor message’s author (if available).",
+                },
+                userName: {
+                  type: "string",
+                  description: "User name of the anchor message’s author (if available).",
+                },
+                permalink: {
+                  type: "string",
+                  description: "A Slack permalink to the anchor (message or thread root), if resolvable.",
+                },
+                context: {
+                  type: "array",
+                  description:
+                    "When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).",
+                  items: {
+                    type: "object",
+                    required: ["ts"],
+                    properties: {
+                      ts: {
+                        type: "string",
+                        description: "Timestamp of the contextual message.",
+                      },
+                      text: {
+                        type: "string",
+                        description: "Text of the contextual message.",
+                      },
+                      userEmail: {
+                        type: "string",
+                        description: "Author user email of the contextual message.",
+                      },
+                      userName: {
+                        type: "string",
+                        description: "Author user name of the contextual message.",
+                      },
+                    },
                   },
                 },
               },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -12647,34 +12647,57 @@ export const gitlabListDirectoryDefinition: ActionTemplate = {
   },
   output: {
     type: "object",
-    required: ["content"],
+    required: ["success"],
     properties: {
-      content: {
+      success: {
+        type: "boolean",
+        description: "Whether the operation was successful",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      results: {
         type: "array",
         description: "Array of directory contents",
         items: {
           type: "object",
-          required: ["name", "path", "type", "htmlUrl"],
+          required: ["name", "url", "contents"],
           properties: {
             name: {
               type: "string",
               description: "The name of the file or directory",
             },
-            path: {
+            url: {
               type: "string",
-              description: "The path of the file or directory",
+              description: "The URL of the file or directory",
             },
-            type: {
-              type: "string",
-              description: 'The type of the entry (either "blob" for file or "tree" for directory)',
-            },
-            size: {
-              type: "number",
-              description: "The size of the file in bytes (only for blobs; omitted or 0 for trees)",
-            },
-            htmlUrl: {
-              type: "string",
-              description: "The URL of the file or folder in the GitLab UI",
+            contents: {
+              type: "object",
+              description: "The contents of the directory",
+              required: ["name", "path", "type", "htmlUrl"],
+              properties: {
+                name: {
+                  type: "string",
+                  description: "The name of the file or directory",
+                },
+                path: {
+                  type: "string",
+                  description: "The path of the file or directory",
+                },
+                type: {
+                  type: "string",
+                  description: 'The type of the entry (either "blob" for file or "tree" for directory)',
+                },
+                size: {
+                  type: "number",
+                  description: "The size of the file in bytes (only for blobs; omitted or 0 for trees)",
+                },
+                htmlUrl: {
+                  type: "string",
+                  description: "The URL of the file or folder in the GitLab UI",
+                },
+              },
             },
           },
         },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -816,11 +816,13 @@ export type jiraGetJiraIssuesByQueryParamsType = z.infer<typeof jiraGetJiraIssue
 
 export const jiraGetJiraIssuesByQueryOutputSchema = z.object({
   success: z.boolean().describe("Whether the records were successfully retrieved"),
-  records: z
-    .object({
-      issues: z
-        .array(
-          z.object({
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the result"),
+        url: z.string().describe("The URL of the result"),
+        contents: z
+          .object({
             id: z.string().describe("Internal Jira issue ID"),
             key: z.string().describe("Human-readable issue key (e.g. SSPR-123)"),
             summary: z.string().describe("Summary of the issue"),
@@ -840,12 +842,11 @@ export const jiraGetJiraIssuesByQueryOutputSchema = z.object({
             updated: z.string().datetime({ offset: true }),
             resolution: z.string().nullable().optional(),
             dueDate: z.string().date().nullable().optional(),
-          }),
-        )
-        .describe("The retrieved Jira issues")
-        .optional(),
-    })
-    .describe("The result object containing issues")
+          })
+          .describe("The result object containing issues"),
+      }),
+    )
+    .describe("The results of the Jira issues")
     .optional(),
   error: z.string().describe("The error that occurred if the records were not successfully retrieved").optional(),
 });
@@ -1132,11 +1133,13 @@ export type jiraOrgGetJiraIssuesByQueryParamsType = z.infer<typeof jiraOrgGetJir
 
 export const jiraOrgGetJiraIssuesByQueryOutputSchema = z.object({
   success: z.boolean().describe("Whether the records were successfully retrieved"),
-  records: z
-    .object({
-      issues: z
-        .array(
-          z.object({
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the result"),
+        url: z.string().describe("The URL of the result"),
+        contents: z
+          .object({
             id: z.string().describe("Internal Jira issue ID"),
             key: z.string().describe("Human-readable issue key (e.g. SSPR-123)"),
             summary: z.string().describe("Summary of the issue"),
@@ -1156,12 +1159,11 @@ export const jiraOrgGetJiraIssuesByQueryOutputSchema = z.object({
             updated: z.string().datetime({ offset: true }),
             resolution: z.string().nullable().optional(),
             dueDate: z.string().date().nullable().optional(),
-          }),
-        )
-        .describe("The retrieved Jira issues")
-        .optional(),
-    })
-    .describe("The result object containing issues")
+          })
+          .describe("The result object containing issues"),
+      }),
+    )
+    .describe("The results of the Jira issues")
     .optional(),
   error: z.string().describe("The error that occurred if the records were not successfully retrieved").optional(),
 });

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -3857,9 +3857,22 @@ export type googleOauthGetDriveFileContentByIdParamsType = z.infer<
 
 export const googleOauthGetDriveFileContentByIdOutputSchema = z.object({
   success: z.boolean().describe("Whether the file content was retrieved successfully"),
-  content: z.string().describe("The content of the file").optional(),
-  fileName: z.string().describe("The name of the file").optional(),
-  fileLength: z.number().describe("The length of the file content prior to truncating").optional(),
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the file"),
+        url: z.string().describe("The URL of the file"),
+        contents: z
+          .object({
+            content: z.string().describe("The content of the file").optional(),
+            fileName: z.string().describe("The name of the file").optional(),
+            fileLength: z.number().describe("The length of the file content prior to truncating").optional(),
+          })
+          .describe("The contents of the file"),
+      }),
+    )
+    .describe("The results of the file content")
+    .optional(),
   error: z.string().describe("Error message if file content retrieval failed").optional(),
 });
 

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -446,28 +446,32 @@ export const slackUserSearchSlackOutputSchema = z.object({
   results: z
     .array(
       z.object({
-        channelId: z.string().describe("Slack channel/conversation ID (C…/G…/D… or name)."),
-        ts: z.string().describe("Slack message timestamp of the hit (or thread root when hydrated as thread)."),
-        text: z.string().describe("Message text of the anchor (hit or thread root).").optional(),
-        userEmail: z.string().describe("User email of the anchor message’s author (if available).").optional(),
-        userName: z.string().describe("User name of the anchor message’s author (if available).").optional(),
-        permalink: z
-          .string()
-          .describe("A Slack permalink to the anchor (message or thread root), if resolvable.")
-          .optional(),
-        context: z
-          .array(
-            z.object({
-              ts: z.string().describe("Timestamp of the contextual message."),
-              text: z.string().describe("Text of the contextual message.").optional(),
-              userEmail: z.string().describe("Author user email of the contextual message.").optional(),
-              userName: z.string().describe("Author user name of the contextual message.").optional(),
-            }),
-          )
-          .describe(
-            "When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).",
-          )
-          .optional(),
+        name: z.string().describe("The name of the result"),
+        url: z.string().describe("The URL of the result"),
+        contents: z.object({
+          channelId: z.string().describe("Slack channel/conversation ID (C…/G…/D… or name)."),
+          ts: z.string().describe("Slack message timestamp of the hit (or thread root when hydrated as thread)."),
+          text: z.string().describe("Message text of the anchor (hit or thread root).").optional(),
+          userEmail: z.string().describe("User email of the anchor message’s author (if available).").optional(),
+          userName: z.string().describe("User name of the anchor message’s author (if available).").optional(),
+          permalink: z
+            .string()
+            .describe("A Slack permalink to the anchor (message or thread root), if resolvable.")
+            .optional(),
+          context: z
+            .array(
+              z.object({
+                ts: z.string().describe("Timestamp of the contextual message."),
+                text: z.string().describe("Text of the contextual message.").optional(),
+                userEmail: z.string().describe("Author user email of the contextual message.").optional(),
+                userName: z.string().describe("Author user name of the contextual message.").optional(),
+              }),
+            )
+            .describe(
+              "When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).",
+            )
+            .optional(),
+        }),
       }),
     )
     .describe("Hydrated search results (threads or small context windows), sorted by ts desc."),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6313,14 +6313,12 @@ export const gitlabGetFileContentOutputSchema = z.object({
       z.object({
         name: z.string().describe("The name of the file"),
         url: z.string().describe("The url of the file"),
-        contents: z
-          .object({
-            content: z.string().describe("The decoded file content as a string"),
-            size: z.number().describe("The size of the file in bytes"),
-            name: z.string().describe("The name of the file"),
-            htmlUrl: z.string().describe("The URL of the file in the GitLab UI"),
-          })
-          .optional(),
+        contents: z.object({
+          content: z.string().describe("The decoded file content as a string"),
+          size: z.number().describe("The size of the file in bytes"),
+          name: z.string().describe("The name of the file"),
+          htmlUrl: z.string().describe("The URL of the file in the GitLab UI"),
+        }),
       }),
     )
     .describe("The results of the file content")

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6283,10 +6283,23 @@ export type gitlabGetFileContentParamsType = z.infer<typeof gitlabGetFileContent
 export const gitlabGetFileContentOutputSchema = z.object({
   success: z.boolean().describe("Whether the operation was successful"),
   error: z.string().describe("The error that occurred if the operation was not successful").optional(),
-  content: z.string().describe("The decoded file content as a string").optional(),
-  size: z.number().describe("The size of the file in bytes").optional(),
-  name: z.string().describe("The name of the file").optional(),
-  htmlUrl: z.string().describe("The URL of the file in the GitLab UI").optional(),
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the file"),
+        url: z.string().describe("The url of the file"),
+        contents: z
+          .object({
+            content: z.string().describe("The decoded file content as a string"),
+            size: z.number().describe("The size of the file in bytes"),
+            name: z.string().describe("The name of the file"),
+            htmlUrl: z.string().describe("The URL of the file in the GitLab UI"),
+          })
+          .optional(),
+      }),
+    )
+    .describe("The results of the file content")
+    .optional(),
 });
 
 export type gitlabGetFileContentOutputType = z.infer<typeof gitlabGetFileContentOutputSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -3766,14 +3766,20 @@ export type googleOauthSearchDriveByKeywordsAndGetFileContentParamsType = z.infe
 
 export const googleOauthSearchDriveByKeywordsAndGetFileContentOutputSchema = z.object({
   success: z.boolean().describe("Whether the search was successful"),
-  files: z
+  results: z
     .array(
       z.object({
-        id: z.string().describe("The file ID"),
-        name: z.string().describe("The file name"),
-        mimeType: z.string().describe("The MIME type of the file"),
-        url: z.string().describe("The web link to view the file"),
-        content: z.string().describe("The data returned from the file, subject to fileSizeLimit").optional(),
+        name: z.string().describe("The name of the file"),
+        url: z.string().describe("The URL of the file"),
+        contents: z
+          .object({
+            id: z.string().describe("The file ID"),
+            name: z.string().describe("The file name"),
+            mimeType: z.string().describe("The MIME type of the file"),
+            url: z.string().describe("The web link to view the file"),
+            content: z.string().describe("The data returned from the file, subject to fileSizeLimit").optional(),
+          })
+          .describe("The contents of the file"),
       }),
     )
     .describe("List of files matching the search")

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -717,7 +717,16 @@ export type jiraGetJiraTicketDetailsParamsType = z.infer<typeof jiraGetJiraTicke
 export const jiraGetJiraTicketDetailsOutputSchema = z.object({
   success: z.boolean().describe("Whether the status was updated successfully"),
   error: z.string().describe("The error that occurred if the retrieval was unsuccessful").optional(),
-  data: z.object({}).catchall(z.any()).describe("The data of the Jira ticket").optional(),
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the result"),
+        url: z.string().describe("The URL of the result"),
+        contents: z.object({}).catchall(z.any()).describe("The data of the Jira ticket"),
+      }),
+    )
+    .describe("The results of the Jira ticket")
+    .optional(),
 });
 
 export type jiraGetJiraTicketDetailsOutputType = z.infer<typeof jiraGetJiraTicketDetailsOutputSchema>;
@@ -1024,7 +1033,16 @@ export type jiraOrgGetJiraTicketDetailsParamsType = z.infer<typeof jiraOrgGetJir
 export const jiraOrgGetJiraTicketDetailsOutputSchema = z.object({
   success: z.boolean().describe("Whether the status was updated successfully"),
   error: z.string().describe("The error that occurred if the retrieval was unsuccessful").optional(),
-  data: z.object({}).catchall(z.any()).describe("The data of the Jira ticket").optional(),
+  results: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the result"),
+        url: z.string().describe("The URL of the result"),
+        contents: z.object({}).catchall(z.any()).describe("The data of the Jira ticket"),
+      }),
+    )
+    .describe("The results of the Jira ticket")
+    .optional(),
 });
 
 export type jiraOrgGetJiraTicketDetailsOutputType = z.infer<typeof jiraOrgGetJiraTicketDetailsOutputSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6323,17 +6323,29 @@ export const gitlabListDirectoryParamsSchema = z.object({
 export type gitlabListDirectoryParamsType = z.infer<typeof gitlabListDirectoryParamsSchema>;
 
 export const gitlabListDirectoryOutputSchema = z.object({
-  content: z
+  success: z.boolean().describe("Whether the operation was successful"),
+  error: z.string().describe("Error message if the operation failed").optional(),
+  results: z
     .array(
       z.object({
         name: z.string().describe("The name of the file or directory"),
-        path: z.string().describe("The path of the file or directory"),
-        type: z.string().describe('The type of the entry (either "blob" for file or "tree" for directory)'),
-        size: z.number().describe("The size of the file in bytes (only for blobs; omitted or 0 for trees)").optional(),
-        htmlUrl: z.string().describe("The URL of the file or folder in the GitLab UI"),
+        url: z.string().describe("The URL of the file or directory"),
+        contents: z
+          .object({
+            name: z.string().describe("The name of the file or directory"),
+            path: z.string().describe("The path of the file or directory"),
+            type: z.string().describe('The type of the entry (either "blob" for file or "tree" for directory)'),
+            size: z
+              .number()
+              .describe("The size of the file in bytes (only for blobs; omitted or 0 for trees)")
+              .optional(),
+            htmlUrl: z.string().describe("The URL of the file or folder in the GitLab UI"),
+          })
+          .describe("The contents of the directory"),
       }),
     )
-    .describe("Array of directory contents"),
+    .describe("Array of directory contents")
+    .optional(),
 });
 
 export type gitlabListDirectoryOutputType = z.infer<typeof gitlabListDirectoryOutputSchema>;

--- a/src/actions/providers/firecrawl/scrapeUrl.ts
+++ b/src/actions/providers/firecrawl/scrapeUrl.ts
@@ -5,7 +5,6 @@ import type {
   firecrawlScrapeUrlOutputType,
   AuthParamsType,
 } from "../../autogen/types.js";
-import { firecrawlScrapeUrlOutputSchema } from "../../autogen/types.js";
 
 const scrapeUrl: firecrawlScrapeUrlFunction = async ({
   params,
@@ -81,9 +80,16 @@ const scrapeUrl: firecrawlScrapeUrlFunction = async ({
     content = result.markdown || "";
   }
 
-  return firecrawlScrapeUrlOutputSchema.parse({
-    content,
-  });
+  return {
+    success: true,
+    results: [
+      {
+        name: result.metadata?.title ?? "Untitled",
+        url: params.url,
+        contents: content,
+      },
+    ],
+  };
 };
 
 export default scrapeUrl;

--- a/src/actions/providers/github/getFileContent.ts
+++ b/src/actions/providers/github/getFileContent.ts
@@ -59,10 +59,18 @@ const getFileContent: githubGetFileContentFunction = async ({
 
   return {
     success: true,
-    content,
-    size: data.size,
-    name: data.name,
-    htmlUrl: data.html_url ?? data.url,
+    results: [
+      {
+        name: data.name,
+        url: data.html_url ?? data.url,
+        contents: {
+          content,
+          size: data.size,
+          name: data.name,
+          htmlUrl: data.html_url ?? data.url,
+        },
+      },
+    ],
   };
 };
 

--- a/src/actions/providers/github/listDirectory.ts
+++ b/src/actions/providers/github/listDirectory.ts
@@ -46,19 +46,17 @@ const listDirectory: githubListDirectoryFunction = async ({
     };
   }
 
-  const content = data.map(item => {
-    return {
-      name: item.name,
-      path: item.path,
-      type: item.type,
-      size: item.size,
-      htmlUrl: item.html_url ?? item.url,
-    };
-  });
-
   return {
     success: true,
-    content,
+    results: data.map(item => ({
+      name: item.name,
+      url: item.html_url ?? item.url,
+      contents: {
+        path: item.path,
+        type: item.type,
+        size: item.size,
+      },
+    })),
   };
 };
 

--- a/src/actions/providers/gitlab/listDirectory.ts
+++ b/src/actions/providers/gitlab/listDirectory.ts
@@ -48,19 +48,23 @@ const listDirectory: gitlabListDirectoryFunction = async ({
 
   const treeItems = await gitlabFetch<{ name: string; path: string; type: string; size?: number }[]>(url, authToken);
 
-  const content = treeItems.map(item => {
+  const results = treeItems.map(item => {
     const isFile = item.type === "blob";
     const htmlUrl = `${gitlabBaseUrl}/${fullPath}/-/blob/${ref}/${item.path}`;
     return {
       name: item.name,
-      path: item.path,
-      type: item.type, // "blob" or "tree"
-      size: isFile ? (item.size ?? 0) : 0, // Size may not be returned; fallback to 0
-      htmlUrl,
+      url: htmlUrl,
+      contents: {
+        name: item.name,
+        path: item.path,
+        type: item.type, // "blob" or "tree"
+        size: isFile ? (item.size ?? 0) : 0, // Size may not be returned; fallback to 0
+        htmlUrl,
+      },
     };
   });
 
-  return { content };
+  return { success: true, results };
 };
 
 export default listDirectory;

--- a/src/actions/providers/google-oauth/getDriveFileContentById.ts
+++ b/src/actions/providers/google-oauth/getDriveFileContentById.ts
@@ -128,7 +128,16 @@ const getDriveFileContentById: googleOauthGetDriveFileContentByIdFunction = asyn
       content = content.slice(0, charLimit);
     }
 
-    return { success: true, content, fileName, fileLength: originalLength };
+    return {
+      success: true,
+      results: [
+        {
+          name: fileName,
+          url: `${BASE_URL}${encodeURIComponent(params.fileId)}`,
+          contents: { content, fileName, fileLength: originalLength },
+        },
+      ],
+    };
   } catch (error) {
     console.error("Error getting Google Drive file content", error);
     return {

--- a/src/actions/providers/google-oauth/searchDriveByKeywordsAndGetFileContent.ts
+++ b/src/actions/providers/google-oauth/searchDriveByKeywordsAndGetFileContent.ts
@@ -50,7 +50,7 @@ const searchDriveByKeywordsAndGetFileContent: googleOauthSearchDriveByKeywordsAn
         name: file.name,
         mimeType: file.mimeType,
         url: file.url,
-        content: contentResult.success ? contentResult.content : undefined,
+        content: contentResult.success ? contentResult.results?.[0]?.contents?.content : undefined,
       };
     } catch (error) {
       console.error(`Error fetching content for file ${file.id}:`, error);

--- a/src/actions/providers/google-oauth/searchDriveByKeywordsAndGetFileContent.ts
+++ b/src/actions/providers/google-oauth/searchDriveByKeywordsAndGetFileContent.ts
@@ -17,7 +17,7 @@ const searchDriveByKeywordsAndGetFileContent: googleOauthSearchDriveByKeywordsAn
   authParams: AuthParamsType;
 }): Promise<googleOauthSearchDriveByKeywordsAndGetFileContentOutputType> => {
   if (!authParams.authToken) {
-    return { success: false, error: MISSING_AUTH_TOKEN, files: [] };
+    return { success: false, error: MISSING_AUTH_TOKEN };
   }
 
   const { searchQuery, limit, searchDriveByDrive, orderByQuery, fileSizeLimit: maxChars } = params;
@@ -34,7 +34,7 @@ const searchDriveByKeywordsAndGetFileContent: googleOauthSearchDriveByKeywordsAn
 
   // If search failed, return error
   if (!searchResult.success) {
-    return { success: false, error: searchResult.error, files: [] };
+    return { success: false, error: searchResult.error };
   }
 
   // For each file, fetch its content in parallel
@@ -66,7 +66,14 @@ const searchDriveByKeywordsAndGetFileContent: googleOauthSearchDriveByKeywordsAn
   const filesWithContent = await Promise.all(contentPromises);
 
   // Return combined results
-  return { success: true, files: filesWithContent };
+  return {
+    success: true,
+    results: filesWithContent.map(file => ({
+      name: file.name,
+      url: file.url,
+      contents: file,
+    })),
+  };
 };
 
 export default searchDriveByKeywordsAndGetFileContent;

--- a/src/actions/providers/google-oauth/searchDriveByQueryAndGetFileContent.ts
+++ b/src/actions/providers/google-oauth/searchDriveByQueryAndGetFileContent.ts
@@ -46,7 +46,7 @@ const searchDriveByQueryAndGetFileContent: googleOauthSearchDriveByQueryAndGetFi
         name: file.name,
         mimeType: file.mimeType,
         url: file.url,
-        content: contentResult.success ? contentResult.content : undefined,
+        content: contentResult.success ? contentResult.results?.[0]?.contents?.content : undefined,
       };
     } catch (error) {
       console.error(`Error fetching content for file ${file.id}:`, error);

--- a/src/actions/providers/jira/getJiraIssuesByQuery.ts
+++ b/src/actions/providers/jira/getJiraIssuesByQuery.ts
@@ -112,8 +112,10 @@ const getJiraIssuesByQuery: jiraGetJiraIssuesByQueryFunction = async ({
 
     return {
       success: true,
-      records: {
-        issues: response.data.issues.map(issue => ({
+      results: response.data.issues.map(issue => ({
+        name: issue.key,
+        url: `${baseUrl}/browse/${issue.key}`,
+        contents: {
           id: issue.id,
           key: issue.key,
           summary: issue.fields.summary,
@@ -140,8 +142,8 @@ const getJiraIssuesByQuery: jiraGetJiraIssuesByQueryFunction = async ({
           resolution: issue.fields.resolution?.name || null,
           dueDate: issue.fields.duedate || null,
           url: `${baseUrl}/browse/${issue.key}`,
-        })),
-      },
+        },
+      })),
     };
   } catch (error) {
     console.error("Error retrieving Jira issues:", error);

--- a/src/actions/providers/jira/getJiraTicketDetails.ts
+++ b/src/actions/providers/jira/getJiraTicketDetails.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { axiosClient } from "../../util/axiosClient.js";
 
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-get
 const getJiraTicketDetails: jiraGetJiraTicketDetailsFunction = async ({
   params,
   authParams,
@@ -32,7 +33,13 @@ const getJiraTicketDetails: jiraGetJiraTicketDetailsFunction = async ({
 
     return {
       success: true,
-      data: response.data,
+      results: [
+        {
+          name: response.data.key,
+          url: response.data.self,
+          contents: response.data,
+        },
+      ],
     };
   } catch (error) {
     console.error("Error retrieving Jira ticket details: ", error);

--- a/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
+++ b/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
@@ -48,16 +48,23 @@ const getSalesforceRecordsByQuery: salesforceGetSalesforceRecordsByQueryFunction
     const response = await axiosClient.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
 
     // Salesforce record types are confusing and non standard
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const recordsWithUrl = response.data.records?.map((record: any) => {
-      const recordId = record.Id;
-      const webUrl = recordId ? `${baseUrl}/lightning/r/${recordId}/view` : undefined;
-      return { ...record, webUrl };
-    });
+    const recordsWithUrl =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      response.data.records?.map((record: any) => {
+        const recordId = record.Id;
+        const webUrl = recordId ? `${baseUrl}/lightning/r/${recordId}/view` : undefined;
+        return { ...record, webUrl };
+      }) || [];
 
     return {
       success: true,
-      records: { ...response.data, records: response.data.records ? recordsWithUrl : undefined },
+      results:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        recordsWithUrl.map((record: any) => ({
+          name: record.Name,
+          url: record.webUrl,
+          content: record,
+        })) || [],
     };
   } catch (error) {
     console.error("Error retrieving Salesforce record:", error);

--- a/src/actions/providers/salesforce/searchSalesforceRecords.ts
+++ b/src/actions/providers/salesforce/searchSalesforceRecords.ts
@@ -54,14 +54,15 @@ const searchSalesforceRecords: salesforceSearchSalesforceRecordsFunction = async
     }
 
     // Salesforce record types are confusing and non standard
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const recordsWithUrl = response.data.searchRecords.map((record: any) => {
-      const recordId = record.Id;
-      const webUrl = recordId ? `${baseUrl}/lightning/r/${recordId}/view` : undefined;
-      return { ...record, webUrl };
-    });
-
-    return { success: true, searchRecords: recordsWithUrl };
+    return {
+      success: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      results: response.data.searchRecords.map((record: any) => {
+        const recordId = record.Id;
+        const webUrl = recordId ? `${baseUrl}/lightning/r/${recordId}/view` : undefined;
+        return { name: record.Name, url: webUrl, contents: record };
+      }),
+    };
   } catch (error) {
     console.error("Error retrieving Salesforce record:", error);
     return {

--- a/src/actions/providers/slackUser/searchSlack.ts
+++ b/src/actions/providers/slackUser/searchSlack.ts
@@ -328,7 +328,14 @@ const searchSlack: slackUserSearchSlackFunction = async ({
   for (const r of settled) if (r.status === "fulfilled" && r.value) results.push(r.value);
 
   results.sort((a, b) => Number(b.ts) - Number(a.ts));
-  return { query, results };
+  return {
+    query,
+    results: results.map(r => ({
+      name: r.text || "Untitled",
+      url: r.permalink || "",
+      contents: r,
+    })),
+  };
 };
 
 export default searchSlack;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1081,15 +1081,22 @@ actions:
           success:
             type: boolean
             description: Whether the records were successfully retrieved
-          records:
-            type: object
-            description: The result object containing issues
-            properties:
-              issues:
-                type: array
-                description: The retrieved Jira issues
-                items:
+          results:
+            type: array
+            description: The results of the Jira issues
+            items:
+              type: object
+              required: [name, url, contents]
+              properties:
+                name:
+                  type: string
+                  description: The name of the result
+                url:
+                  type: string
+                  description: The URL of the result
+                contents:
                   type: object
+                  description: The result object containing issues
                   required:
                     - id
                     - key

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1851,11 +1851,30 @@ actions:
               enum: ["json", "html", "screenshot", "markdown", "rawHtml", "links", "changeTracking"]
       output:
         type: object
-        required: [content]
+        required: [success]
         properties:
-          content:
+          success:
+            type: boolean
+            description: Whether the operation was successful
+          error:
             type: string
-            description: The content of the URL
+            description: Error message if the operation failed
+          results:
+            type: array
+            description: The results of the scrape
+            items:
+              type: object
+              required: [name, url, contents]
+              properties:
+                name:
+                  type: string
+                  description: The name of the result
+                url:
+                  type: string
+                  description: The URL of the result
+                contents:
+                  type: string
+                  description: The content of the URL
     searchAndScrape:
       description: Search and scrape the web using Firecrawl
       scopes: []
@@ -6591,28 +6610,38 @@ actions:
           success:
             type: boolean
             description: Whether the records were successfully retrieved
-          searchRecords:
+          results:
             type: array
             description: The records that match the search
             items:
               type: object
               description: A record from Salesforce
               properties:
-                id:
+                name:
                   type: string
-                  description: The Salesforce record ID
-                attributes:
+                  description: The name of the record
+                url:
+                  type: string
+                  description: The URL of the record
+                contents:
                   type: object
-                  description: Metadata about the Salesforce record
+                  description: The contents of the record
                   properties:
-                    type:
+                    id:
                       type: string
-                      description: The Salesforce object type
-                    url:
-                      type: string
-                      description: The Salesforce record URL
-                  required: [type, url]
-                  additionalProperties: true
+                      description: The Salesforce record ID
+                    attributes:
+                      type: object
+                      description: Metadata about the Salesforce record
+                      properties:
+                        type:
+                          type: string
+                          description: The Salesforce object type
+                        url:
+                          type: string
+                          description: The Salesforce record URL
+                      required: [type, url]
+                      additionalProperties: true
           error:
             type: string
             description: The error that occurred if the records were not successfully retrieved
@@ -6636,14 +6665,21 @@ actions:
           success:
             type: boolean
             description: Whether the records were successfully retrieved
-          records:
+          results:
             type: array
-            description: The retrieved records
-            items:
-              type: object
-              description: A record from Salesforce
-              additionalProperties:
+            description: Array of standardized results objects
+            properties:
+              name:
                 type: string
+                description: The name of the record
+              url:
+                type: string
+                description: The url of the record
+              contents:
+                type: object
+                description: A record from Salesforce
+                additionalProperties:
+                  type: string
           error:
             type: string
             description: The error that occurred if the records were not successfully retrieved
@@ -7019,41 +7055,56 @@ actions:
             description: The state of the pull requests to list (e.g., open, closed)
       output:
         type: object
-        required: [pullRequests]
+        required: [success]
         properties:
-          pullRequests:
+          success:
+            type: boolean
+            description: Whether the operation was successful
+          error:
+            type: string
+            description: The error that occurred if the operation was not successful
+          results:
             type: array
             description: A list of pull requests in the repository
             items:
               type: object
               properties:
-                number:
-                  type: number
-                  description: The number of the pull request
-                title:
+                name:
                   type: string
                   description: The title of the pull request
-                state:
-                  type: string
-                  description: The state of the pull request (e.g., open, closed)
                 url:
                   type: string
                   description: The URL of the pull request
-                createdAt:
-                  type: string
-                  description: The date and time when the pull request was created
-                updatedAt:
-                  type: string
-                  description: The date and time when the pull request was last updated
-                user:
+                contents:
                   type: object
                   properties:
-                    login:
+                    number:
+                      type: number
+                      description: The number of the pull request
+                    title:
                       type: string
-                      description: The username of the user who created the pull request
-                description:
-                  type: string
-                  description: The description of the pull request
+                      description: The title of the pull request
+                    state:
+                      type: string
+                      description: The state of the pull request (e.g., open, closed)
+                    url:
+                      type: string
+                      description: The URL of the pull request
+                    createdAt:
+                      type: string
+                      description: The date and time when the pull request was created
+                    updatedAt:
+                      type: string
+                      description: The date and time when the pull request was last updated
+                    user:
+                      type: object
+                      properties:
+                        login:
+                          type: string
+                          description: The username of the user who created the pull request
+                    description:
+                      type: string
+                      description: The description of the pull request
     getPullRequestDetails:
       description: Get detailed information about a specific pull request including description, files, reviews, and status
       scopes: []
@@ -7280,18 +7331,33 @@ actions:
           error:
             type: string
             description: The error that occurred if the operation was not successful
-          content:
-            type: string
-            description: The decoded file content as a string
-          size:
-            type: number
-            description: The size of the file in bytes
-          name:
-            type: string
-            description: The name of the file
-          htmlUrl:
-            type: string
-            description: The URL of the file in the Github UI
+          results:
+            type: array
+            description: A list of Github files
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the file
+                url:
+                  type: string
+                  description: The URL of the file in the Github UI
+                contents:
+                  type: object
+                  properties:
+                    content:
+                      type: string
+                      description: The decoded file content as a string
+                    size:
+                      type: number
+                      description: The size of the file in bytes
+                    name:
+                      type: string
+                      description: The name of the file
+                    htmlUrl:
+                      type: string
+                      description: The URL of the file in the Github UI
     listDirectory:
       description: List directory contents of a path in a GitHub repository
       scopes: []
@@ -7318,28 +7384,33 @@ actions:
           error:
             type: string
             description: Error message if the operation failed
-          content:
+          results:
             type: array
             description: Array of directory contents
             items:
               type: object
-              required: [name, path, type, size, htmlUrl]
+              required: [name, url, contents]
               properties:
                 name:
                   type: string
                   description: The name of the file
-                path:
-                  type: string
-                  description: The path of the file
-                type:
-                  type: string
-                  description: The type of the file
-                size:
-                  type: number
-                  description: The size of the file in bytes
-                htmlUrl:
+                url:
                   type: string
                   description: The URL of the file in the Github UI
+                contents:
+                  type: object
+                  required: [path, type, size]
+                  description: The contents of the file
+                  properties:
+                    path:
+                      type: string
+                      description: The path of the file
+                    type:
+                      type: string
+                      description: The type of the file
+                    size:
+                      type: number
+                      description: The size of the file in bytes
     searchRepository:
       description: Search for code, issues and pull requests within a repository in a GitHub organization
       scopes: []
@@ -7527,157 +7598,173 @@ actions:
             description: The repository to search for data in
       output:
         type: object
-        required: [code, commits, issuesAndPullRequests]
+        required: [success]
         properties:
-          code:
+          success:
+            type: boolean
+            description: Whether the operation was successful
+          error:
+            type: string
+            description: Error message if the operation failed
+          results:
             type: array
-            description: A list of code results that match the query
+            description: Array of search results
             items:
               type: object
-              required: [name, path, sha, url, score, textMatches]
+              required: [name, url, type, content]
               properties:
                 name:
                   type: string
-                  description: The name of the file that had a match
-                path:
-                  type: string
-                  description: The path of the file that had a match
-                sha:
-                  type: string
-                  description: The SHA of the commit that had a match
+                  description: The name of the result (file name, commit SHA, or issue/PR title)
                 url:
                   type: string
-                  description: The URL of the file that had a match
-                score:
-                  type: number
-                  description: The similarity score of the match
-                textMatches:
-                  type: array
-                  description: A list of text matches that match the query
-                  items:
-                    type: object
-                    required: [matches]
-                    properties:
-                      object_url:
-                        type: string
-                        description: The URL of the object that had a match
-                      object_type:
-                        type: string
-                        description: The type of the object that had a match
-                      fragment:
-                        type: string
-                        description: The fragment of the text that had a match
-                      matches:
-                        type: array
-                        description: A list of matches that match the query
-                        items:
-                          type: object
-                          properties:
-                            text:
-                              type: string
-                              description: The text that had a match
-                            indices:
-                              type: array
-                              description: The indices of the text that had a match
-                              items:
-                                type: number
-          commits:
-            type: array
-            description: A list of commits that match the query
-            items:
-              type: object
-              required: [sha, url, message, author, committer, parents, tree, commitDate]
-              properties:
-                sha:
+                  description: The URL of the result
+                type:
                   type: string
-                  description: The SHA of the commit that had a match
-                url:
-                  type: string
-                  description: The URL of the commit that had a match
-                commit:
-                  type: object
-                  required: [message, author, score, files]
-                  properties:
-                    author:
-                      type: object
-                      required: [name, email, date]
+                  enum: [code, commit, issueOrPullRequest]
+                  description: The type of the result
+                content:
+                  oneOf:
+                    - type: object
+                      description: Code result content
+                      required: [name, path, sha, url, score, textMatches]
                       properties:
                         name:
                           type: string
-                          description: The name of the author
-                        email:
+                          description: The name of the file that had a match
+                        path:
                           type: string
-                          description: The email of the author
-                        date:
+                          description: The path of the file that had a match
+                        sha:
                           type: string
-                          description: The date of the commit
-                    message:
-                      type: string
-                      description: The message of the commit
-                  score:
-                    type: number
-                    description: The score of the commit
-                  files:
-                    type: array
-                    description: A list of files that match the query
-                    items:
-                      type: object
-                      required: [filename, status, patch]
+                          description: The SHA of the commit that had a match
+                        url:
+                          type: string
+                          description: The URL of the file that had a match
+                        score:
+                          type: number
+                          description: The similarity score of the match
+                        textMatches:
+                          type: array
+                          description: A list of text matches that match the query
+                          items:
+                            type: object
+                            required: [matches]
+                            properties:
+                              object_url:
+                                type: string
+                                description: The URL of the object that had a match
+                              object_type:
+                                type: string
+                                description: The type of the object that had a match
+                              fragment:
+                                type: string
+                                description: The fragment of the text that had a match
+                              matches:
+                                type: array
+                                description: A list of matches that match the query
+                                items:
+                                  type: object
+                                  properties:
+                                    text:
+                                      type: string
+                                      description: The text that had a match
+                                    indices:
+                                      type: array
+                                      description: The indices of the text that had a match
+                                      items:
+                                        type: number
+                    - type: object
+                      description: Commit result content
+                      required: [sha, url, message, author, committer, parents, tree, commitDate]
                       properties:
-                        filename:
+                        sha:
                           type: string
-                          description: The filename of the file
-                        status:
+                          description: The SHA of the commit that had a match
+                        url:
                           type: string
-                          description: The status of the file
-                        patch:
+                          description: The URL of the commit that had a match
+                        commit:
+                          type: object
+                          required: [message, author, score, files]
+                          properties:
+                            author:
+                              type: object
+                              required: [name, email, date]
+                              properties:
+                                name:
+                                  type: string
+                                  description: The name of the author
+                                email:
+                                  type: string
+                                  description: The email of the author
+                                date:
+                                  type: string
+                                  description: The date of the commit
+                            message:
+                              type: string
+                              description: The message of the commit
+                          score:
+                            type: number
+                            description: The score of the commit
+                          files:
+                            type: array
+                            description: A list of files that match the query
+                            items:
+                              type: object
+                              required: [filename, status, patch]
+                              properties:
+                                filename:
+                                  type: string
+                                  description: The filename of the file
+                                status:
+                                  type: string
+                                  description: The status of the file
+                                patch:
+                                  type: string
+                                  description: The patch of the file
+                    - type: object
+                      description: Issue or pull request result content
+                      required: [title, url, state, createdAt, updatedAt, user]
+                      properties:
+                        number:
+                          type: number
+                          description: The number of the issue or pull request
+                        title:
                           type: string
-                          description: The patch of the file
-          issuesAndPullRequests:
-            type: array
-            description: A list of issues and pull requests that match the query
-            items:
-              type: object
-              required: [title, url, state, createdAt, updatedAt, user]
-              properties:
-                number:
-                  type: number
-                  description: The number of the issue or pull request
-                title:
-                  type: string
-                  description: The title of the issue or pull request
-                html_url:
-                  type: string
-                  description: The URL of the issue or pull request
-                state:
-                  type: string
-                  description: The state of the issue or pull request
-                  enum: [open, closed]
-                isPullRequest:
-                  type: boolean
-                  description: Whether the issue or pull request is a pull request
-                body:
-                  type: string
-                  description: The body of the issue or pull request
-                score:
-                  type: number
-                  description: The score of the issue or pull request
-                files:
-                  type: array
-                  description: A list of files that match the query
-                  items:
-                    type: object
-                    required: [filename, status]
-                    properties:
-                      filename:
-                        type: string
-                        description: The filename of the file
-                      status:
-                        type: string
-                        description: The status of the file
-                      patch:
-                        type: string
-                        description: The patch of the file
+                          description: The title of the issue or pull request
+                        html_url:
+                          type: string
+                          description: The URL of the issue or pull request
+                        state:
+                          type: string
+                          description: The state of the issue or pull request
+                          enum: [open, closed]
+                        isPullRequest:
+                          type: boolean
+                          description: Whether the issue or pull request is a pull request
+                        body:
+                          type: string
+                          description: The body of the issue or pull request
+                        score:
+                          type: number
+                          description: The score of the issue or pull request
+                        files:
+                          type: array
+                          description: A list of files that match the query
+                          items:
+                            type: object
+                            required: [filename, status]
+                            properties:
+                              filename:
+                                type: string
+                                description: The filename of the file
+                              status:
+                                type: string
+                                description: The status of the file
+                              patch:
+                                type: string
+                                description: The patch of the file
     getBranch:
       description: Get a branch in a GitHub repository
       scopes: []

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -8510,30 +8510,47 @@ actions:
             description: The branch, tag, or commit (defaults to "main")
       output:
         type: object
-        required: [content]
+        required: [success]
         properties:
-          content:
+          success:
+            type: boolean
+            description: Whether the operation was successful
+          error:
+            type: string
+            description: Error message if the operation failed
+          results:
             type: array
             description: Array of directory contents
             items:
               type: object
-              required: [name, path, type, htmlUrl]
+              required: [name, url, contents]
               properties:
                 name:
                   type: string
                   description: The name of the file or directory
-                path:
+                url:
                   type: string
-                  description: The path of the file or directory
-                type:
-                  type: string
-                  description: The type of the entry (either "blob" for file or "tree" for directory)
-                size:
-                  type: number
-                  description: The size of the file in bytes (only for blobs; omitted or 0 for trees)
-                htmlUrl:
-                  type: string
-                  description: The URL of the file or folder in the GitLab UI
+                  description: The URL of the file or directory
+                contents:
+                  type: object
+                  description: The contents of the directory
+                  required: [name, path, type, htmlUrl]
+                  properties:
+                    name:
+                      type: string
+                      description: The name of the file or directory
+                    path:
+                      type: string
+                      description: The path of the file or directory
+                    type:
+                      type: string
+                      description: The type of the entry (either "blob" for file or "tree" for directory)
+                    size:
+                      type: number
+                      description: The size of the file in bytes (only for blobs; omitted or 0 for trees)
+                    htmlUrl:
+                      type: string
+                      description: The URL of the file or folder in the GitLab UI
   linear:
     getIssues:
       description: Get Linear issues with optional query filter

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -943,9 +943,22 @@ actions:
           error:
             type: string
             description: The error that occurred if the retrieval was unsuccessful
-          data:
-            type: object
-            description: The data of the Jira ticket
+          results:
+            type: array
+            description: The results of the Jira ticket
+            items:
+              type: object
+              required: [name, url, contents]
+              properties:
+                name:
+                  type: string
+                  description: The name of the result
+                url:
+                  type: string
+                  description: The URL of the result
+                contents:
+                  type: object
+                  description: The data of the Jira ticket
     getJiraTicketHistory:
       description: Get ticket history of a ticket in Jira
       scopes:

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -4790,15 +4790,32 @@ actions:
           success:
             type: boolean
             description: Whether the file content was retrieved successfully
-          content:
-            type: string
-            description: The content of the file
-          fileName:
-            type: string
-            description: The name of the file
-          fileLength:
-            type: number
-            description: The length of the file content prior to truncating
+          results:
+            type: array
+            description: The results of the file content
+            items:
+              type: object
+              required: [name, url, contents]
+              properties:
+                name:
+                  type: string
+                  description: The name of the file
+                url:
+                  type: string
+                  description: The URL of the file
+                contents:
+                  type: object
+                  description: The contents of the file
+                  properties:
+                    content:
+                      type: string
+                      description: The content of the file
+                    fileName:
+                      type: string
+                      description: The name of the file
+                    fileLength:
+                      type: number
+                      description: The length of the file content prior to truncating
           error:
             type: string
             description: Error message if file content retrieval failed

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -8226,175 +8226,191 @@ actions:
             description: The name of the project to search in
       output:
         type: object
-        required: [mergeRequests, blobs]
+        required: [success]
         properties:
-          mergeRequests:
+          success:
+            type: boolean
+            description: Whether the search operation was successful
+          error:
+            type: string
+            description: Error message if the search operation failed
+          results:
             type: array
-            description: A list of merge requests that match the query
+            description: A list of search results that match the query
             items:
               type: object
-              required: [metadata, diffs]
+              required: [name, url, type, contents]
               properties:
-                metadata:
-                  type: object
-                  required: [id, iid, project_id, title, web_url]
-                  description: The metadata of the merge request
-                  properties:
-                    id:
-                      type: number
-                      description: The ID of the merge request
-                    iid:
-                      type: number
-                      description: The internal ID of the merge request
-                    project_id:
-                      type: number
-                      description: The ID of the project the merge request belongs to
-                    title:
-                      type: string
-                      description: The title of the merge request
-                    web_url:
-                      type: string
-                      description: The URL of the merge request
-                    description:
-                      type: string
-                      description: The description of the merge request
-                    author:
-                      type: object
-                      description: The author of the merge request
+                name:
+                  type: string
+                  description: The name/title of the search result
+                url:
+                  type: string
+                  description: The URL to view the result in GitLab
+                type:
+                  type: string
+                  enum: [mergeRequest, blob, commit]
+                  description: The type of search result
+                contents:
+                  oneOf:
+                    - type: object
+                      description: Merge request contents
+                      required: [metadata, diffs]
                       properties:
-                        name:
+                        metadata:
+                          type: object
+                          required: [id, iid, project_id, title, web_url]
+                          description: The metadata of the merge request
+                          properties:
+                            id:
+                              type: number
+                              description: The ID of the merge request
+                            iid:
+                              type: number
+                              description: The internal ID of the merge request
+                            project_id:
+                              type: number
+                              description: The ID of the project the merge request belongs to
+                            title:
+                              type: string
+                              description: The title of the merge request
+                            web_url:
+                              type: string
+                              description: The URL of the merge request
+                            description:
+                              type: string
+                              description: The description of the merge request
+                            author:
+                              type: object
+                              description: The author of the merge request
+                              properties:
+                                name:
+                                  type: string
+                                  description: The name of the author
+                            merged_at:
+                              type: string
+                              description: The date and time the merge request was merged
+                        diffs:
+                          type: array
+                          description: A list of diffs that match the query
+                          items:
+                            type: object
+                            required: [old_path, new_path, diff, new_file, renamed_file, deleted_file]
+                            properties:
+                              old_path:
+                                type: string
+                                description: The old path of the diff
+                              new_path:
+                                type: string
+                                description: The new path of the diff
+                              diff:
+                                type: string
+                                description: The contents of the diff
+                              new_file:
+                                type: boolean
+                                description: Whether the diff is a new file
+                              renamed_file:
+                                type: boolean
+                                description: Whether the diff is a renamed file
+                              deleted_file:
+                                type: boolean
+                                description: Whether the diff is a deleted file
+                              too_large:
+                                type: boolean
+                                description: Whether the diff is too large
+                    - type: object
+                      description: Blob contents
+                      required: [metadata, matchedMergeRequests]
+                      properties:
+                        metadata:
+                          type: object
+                          required: [path, basename, data, project_id, ref, startline, filename, web_url]
+                          properties:
+                            path:
+                              type: string
+                              description: The path of the blob
+                            basename:
+                              type: string
+                              description: The basename of the blob
+                            data:
+                              type: string
+                              description: The data of the blob
+                            project_id:
+                              type: number
+                              description: The ID of the project the blob belongs to
+                            ref:
+                              type: string
+                              description: The ref of the blob
+                            startline:
+                              type: number
+                              description: The start line of the blob
+                            filename:
+                              type: string
+                              description: The filename of the blob
+                            web_url:
+                              type: string
+                              description: The URL of the blob
+                        matchedMergeRequests:
+                          type: array
+                          description: A list of merge requests that match the blob
+                          items:
+                            type: object
+                            required: [title, web_url]
+                            properties:
+                              title:
+                                type: string
+                                description: The title of the merge request
+                              web_url:
+                                type: string
+                                description: The URL of the merge request
+                              author:
+                                type: object
+                                description: The author of the merge request
+                              merged_at:
+                                type: string
+                                description: The date and time the merge request was merged
+                    - type: object
+                      description: Commit contents
+                      required: [sha, web_url, message, author, created_at, files]
+                      properties:
+                        sha:
                           type: string
-                          description: The name of the author
-                    merged_at:
-                      type: string
-                      description: The date and time the merge request was merged
-                diffs:
-                  type: array
-                  description: A list of diffs that match the query
-                  items:
-                    type: object
-                    required: [old_path, new_path, diff, new_file, renamed_file, deleted_file]
-                    properties:
-                      old_path:
-                        type: string
-                        description: The old path of the diff
-                      new_path:
-                        type: string
-                        description: The new path of the diff
-                      diff:
-                        type: string
-                        description: The contents of the diff
-                      new_file:
-                        type: boolean
-                        description: Whether the diff is a new file
-                      renamed_file:
-                        type: boolean
-                        description: Whether the diff is a renamed file
-                      deleted_file:
-                        type: boolean
-                        description: Whether the diff is a deleted file
-                      too_large:
-                        type: boolean
-                        description: Whether the diff is too large
-          blobs:
-            type: array
-            description: A list of blobs that match the query
-            items:
-              type: object
-              required: [metadata, diffs]
-              properties:
-                metadata:
-                  type: object
-                  required: [path, basename, data, project_id, ref, startline, filename, web_url]
-                  properties:
-                    path:
-                      type: string
-                      description: The path of the blob
-                    basename:
-                      type: string
-                      description: The basename of the blob
-                    data:
-                      type: string
-                      description: The data of the blob
-                    project_id:
-                      type: number
-                      description: The ID of the project the blob belongs to
-                    ref:
-                      type: string
-                      description: The ref of the blob
-                    startline:
-                      type: number
-                      description: The start line of the blob
-                    filename:
-                      type: string
-                      description: The filename of the blob
-                    web_url:
-                      type: string
-                      description: The URL of the blob
-                matchedMergeRequests:
-                  type: array
-                  description: A list of merge requests that match the blob
-                  items:
-                    type: object
-                    required: [title, web_url]
-                    properties:
-                      title:
-                        type: string
-                        description: The title of the merge request
-                      web_url:
-                        type: string
-                        description: The URL of the merge request
-                      author:
-                        type: object
-                        description: The author of the merge request
-                      merged_at:
-                        type: string
-                        description: The date and time the merge request was merged
-          commits:
-            type: array
-            description: A list of commits that match the query
-            items:
-              type: object
-              required: [sha, web_url, message, author, created_at, files]
-              properties:
-                sha:
-                  type: string
-                  description: The commit SHA
-                web_url:
-                  type: string
-                  description: The URL to view the commit in GitLab
-                message:
-                  type: string
-                  description: The full commit message
-                author:
-                  type: object
-                  required: [name, email]
-                  properties:
-                    name:
-                      type: string
-                      description: The name of the commit author
-                    email:
-                      type: string
-                      description: The email of the commit author
-                created_at:
-                  type: string
-                  description: The date/time the commit was created
-                files:
-                  type: array
-                  description: A list of files changed in the commit
-                  items:
-                    type: object
-                    required: [old_path, new_path, diff]
-                    properties:
-                      old_path:
-                        type: string
-                        description: The old path of the file
-                      new_path:
-                        type: string
-                        description: The new path of the file
-                      diff:
-                        type: string
-                        description: The diff contents for the file
+                          description: The commit SHA
+                        web_url:
+                          type: string
+                          description: The URL to view the commit in GitLab
+                        message:
+                          type: string
+                          description: The full commit message
+                        author:
+                          type: object
+                          required: [name, email]
+                          properties:
+                            name:
+                              type: string
+                              description: The name of the commit author
+                            email:
+                              type: string
+                              description: The email of the commit author
+                        created_at:
+                          type: string
+                          description: The date/time the commit was created
+                        files:
+                          type: array
+                          description: A list of files changed in the commit
+                          items:
+                            type: object
+                            required: [old_path, new_path, diff]
+                            properties:
+                              old_path:
+                                type: string
+                                description: The old path of the file
+                              new_path:
+                                type: string
+                                description: The new path of the file
+                              diff:
+                                type: string
+                                description: The diff contents for the file
     getFileContent:
       description: Get specified file content from a GitLab repository
       scopes: []

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -8450,18 +8450,35 @@ actions:
           error:
             type: string
             description: The error that occurred if the operation was not successful
-          content:
-            type: string
-            description: The decoded file content as a string
-          size:
-            type: number
-            description: The size of the file in bytes
-          name:
-            type: string
-            description: The name of the file
-          htmlUrl:
-            type: string
-            description: The URL of the file in the GitLab UI
+          results:
+            type: array
+            description: The results of the file content
+            items:
+              type: object
+              required: [name, url, content]
+              properties:
+                name:
+                  type: string
+                  description: The name of the file
+                url:
+                  type: string
+                  description: The url of the file
+                contents:
+                  type: object
+                  required: [content, size, name, htmlUrl]
+                  properties:
+                    content:
+                      type: string
+                      description: The decoded file content as a string
+                    size:
+                      type: number
+                      description: The size of the file in bytes
+                    name:
+                      type: string
+                      description: The name of the file
+                    htmlUrl:
+                      type: string
+                      description: The URL of the file in the GitLab UI
     listDirectory:
       description: List directory contents of a path in a GitLab repository
       scopes: []

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -563,48 +563,58 @@ actions:
             description: Hydrated search results (threads or small context windows), sorted by ts desc.
             items:
               type: object
-              required:
-                - channelId
-                - ts
+              required: [name, url, contents]
               properties:
-                channelId:
+                name:
                   type: string
-                  description: Slack channel/conversation ID (C…/G…/D… or name).
-                ts:
+                  description: The name of the result
+                url:
                   type: string
-                  description: Slack message timestamp of the hit (or thread root when hydrated as thread).
-                text:
-                  type: string
-                  description: Message text of the anchor (hit or thread root).
-                userEmail:
-                  type: string
-                  description: User email of the anchor message’s author (if available).
-                userName:
-                  type: string
-                  description: User name of the anchor message’s author (if available).
-                permalink:
-                  type: string
-                  description: A Slack permalink to the anchor (message or thread root), if resolvable.
-                context:
-                  type: array
-                  description: When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).
-                  items:
-                    type: object
-                    required:
-                      - ts
-                    properties:
-                      ts:
-                        type: string
-                        description: Timestamp of the contextual message.
-                      text:
-                        type: string
-                        description: Text of the contextual message.
-                      userEmail:
-                        type: string
-                        description: Author user email of the contextual message.
-                      userName:
-                        type: string
-                        description: Author user name of the contextual message.
+                  description: The URL of the result
+                contents:
+                  type: object
+                  required:
+                    - channelId
+                    - ts
+                  properties:
+                    channelId:
+                      type: string
+                      description: Slack channel/conversation ID (C…/G…/D… or name).
+                    ts:
+                      type: string
+                      description: Slack message timestamp of the hit (or thread root when hydrated as thread).
+                    text:
+                      type: string
+                      description: Message text of the anchor (hit or thread root).
+                    userEmail:
+                      type: string
+                      description: User email of the anchor message’s author (if available).
+                    userName:
+                      type: string
+                      description: User name of the anchor message’s author (if available).
+                    permalink:
+                      type: string
+                      description: A Slack permalink to the anchor (message or thread root), if resolvable.
+                    context:
+                      type: array
+                      description: When a hit is in a thread, this is the full thread (root first). Otherwise, a small surrounding context window (~3 before, 5 after).
+                      items:
+                        type: object
+                        required:
+                          - ts
+                        properties:
+                          ts:
+                            type: string
+                            description: Timestamp of the contextual message.
+                          text:
+                            type: string
+                            description: Text of the contextual message.
+                          userEmail:
+                            type: string
+                            description: Author user email of the contextual message.
+                          userName:
+                            type: string
+                            description: Author user name of the contextual message.
   math:
     add:
       description: Adds two numbers together

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -4666,28 +4666,39 @@ actions:
           success:
             type: boolean
             description: Whether the search was successful
-          files:
+          results:
             type: array
             description: List of files matching the search
             items:
               type: object
-              required: [id, name, mimeType, url]
+              required: [name, url, contents]
               properties:
-                id:
-                  type: string
-                  description: The file ID
                 name:
                   type: string
-                  description: The file name
-                mimeType:
-                  type: string
-                  description: The MIME type of the file
+                  description: The name of the file
                 url:
                   type: string
-                  description: The web link to view the file
-                content:
-                  type: string
-                  description: The data returned from the file, subject to fileSizeLimit
+                  description: The URL of the file
+                contents:
+                  type: object
+                  description: The contents of the file
+                  required: [id, name, mimeType, url]
+                  properties:
+                    id:
+                      type: string
+                      description: The file ID
+                    name:
+                      type: string
+                      description: The file name
+                    mimeType:
+                      type: string
+                      description: The MIME type of the file
+                    url:
+                      type: string
+                      description: The web link to view the file
+                    content:
+                      type: string
+                      description: The data returned from the file, subject to fileSizeLimit
           error:
             type: string
             description: Error message if search failed

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -8500,7 +8500,7 @@ actions:
             description: The results of the file content
             items:
               type: object
-              required: [name, url, content]
+              required: [name, url, contents]
               properties:
                 name:
                   type: string

--- a/tests/firecrawl/testFirecrawlScrape.ts
+++ b/tests/firecrawl/testFirecrawlScrape.ts
@@ -1,11 +1,12 @@
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
 import dotenv from "dotenv";
+import { type firecrawlScrapeUrlOutputType } from "../../src/actions/autogen/types.js";
 
 dotenv.config();
 
 async function runTest() {
-  const result = await runAction(
+  const result = (await runAction(
     "scrapeUrl",
     "firecrawl",
     { apiKey: process.env.FIRECRAWL_API_KEY }, // authParams
@@ -14,9 +15,10 @@ async function runTest() {
       waitMs: 2000, // Wait 2 seconds before scraping
       onlyMainContent: true, // Test the new optional parameter
       formats: [], // Test the new optional parameter
-    },
-  );
+    }
+  )) as firecrawlScrapeUrlOutputType;
   console.log(result);
-  assert(result.content.length > 0, "No content found");
+  assert(result.results, "Results should be an array");
+  assert(result.results[0].contents.length > 0, "No content found");
 }
 runTest().catch(console.error);

--- a/tests/firecrawl/testScrapeUrl.ts
+++ b/tests/firecrawl/testScrapeUrl.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+import {
+  firecrawlScrapeUrlOutputSchema,
+  type firecrawlScrapeUrlOutputType,
+} from "../../src/actions/autogen/types.js";
+
+dotenv.config();
+
+async function runTest() {
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  
+  if (!apiKey) {
+    throw new Error("FIRECRAWL_API_KEY environment variable is required");
+  }
+
+  try {
+    // Test basic scraping with markdown format
+    const result = (await runAction(
+      "scrapeUrl",
+      "firecrawl",
+      { apiKey },
+      {
+        url: "https://example.com",
+        formats: ["markdown"],
+        onlyMainContent: true,
+        waitMs: 1000
+      }
+    )) as firecrawlScrapeUrlOutputType;
+
+    console.dir(result, { depth: 4 });
+    
+    // Validate the response structure
+    assert.strictEqual(result.success, true);
+    assert.equal(
+      firecrawlScrapeUrlOutputSchema.safeParse(result).success,
+      true
+    );
+    
+    // Validate results array
+    assert(result.results && Array.isArray(result.results), "Results should be an array");
+    assert(result.results.length > 0, "Should have at least one result");
+    
+    // Validate first result
+    const firstResult = result.results[0];
+    assert(typeof firstResult.name === "string", "Result name should be a string");
+    assert(typeof firstResult.url === "string", "Result url should be a string");
+    assert(typeof firstResult.contents === "string", "Result contents should be a string");
+    assert(firstResult.contents.length > 0, "Content should not be empty");
+    
+    console.log("✅ Basic scraping test passed");
+  } catch (error) {
+    console.error("❌ Basic scraping test failed:", error);
+    throw error;
+  }
+}
+
+async function testMultipleFormats() {
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  
+  if (!apiKey) {
+    throw new Error("FIRECRAWL_API_KEY environment variable is required");
+  }
+
+  try {
+    // Test scraping with multiple formats
+    const result = (await runAction(
+      "scrapeUrl",
+      "firecrawl",
+      { apiKey },
+      {
+        url: "https://example.com",
+        formats: ["markdown", "html", "links"],
+        onlyMainContent: false
+      }
+    )) as firecrawlScrapeUrlOutputType;
+
+    console.dir(result, { depth: 4 });
+    
+    assert.strictEqual(result.success, true);
+    assert(result.results && result.results.length > 0, "Should have results");
+    assert(result.results[0].contents.includes("=== MARKDOWN ==="), "Should contain markdown section");
+    assert(result.results[0].contents.includes("=== HTML ==="), "Should contain HTML section");
+    assert(result.results[0].contents.includes("=== LINKS ==="), "Should contain links section");
+    
+    console.log("✅ Multiple formats test passed");
+  } catch (error) {
+    console.error("❌ Multiple formats test failed:", error);
+    throw error;
+  }
+}
+
+async function testDefaultFormat() {
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  
+  if (!apiKey) {
+    throw new Error("FIRECRAWL_API_KEY environment variable is required");
+  }
+
+  try {
+    // Test scraping without specifying formats (should default to markdown)
+    const result = (await runAction(
+      "scrapeUrl",
+      "firecrawl",
+      { apiKey },
+      {
+        url: "https://example.com"
+      }
+    )) as firecrawlScrapeUrlOutputType;
+
+    console.dir(result, { depth: 4 });
+    
+    assert.strictEqual(result.success, true);
+    assert(result.results && result.results.length > 0, "Should have results");
+    assert(result.results[0].contents.length > 0, "Should have content even without format specified");
+    
+    console.log("✅ Default format test passed");
+  } catch (error) {
+    console.error("❌ Default format test failed:", error);
+    throw error;
+  }
+}
+
+async function runAllTests() {
+  try {
+    await runTest();
+    await testMultipleFormats();
+    await testDefaultFormat();
+    console.log("🎉 All tests passed!");
+  } catch (error) {
+    console.error("❌ Test failed:", error);
+    process.exit(1);
+  }
+}
+
+runAllTests();

--- a/tests/github/testGetFileContent.ts
+++ b/tests/github/testGetFileContent.ts
@@ -33,16 +33,16 @@ async function runTest() {
   assert(typedResult, "Response should not be null");
   assert(typedResult.success, "Response should indicate success");
   assert(
-    typedResult.htmlUrl ==
+    typedResult.results?.[0]?.contents?.htmlUrl ==
       "https://github.com/Credal-ai/actions-sdk/blob/main/src/app.ts",
     "Response should contain the correct URL"
   );
   assert(
-    typedResult.name == "app.ts",
+    typedResult.results?.[0]?.name == "app.ts",
     "Response should contain the correct name"
   );
   assert(
-    typedResult.content?.includes("action"),
+    typedResult.results?.[0]?.contents?.content?.includes("action"),
     "Response should contain the correct content"
   );
 }

--- a/tests/github/testGetFileContent.ts
+++ b/tests/github/testGetFileContent.ts
@@ -33,7 +33,7 @@ async function runTest() {
   assert(typedResult, "Response should not be null");
   assert(typedResult.success, "Response should indicate success");
   assert(
-    typedResult.results?.[0]?.contents?.htmlUrl ==
+    typedResult.results?.[0]?.url ==
       "https://github.com/Credal-ai/actions-sdk/blob/main/src/app.ts",
     "Response should contain the correct URL"
   );

--- a/tests/github/testListDirectory.ts
+++ b/tests/github/testListDirectory.ts
@@ -32,9 +32,9 @@ async function runTest() {
   // Validate response
   assert(typedResult, "Response should not be null");
   assert(typedResult.success, "Response should indicate success");
-  assert(Array.isArray(typedResult.content), "Content should be an array");
-  assert(typedResult.content.length > 0, "Content should not be empty");
-  assert(typedResult.content.some((item) => item.name === "app.ts"));
+  assert(Array.isArray(typedResult.results), "Results should be an array");
+  assert(typedResult.results.length > 0, "Results should not be empty");
+  assert(typedResult.results.some((item) => item.name === "app.ts"));
 }
 
 runTest().catch((error) => {

--- a/tests/github/testListPullRequests.ts
+++ b/tests/github/testListPullRequests.ts
@@ -14,7 +14,7 @@ async function runTest() {
     {
       repositoryOwner: "Credal-ai",
       repositoryName: "app",
-    },
+    }
   );
 
   console.log(JSON.stringify(result, null, 2));

--- a/tests/github/testSearchOrganization.ts
+++ b/tests/github/testSearchOrganization.ts
@@ -1,13 +1,14 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
 import dotenv from "dotenv";
+import { type githubSearchOrganizationOutputType } from "../../src/actions/autogen/types.js";
 
 dotenv.config();
 
 async function runSearchOrganizationWithoutRepository() {
   const authToken = process.env.GITHUB_ACCESS_TOKEN;
 
-  const result = await runAction(
+  const result = (await runAction(
     "searchOrganization",
     "github",
     {
@@ -17,24 +18,19 @@ async function runSearchOrganizationWithoutRepository() {
       organization: "Credal-ai",
       query: "test",
     }
-  );
+  )) as githubSearchOrganizationOutputType;
 
   console.log(JSON.stringify(result, null, 2));
 
   // Validate response
   assert(result, "Response should not be null");
-  assert(Array.isArray(result.code), "Code should be an array");
-  assert(Array.isArray(result.commits), "Commits should be an array");
-  assert(
-    Array.isArray(result.issuesAndPullRequests),
-    "Issues and pull requests should be an array"
-  );
+  assert(Array.isArray(result.results), "Results should be an array");
 }
 
 async function runSearchOrganizationWithRepository() {
   const authToken = process.env.GITHUB_ACCESS_TOKEN;
 
-  const result = await runAction(
+  const result = (await runAction(
     "searchOrganization",
     "github",
     {
@@ -45,18 +41,13 @@ async function runSearchOrganizationWithRepository() {
       repository: "app",
       query: "test",
     }
-  );
+  )) as githubSearchOrganizationOutputType;
 
   console.log(JSON.stringify(result, null, 2));
 
   // Validate response
   assert(result, "Response should not be null");
-  assert(Array.isArray(result.code), "Code should be an array");
-  assert(Array.isArray(result.commits), "Commits should be an array");
-  assert(
-    Array.isArray(result.issuesAndPullRequests),
-    "Issues and pull requests should be an array"
-  );
+  assert(Array.isArray(result.results), "Results should be an array");
 }
 
 runSearchOrganizationWithoutRepository().catch((error) => {

--- a/tests/gitlab/testGetFileContent.ts
+++ b/tests/gitlab/testGetFileContent.ts
@@ -27,10 +27,9 @@ async function runTest() {
   assert(typeof result === "object", "Result should be an object");
   assert("success" in result, "Result should have 'success'");
   if (result.success) {
-    assert(typeof result.content === "string", "Content should be a string");
-    assert(typeof result.size === "number", "Size should be a number");
-    assert(typeof result.name === "string", "Name should be a string");
-    assert(typeof result.htmlUrl === "string", "htmlUrl should be a string");
+    assert(typeof result.results?.[0]?.contents?.content === "string", "Content should be a string");
+    assert(typeof result.results?.[0]?.name === "string", "Name should be a string");
+    assert(typeof result.results?.[0]?.url === "string", "url should be a string");
   } else {
     assert(typeof result.error === "string", "Error should be a string when not successful");
     console.error("Failed to get file content:", result.error);

--- a/tests/gitlab/testListDirectory.ts
+++ b/tests/gitlab/testListDirectory.ts
@@ -22,7 +22,7 @@ async function runTest() {
   );
   console.log("Resulting payload:");
   console.dir(result, { depth: 4 });
-  assert(Array.isArray(result.content), "Content should be an array");
+  assert(Array.isArray(result.results), "Results should be an array");
 }
 
 runTest().catch((error) => {

--- a/tests/gitlab/testSearchGroup.ts
+++ b/tests/gitlab/testSearchGroup.ts
@@ -1,4 +1,7 @@
-import type { gitlabSearchGroupParamsType } from "../../src/actions/autogen/types.js";
+import type {
+  gitlabSearchGroupOutputType,
+  gitlabSearchGroupParamsType,
+} from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
 import dotenv from "dotenv";
@@ -13,16 +16,15 @@ async function runSearchGroupWithoutProject() {
     groupId: "credal",
   };
 
-  const result = await runAction(
+  const result = (await runAction(
     "searchGroup",
     "gitlab",
-    { authToken: process.env.GITLAB_ACCESS_TOKEN }, 
-    params,
-  );
+    { authToken: process.env.GITLAB_ACCESS_TOKEN },
+    params
+  )) as gitlabSearchGroupOutputType;
   console.log("Resulting payload:");
   console.dir(result, { depth: 4 });
-  assert(Array.isArray(result.mergeRequests), "Merge requests should be an array");
-  assert(Array.isArray(result.blobs), "Blobs should be an array");
+  assert(Array.isArray(result.results), "Results should be an array");
 }
 
 async function runSearchGroupWithProject() {
@@ -34,16 +36,15 @@ async function runSearchGroupWithProject() {
     project: "test-project",
   };
 
-  const result = await runAction(
+  const result = (await runAction(
     "searchGroup",
     "gitlab",
-    { authToken: process.env.GITLAB_ACCESS_TOKEN }, 
-    params,
-  );
+    { authToken: process.env.GITLAB_ACCESS_TOKEN },
+    params
+  )) as gitlabSearchGroupOutputType;
   console.log("Resulting payload:");
   console.dir(result, { depth: 4 });
-  assert(Array.isArray(result.mergeRequests), "Merge requests should be an array");
-  assert(Array.isArray(result.blobs), "Blobs should be an array");
+  assert(Array.isArray(result.results), "Results should be an array");
 }
 
 runSearchGroupWithoutProject().catch((error) => {

--- a/tests/google-oauth/testGetDriveFileContentById.ts
+++ b/tests/google-oauth/testGetDriveFileContentById.ts
@@ -1,4 +1,7 @@
-import type { googleOauthGetDriveFileContentByIdParamsType } from "../../src/actions/autogen/types.js";
+import type {
+  googleOauthGetDriveFileContentByIdOutputType,
+  googleOauthGetDriveFileContentByIdParamsType,
+} from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
 import dotenv from "dotenv";
@@ -18,41 +21,44 @@ async function runTest() {
   };
 
   const startTime = performance.now();
-  const result = await runAction(
+  const result = (await runAction(
     "getDriveFileContentById", // Ensure this matches the action name defined in schema
     "googleOauth",
     {
       authToken: process.env.GOOGLE_DRIVE_AUTH_TOKEN, // Use a valid OAuth token with Drive readonly scope,
     },
-    params,
-  );
+    params
+  )) as googleOauthGetDriveFileContentByIdOutputType;
   const endTime = performance.now();
   const duration = endTime - startTime;
   console.log(`Time taken: ${duration} milliseconds`);
 
   // Basic assertions
   assert.strictEqual(result.success, true, "Retrieval should be successful");
-  assert(typeof result.content === "string", "Content should be a string");
+  assert(
+    typeof result.results?.[0]?.contents?.content === "string",
+    "Content should be a string"
+  );
 
   // Additional checks when successful
   if (result.success) {
-    assert(result.fileName, "Should include fileName");
+    assert(result.results?.[0]?.name, "Should include fileName");
     assert(
-      typeof result.fileLength === "number",
+      typeof result.results?.[0]?.contents?.fileLength === "number",
       "Should include fileLength as number"
     );
 
     // Ensure truncation logic works when limit is set
     if (params.limit) {
       assert(
-        result.content!.length <= params.limit,
+        result.results?.[0]?.contents?.content?.length <= params.limit,
         "Content should respect the limit"
       );
     }
   }
 
-  console.log("File name:", result.fileName);
-  console.log("Content snippet:", result.content);
+  console.log("File name:", result.results?.[0]?.name);
+  console.log("Content snippet:", result.results?.[0]?.contents?.content);
 }
 
 // Run the test

--- a/tests/google-oauth/testSearchDriveByKeywordsAndGetFileContent.ts
+++ b/tests/google-oauth/testSearchDriveByKeywordsAndGetFileContent.ts
@@ -1,4 +1,7 @@
-import type { googleOauthSearchDriveByKeywordsAndGetFileContentParamsType } from "../../src/actions/autogen/types.js";
+import type {
+  googleOauthSearchDriveByKeywordsAndGetFileContentOutputType,
+  googleOauthSearchDriveByKeywordsAndGetFileContentParamsType,
+} from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
 import dotenv from "dotenv";
@@ -10,7 +13,7 @@ dotenv.config();
 async function runTest() {
   console.log("Running test searchDriveByKeywordsAndGetFileContent");
 
-  const result = await runAction(
+  const result = (await runAction(
     "searchDriveByKeywordsAndGetFileContent",
     "googleOauth",
     {
@@ -20,21 +23,21 @@ async function runTest() {
       searchQuery: "Japan travel expense",
       searchDriveByDrive: false,
     } as googleOauthSearchDriveByKeywordsAndGetFileContentParamsType
-  );
+  )) as googleOauthSearchDriveByKeywordsAndGetFileContentOutputType;
 
-  console.log("Found files with content:", result.files);
+  console.log("Found files with content:", result.results);
 
   // Validate the result
   assert.strictEqual(result.success, true, "Search should be successful");
-  assert(Array.isArray(result.files), "Files should be an array");
+  assert(Array.isArray(result.results), "Files should be an array");
 
-  if (result.files.length > 0) {
-    const firstFile = result.files[0];
-    assert(firstFile.id, "First file should have an id");
+  if (result.results.length > 0) {
+    const firstFile = result.results[0];
     assert(firstFile.name, "First file should have a name");
-    assert(firstFile.mimeType, "First file should have a mimeType");
     assert(firstFile.url, "First file should have a url");
-    assert(firstFile.content, "First file should have content");
+    assert(firstFile.contents.id, "First file should have an id");
+    assert(firstFile.contents.mimeType, "First file should have a mimeType");
+    assert(firstFile.contents.content, "First file should have content");
   }
 }
 

--- a/tests/jira/testGetJiraIssuesByQuery.ts
+++ b/tests/jira/testGetJiraIssuesByQuery.ts
@@ -10,7 +10,7 @@ import { jiraConfig } from "./utils.js";
 dotenv.config();
 
 async function runTest() {
-  const { authToken, cloudId, projectKey } = jiraConfig;
+  const { authToken, cloudId, baseUrl, projectKey } = jiraConfig;
 
   const result = (await runAction(
     "getJiraIssuesByQuery",
@@ -18,6 +18,7 @@ async function runTest() {
     {
       authToken,
       cloudId,
+      baseUrl,
     },
     {
       query: `project = ${projectKey}`,

--- a/tests/jira/testGetJiraIssuesByQuery.ts
+++ b/tests/jira/testGetJiraIssuesByQuery.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
 import dotenv from "dotenv";
-import { jiraGetJiraIssuesByQueryOutputSchema } from "../../src/actions/autogen/types.js";
+import {
+  jiraGetJiraIssuesByQueryOutputSchema,
+  type jiraGetJiraIssuesByQueryOutputType,
+} from "../../src/actions/autogen/types.js";
 
 dotenv.config();
 
@@ -9,7 +12,7 @@ async function runTest() {
   const authToken = process.env.JIRA_AUTH_TOKEN;
   const cloudId = process.env.JIRA_CLOUD_ID;
 
-  const result = await runAction(
+  const result = (await runAction(
     "getJiraIssuesByQuery",
     "jira",
     {
@@ -18,12 +21,15 @@ async function runTest() {
     },
     {
       query: `project = CTP`,
-      limit: 10
+      limit: 10,
     }
-  );
+  )) as jiraGetJiraIssuesByQueryOutputType;
   console.dir(result, { depth: 4 });
   assert.strictEqual(result.success, true);
-  assert.equal(jiraGetJiraIssuesByQueryOutputSchema.safeParse(result).success, true);
+  assert.equal(
+    jiraGetJiraIssuesByQueryOutputSchema.safeParse(result).success,
+    true
+  );
 }
 
 runTest().catch(console.error);

--- a/tests/jira/testGetJiraTicketDetails.ts
+++ b/tests/jira/testGetJiraTicketDetails.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
 import { jiraConfig, provider } from "./utils.js";
+import type { jiraGetJiraTicketDetailsOutputType } from "../../src/actions/autogen/types";
 
 async function runTest() {
   const { authToken, cloudId, baseUrl, issueId } = jiraConfig;
 
-  const result = await runAction(
+  const result = (await runAction(
     "getJiraTicketDetails",
     provider,
     {
@@ -15,20 +16,23 @@ async function runTest() {
     },
     {
       issueId,
-    },
-  );
+    }
+  )) as jiraGetJiraTicketDetailsOutputType;
 
   console.log(JSON.stringify(result, null, 2));
 
   // Validate response
   assert(result, "Response should not be null");
   assert(result.success, "Response should indicate success");
-  assert(result.data, "Response should contain ticket data");
-  assert(result.data.key, "Ticket data should include a key");
-  assert(result.data.fields, "Ticket data should include fields");
+  assert(result.results, "Response should contain ticket data");
+  assert(result.results[0].contents.key, "Ticket data should include a key");
+  assert(
+    result.results[0].contents.fields,
+    "Ticket data should include fields"
+  );
 
   console.log(
-    `Successfully retrieved Jira ticket details for: ${result.data.key}`,
+    `Successfully retrieved Jira ticket details for: ${result.results[0].name}`
   );
 }
 

--- a/tests/salesforce/testGetSalesforceRecordsByQuery.ts
+++ b/tests/salesforce/testGetSalesforceRecordsByQuery.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
 import dotenv from "dotenv";
+import { type salesforceGetSalesforceRecordsByQueryOutputType } from "../../src/actions/autogen/types";
 
 dotenv.config();
 
@@ -9,7 +10,7 @@ async function runTest() {
   const baseUrl = process.env.SALESFORCE_URL;
 
   // Test 1: Regular query with limit
-  const regularQueryResult = await runAction(
+  const regularQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -18,14 +19,14 @@ async function runTest() {
     },
     {
       query: "SELECT Id FROM Account",
-      limit: 10
+      limit: 10,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(regularQueryResult.success, true);
-  assert.strictEqual(regularQueryResult.records.records.length, 10);
+  assert.strictEqual(regularQueryResult.results?.length, 10);
 
   // Test 2: Aggregate query without limit
-  const aggregateQueryResult = await runAction(
+  const aggregateQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -34,14 +35,14 @@ async function runTest() {
     },
     {
       query: "SELECT COUNT(Id) FROM Account",
-      limit: 10
+      limit: 10,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(aggregateQueryResult.success, true);
-  assert.strictEqual(aggregateQueryResult.records.records.length, 1);
+  assert.strictEqual(aggregateQueryResult.results?.length, 1);
 
   // Test 3: Aggregate query with GROUP BY
-  const groupByQueryResult = await runAction(
+  const groupByQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -50,15 +51,15 @@ async function runTest() {
     },
     {
       query: "SELECT COUNT(Id), Industry FROM Account GROUP BY Industry",
-      limit: 10
+      limit: 10,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(groupByQueryResult.success, true);
-  assert.ok(groupByQueryResult.records.records.length > 0);
-  assert.ok(groupByQueryResult.records.records[0].Industry !== undefined);
+  assert.ok(groupByQueryResult.results?.length ?? 0 > 0);
+  assert.ok(groupByQueryResult.results?.[0].Industry !== undefined);
 
   // Test 4: Query with existing LIMIT clause and no limit parameter - should keep existing limit if < 2000
-  const existingLimitQueryResult = await runAction(
+  const existingLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -68,12 +69,12 @@ async function runTest() {
     {
       query: "SELECT Id FROM Account LIMIT 5",
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(existingLimitQueryResult.success, true);
-  assert.ok(existingLimitQueryResult.records.records.length <= 5);
+  assert.ok(existingLimitQueryResult.results?.length ?? 0 <= 5);
 
   // Test 5: Query with existing LIMIT clause >= 2000 and no limit parameter - should replace with 2000
-  const highLimitQueryResult = await runAction(
+  const highLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -83,12 +84,12 @@ async function runTest() {
     {
       query: "SELECT Id FROM Account LIMIT 3000",
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(highLimitQueryResult.success, true);
   // Should be capped at 2000 or whatever records exist
 
   // Test 6: Query with existing LIMIT clause and limit parameter - should use parameter
-  const overrideLimitQueryResult = await runAction(
+  const overrideLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -97,14 +98,14 @@ async function runTest() {
     },
     {
       query: "SELECT Id FROM Account LIMIT 100",
-      limit: 3
+      limit: 3,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(overrideLimitQueryResult.success, true);
-  assert.ok(overrideLimitQueryResult.records.records.length <= 3);
+  assert.ok(overrideLimitQueryResult.results?.length ?? 0 <= 3);
 
   // Test 7: Query with existing LIMIT clause and limit parameter > 2000 - should cap at 2000
-  const capLimitQueryResult = await runAction(
+  const capLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -113,14 +114,14 @@ async function runTest() {
     },
     {
       query: "SELECT Id FROM Account LIMIT 50",
-      limit: 3000
+      limit: 3000,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(capLimitQueryResult.success, true);
   // Should be capped at 2000
 
   // Test 8: Query with LIMIT in different case
-  const caseLimitQueryResult = await runAction(
+  const caseLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -130,12 +131,12 @@ async function runTest() {
     {
       query: "SELECT Id FROM Account limit 7",
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(caseLimitQueryResult.success, true);
-  assert.ok(caseLimitQueryResult.records.records.length <= 7);
+  assert.ok(caseLimitQueryResult.results?.length ?? 0 <= 7);
 
   // Test 9: Query with LIMIT and extra whitespace
-  const whitespaceLimitQueryResult = await runAction(
+  const whitespaceLimitQueryResult = (await runAction(
     "getSalesforceRecordsByQuery",
     "salesforce",
     {
@@ -144,11 +145,11 @@ async function runTest() {
     },
     {
       query: "SELECT Id FROM Account   LIMIT   15   ",
-      limit: 4
+      limit: 4,
     }
-  );
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(whitespaceLimitQueryResult.success, true);
-  assert.ok(whitespaceLimitQueryResult.records.records.length <= 4);
+  assert.ok(whitespaceLimitQueryResult.results?.length ?? 0 <= 4);
 
   console.log("All tests passed!");
 }

--- a/tests/salesforce/testSearchSalesforceRecords.ts
+++ b/tests/salesforce/testSearchSalesforceRecords.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
 import dotenv from "dotenv";
-import { salesforceSearchSalesforceRecordsOutputSchema } from "../../src/actions/autogen/types.js";
+import {
+  salesforceSearchSalesforceRecordsOutputSchema,
+  type salesforceSearchSalesforceRecordsOutputType,
+} from "../../src/actions/autogen/types.js";
 
 dotenv.config();
 
@@ -10,7 +13,7 @@ async function runTest() {
   const baseUrl = process.env.SALESFORCE_URL;
 
   // Test 1: Regular query with limit
-  const regularQueryResult = await runAction(
+  const regularQueryResult = (await runAction(
     "searchSalesforceRecords",
     "salesforce",
     {
@@ -21,12 +24,16 @@ async function runTest() {
       keyword: "Health",
       recordType: "Account",
       fieldsToSearch: ["Name"],
-      limit: 1
+      limit: 1,
     }
-  );
+  )) as salesforceSearchSalesforceRecordsOutputType;
   assert.strictEqual(regularQueryResult.success, true);
-  assert.equal(salesforceSearchSalesforceRecordsOutputSchema.safeParse(regularQueryResult).success, true);
-  assert.equal(regularQueryResult.searchRecords.length, 1);
+  assert.equal(
+    salesforceSearchSalesforceRecordsOutputSchema.safeParse(regularQueryResult)
+      .success,
+    true
+  );
+  assert.equal(regularQueryResult.results?.length, 1);
 
   const dashKeywordResult = await runAction(
     "searchSalesforceRecords",
@@ -39,12 +46,16 @@ async function runTest() {
       keyword: "health-company",
       recordType: "Account",
       fieldsToSearch: ["Name"],
-      limit: 1
+      limit: 1,
     }
   );
   assert.strictEqual(dashKeywordResult.success, true);
-  assert.equal(salesforceSearchSalesforceRecordsOutputSchema.safeParse(dashKeywordResult).success, true);
-  
+  assert.equal(
+    salesforceSearchSalesforceRecordsOutputSchema.safeParse(dashKeywordResult)
+      .success,
+    true
+  );
+
   console.log("All tests passed!");
 }
 

--- a/tests/slackUser/testSearchSlack.ts
+++ b/tests/slackUser/testSearchSlack.ts
@@ -1,3 +1,4 @@
+import type { slackUserSearchSlackOutputType } from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import dotenv from "dotenv";
 
@@ -5,39 +6,43 @@ dotenv.config();
 
 async function runTest() {
   // Single person DM
-  const result1 = await runAction(
+  const result1 = (await runAction(
     "searchSlack",
     "slackUser",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { emails: ["jack@credal.ai"], limit: 10, topic: "flatiron" },
-  );
+    { emails: ["jack@credal.ai"], limit: 10, topic: "flatiron" }
+  )) as slackUserSearchSlackOutputType;
 
   // Multiple person DM
-  const result2 = await runAction(
+  const result2 = (await runAction(
     "searchSlack",
     "slackUser",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { emails: ["jack@credal.ai", "ravin@credal.ai"], limit: 1, topic: "good to know" },
-  );
+    {
+      emails: ["jack@credal.ai", "ravin@credal.ai"],
+      limit: 1,
+      topic: "good to know",
+    }
+  )) as slackUserSearchSlackOutputType;
 
   // Channel
-  const result3 = await runAction(
+  const result3 = (await runAction(
     "searchSlack",
     "slackUser",
     { authToken: process.env.SLACK_AUTH_TOKEN },
-    { channel: "general", limit: 1, topic: "welcome" },
-  );
-  
+    { channel: "general", limit: 1, topic: "welcome" }
+  )) as slackUserSearchSlackOutputType;
+
   console.log(
-    "Send Message Test Response 1: " + JSON.stringify(result1, null, 2),
+    "Send Message Test Response 1: " + JSON.stringify(result1, null, 2)
   );
 
   console.log(
-    "Send Message Test Response 2: " + JSON.stringify(result2, null, 2),
+    "Send Message Test Response 2: " + JSON.stringify(result2, null, 2)
   );
 
   console.log(
-    "Send Message Test Response 3: " + JSON.stringify(result3, null, 2),
+    "Send Message Test Response 3: " + JSON.stringify(result3, null, 2)
   );
 }
 


### PR DESCRIPTION
Updates the following actions

* getSalesforceRecordsByQuery
* searchGroup (gitlab)
* listDirectory (github)
* listPullRequests (github)
* searchSalesforceRecords
* getFileContent (github)
* searchOrganization (github)
* scrapeUrl (firecrawl)
* getJiraTicketDetails 
* getFileContent (gitlab)
* searchSlack
* listDirectory (gitlab)
* searchDriveByKeywordsAndGetFileContent
* getJiraIssuesByQuery
* getDriveFileContentById
