### PR TITLE
[bugfix] Fix jira get ticket details url

### DIFF
--- a/src/actions/providers/jira/getJiraTicketDetails.ts
+++ b/src/actions/providers/jira/getJiraTicketDetails.ts
@@ -14,11 +14,11 @@ const getJiraTicketDetails: jiraGetJiraTicketDetailsFunction = async ({
   params: jiraGetJiraTicketDetailsParamsType;
   authParams: AuthParamsType;
 }): Promise<jiraGetJiraTicketDetailsOutputType> => {
-  const { authToken, cloudId } = authParams;
+  const { authToken, cloudId, baseUrl } = authParams;
   const { issueId } = params;
 
-  if (!cloudId || !authToken) {
-    throw new Error("Valid Cloud ID and auth token are required to comment on Jira ticket");
+  if (!cloudId || !authToken || !baseUrl) {
+    throw new Error("Valid Cloud ID, base URL, and auth token are required to get Jira ticket details");
   }
 
   const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueId}`;
@@ -36,7 +36,7 @@ const getJiraTicketDetails: jiraGetJiraTicketDetailsFunction = async ({
       results: [
         {
           name: response.data.key,
-          url: response.data.self,
+          url: `${baseUrl}/browse/${response.data.key}`,
           contents: response.data,
         },
       ],

--- a/tests/jira/testGetJiraTicketDetails.ts
+++ b/tests/jira/testGetJiraTicketDetails.ts
@@ -4,7 +4,7 @@ import { jiraConfig, provider } from "./utils.js";
 import type { jiraGetJiraTicketDetailsOutputType } from "../../src/actions/autogen/types";
 
 async function runTest() {
-  const { authToken, cloudId, baseUrl, issueId } = jiraConfig;
+  const { authToken, cloudId, baseUrl, issueId, projectKey } = jiraConfig;
 
   const result = (await runAction(
     "getJiraTicketDetails",
@@ -16,6 +16,7 @@ async function runTest() {
     },
     {
       issueId,
+      projectKey
     }
   )) as jiraGetJiraTicketDetailsOutputType;
 


### PR DESCRIPTION
before:
```
> node --loader ts-node/esm tests/jira/testGetJiraTicketDetails.ts

(node:17274) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
{
  "success": true,
  "results": [
    {
      "name": "TEST-1",
      "url": "https://api.atlassian.com/ex/jira/87d9ab90-2f10-4051-b94e-160a13f679d7/rest/api/3/issue/10034",
      "contents": {...
```

After:
```
> node --loader ts-node/esm tests/jira/testGetJiraTicketDetails.ts

(node:28112) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
{
  "success": true,
  "results": [
    {
      "name": "TEST-1",
      "url": "https://lilindaxu.atlassian.net/browse/TEST-1",
      "contents": {...
```