### PR TITLE
Add getSpreadsheetMetadata action and refactor Google Sheets export path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3452,7 +3452,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3473,7 +3472,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3494,7 +3492,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3515,7 +3512,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3536,7 +3532,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3557,7 +3552,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3578,7 +3572,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3599,7 +3592,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3620,7 +3612,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3641,7 +3632,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3662,7 +3652,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -93,6 +93,8 @@ import {
   googleOauthAddTextToTopOfDocOutputSchema,
   googleOauthCreateSpreadsheetParamsSchema,
   googleOauthCreateSpreadsheetOutputSchema,
+  googleOauthGetSpreadsheetMetadataParamsSchema,
+  googleOauthGetSpreadsheetMetadataOutputSchema,
   googleOauthUpdateSpreadsheetParamsSchema,
   googleOauthUpdateSpreadsheetOutputSchema,
   googleOauthAppendRowsToSpreadsheetParamsSchema,
@@ -339,6 +341,7 @@ import updateCalendarEvent from "./providers/google-oauth/updateCalendarEvent.js
 import deleteCalendarEvent from "./providers/google-oauth/deleteCalendarEvent.js";
 import editAGoogleCalendarEvent from "./providers/google-oauth/editAGoogleCalendarEvent.js";
 import createSpreadsheet from "./providers/google-oauth/createSpreadsheet.js";
+import getSpreadsheetMetadata from "./providers/google-oauth/getSpreadsheetMetadata.js";
 import updateSpreadsheet from "./providers/google-oauth/updateSpreadsheet.js";
 import appendRowsToSpreadsheet from "./providers/google-oauth/appendRowsToSpreadsheet.js";
 import deleteRowFromSpreadsheet from "./providers/google-oauth/deleteRowFromSpreadsheet.js";
@@ -887,6 +890,12 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       paramsSchema: googleOauthCreateSpreadsheetParamsSchema,
       outputSchema: googleOauthCreateSpreadsheetOutputSchema,
       actionType: "write",
+    },
+    getSpreadsheetMetadata: {
+      fn: getSpreadsheetMetadata,
+      paramsSchema: googleOauthGetSpreadsheetMetadataParamsSchema,
+      outputSchema: googleOauthGetSpreadsheetMetadataOutputSchema,
+      actionType: "read",
     },
     updateSpreadsheet: {
       fn: updateSpreadsheet,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -7122,6 +7122,72 @@ export const googleOauthCreateSpreadsheetDefinition: ActionTemplate = {
   name: "createSpreadsheet",
   provider: "googleOauth",
 };
+export const googleOauthGetSpreadsheetMetadataDefinition: ActionTemplate = {
+  displayName: "Get spreadsheet metadata",
+  description: "Get lightweight metadata for an existing Google Spreadsheet including sheet IDs and titles",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["spreadsheetId"],
+    properties: {
+      spreadsheetId: {
+        type: "string",
+        description: "The ID of the Google Spreadsheet to fetch metadata for",
+        tags: ["recommend-predefined"],
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether spreadsheet metadata was fetched successfully",
+      },
+      spreadsheetId: {
+        type: "string",
+        description: "The spreadsheet ID",
+      },
+      spreadsheetTitle: {
+        type: "string",
+        description: "The spreadsheet title",
+      },
+      sheets: {
+        type: "array",
+        description: "The list of sheets in the spreadsheet",
+        items: {
+          type: "object",
+          properties: {
+            sheetId: {
+              type: "number",
+              description: "The ID of the sheet",
+            },
+            title: {
+              type: "string",
+              description: "The sheet title",
+            },
+            index: {
+              type: "number",
+              description: "The sheet index",
+            },
+            gid: {
+              type: "number",
+              description: "The gid used in Google Sheets URLs (same value as sheetId)",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if metadata retrieval failed",
+      },
+    },
+  },
+  name: "getSpreadsheetMetadata",
+  provider: "googleOauth",
+};
 export const googleOauthUpdateSpreadsheetDefinition: ActionTemplate = {
   displayName: "Update a spreadsheet",
   description: "Update a Google Spreadsheet with new content specified",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -104,6 +104,7 @@ export enum ActionName {
   EDITAGOOGLECALENDAREVENT = "editAGoogleCalendarEvent",
   DELETECALENDAREVENT = "deleteCalendarEvent",
   CREATESPREADSHEET = "createSpreadsheet",
+  GETSPREADSHEETMETADATA = "getSpreadsheetMetadata",
   UPDATESPREADSHEET = "updateSpreadsheet",
   APPENDROWSTOSPREADSHEET = "appendRowsToSpreadsheet",
   DELETEROWFROMSPREADSHEET = "deleteRowFromSpreadsheet",
@@ -3795,6 +3796,37 @@ export type googleOauthCreateSpreadsheetFunction = ActionFunction<
   googleOauthCreateSpreadsheetParamsType,
   AuthParamsType,
   googleOauthCreateSpreadsheetOutputType
+>;
+
+export const googleOauthGetSpreadsheetMetadataParamsSchema = z.object({
+  spreadsheetId: z.string().describe("The ID of the Google Spreadsheet to fetch metadata for"),
+});
+
+export type googleOauthGetSpreadsheetMetadataParamsType = z.infer<typeof googleOauthGetSpreadsheetMetadataParamsSchema>;
+
+export const googleOauthGetSpreadsheetMetadataOutputSchema = z.object({
+  success: z.boolean().describe("Whether spreadsheet metadata was fetched successfully"),
+  spreadsheetId: z.string().describe("The spreadsheet ID").optional(),
+  spreadsheetTitle: z.string().describe("The spreadsheet title").optional(),
+  sheets: z
+    .array(
+      z.object({
+        sheetId: z.number().describe("The ID of the sheet").optional(),
+        title: z.string().describe("The sheet title").optional(),
+        index: z.number().describe("The sheet index").optional(),
+        gid: z.number().describe("The gid used in Google Sheets URLs (same value as sheetId)").optional(),
+      }),
+    )
+    .describe("The list of sheets in the spreadsheet")
+    .optional(),
+  error: z.string().describe("The error that occurred if metadata retrieval failed").optional(),
+});
+
+export type googleOauthGetSpreadsheetMetadataOutputType = z.infer<typeof googleOauthGetSpreadsheetMetadataOutputSchema>;
+export type googleOauthGetSpreadsheetMetadataFunction = ActionFunction<
+  googleOauthGetSpreadsheetMetadataParamsType,
+  AuthParamsType,
+  googleOauthGetSpreadsheetMetadataOutputType
 >;
 
 export const googleOauthUpdateSpreadsheetParamsSchema = z.object({

--- a/src/actions/providers/google-oauth/getDriveFileContentById.ts
+++ b/src/actions/providers/google-oauth/getDriveFileContentById.ts
@@ -8,9 +8,13 @@ import type {
 } from "../../autogen/types.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 import { extractTextFromPdf } from "../../../utils/pdf.js";
-import { getGoogleDocContent, getGoogleSheetContent, getGoogleSlidesContent } from "../../../utils/google.js";
+import {
+  getGoogleDocContent,
+  getGoogleSheetContent,
+  getGoogleSlidesContent,
+  parseWorkbookBufferToPlainText,
+} from "../../../utils/google.js";
 import type { DriveFileMetadata } from "./common.js";
-import { read, utils } from "xlsx";
 import officeParser from "officeparser";
 
 const BASE_WEB_URL = "https://drive.google.com/file/d/";
@@ -139,26 +143,7 @@ const getDriveFileContentById: googleOauthGetDriveFileContentByIdFunction = asyn
         headers,
         responseType: "arraybuffer",
       });
-
-      // 1. Read the buffer into a workbook
-      const workbook = read(downloadRes.data, { type: "buffer", sheetStubs: false });
-
-      // Convert sheets to CSV with early termination if charLimit is set
-      const sheetTexts: string[] = [];
-      let totalLength = 0;
-      const effectiveLimit = charLimit ? charLimit * 1.5 : 100000; // Process 1.5x limit for safety
-
-      // 2. Convert all sheets to plain text (CSV-style)
-      for (const sheetName of workbook.SheetNames) {
-        if (totalLength >= effectiveLimit) break; // Early termination
-
-        const sheet = workbook.Sheets[sheetName];
-        const csv = utils.sheet_to_csv(sheet);
-        sheetTexts.push(`--- Sheet: ${sheetName} ---\n${csv}`);
-        totalLength += csv.length;
-      }
-
-      content = sheetTexts.join("\n").trim();
+      content = parseWorkbookBufferToPlainText(downloadRes.data, charLimit);
     } else if (mimeType === "application/vnd.openxmlformats-officedocument.presentationml.presentation") {
       // Handle modern PowerPoint files (.pptx only)
       const downloadUrl = `${BASE_API_URL}${encodeURIComponent(params.fileId)}?alt=media${sharedDriveParam}`;

--- a/src/actions/providers/google-oauth/getSpreadsheetMetadata.ts
+++ b/src/actions/providers/google-oauth/getSpreadsheetMetadata.ts
@@ -1,0 +1,67 @@
+import type {
+  AuthParamsType,
+  googleOauthGetSpreadsheetMetadataFunction,
+  googleOauthGetSpreadsheetMetadataOutputType,
+  googleOauthGetSpreadsheetMetadataParamsType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { createAxiosClientWithTimeout } from "../../util/axiosClient.js";
+
+/**
+ * Fetches metadata for a Google Sheets spreadsheet — title and the list of
+ * sheets (name, sheetId, and tab index) — without downloading any cell data.
+ *
+ * Use this action to discover sheet names and their numeric sheetId values
+ * before performing targeted reads or writes. The `sheetId` returned for each
+ * sheet is the same integer that appears as `#gid=<n>` in the spreadsheet URL.
+ *
+ * @param params.spreadsheetId - The ID of the spreadsheet (from its URL)
+ * @param authParams.authToken - OAuth2 bearer token with Sheets read scope
+ * @returns Spreadsheet title and an array of sheet descriptors, or an error
+ */
+const getSpreadsheetMetadata: googleOauthGetSpreadsheetMetadataFunction = async ({
+  params,
+  authParams,
+}: {
+  params: googleOauthGetSpreadsheetMetadataParamsType;
+  authParams: AuthParamsType;
+}): Promise<googleOauthGetSpreadsheetMetadataOutputType> => {
+  if (!authParams.authToken) {
+    return { success: false, error: MISSING_AUTH_TOKEN };
+  }
+
+  const { spreadsheetId } = params;
+  const axiosClient = createAxiosClientWithTimeout(15_000);
+
+  try {
+    const response = await axiosClient.get(`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}`, {
+      headers: { Authorization: `Bearer ${authParams.authToken}` },
+      params: {
+        fields: "spreadsheetId,properties/title,sheets/properties(sheetId,title,index)",
+      },
+    });
+
+    return {
+      success: true,
+      spreadsheetId: response.data.spreadsheetId,
+      spreadsheetTitle: response.data.properties?.title,
+      sheets: (response.data.sheets || []).map(
+        (sheet: { properties?: { sheetId?: number; title?: string; index?: number } }) => ({
+          sheetId: sheet.properties?.sheetId,
+          title: sheet.properties?.title,
+          /** 0-based position of this sheet in the spreadsheet tab order */
+          index: sheet.properties?.index,
+          /** Same integer used in Google Sheets URL fragments like #gid=<n>. */
+          gid: sheet.properties?.sheetId,
+        }),
+      ),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default getSpreadsheetMetadata;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -3832,6 +3832,52 @@ actions:
           error:
             type: string
             description: The error that occurred if the spreadsheet was not created successfully
+    getSpreadsheetMetadata:
+      displayName: Get spreadsheet metadata
+      description: Get lightweight metadata for an existing Google Spreadsheet including sheet IDs and titles
+      scopes: []
+      parameters:
+        type: object
+        required: [spreadsheetId]
+        properties:
+          spreadsheetId:
+            type: string
+            description: The ID of the Google Spreadsheet to fetch metadata for
+            tags: [recommend-predefined]
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether spreadsheet metadata was fetched successfully
+          spreadsheetId:
+            type: string
+            description: The spreadsheet ID
+          spreadsheetTitle:
+            type: string
+            description: The spreadsheet title
+          sheets:
+            type: array
+            description: The list of sheets in the spreadsheet
+            items:
+              type: object
+              properties:
+                sheetId:
+                  type: number
+                  description: The ID of the sheet
+                title:
+                  type: string
+                  description: The sheet title
+                index:
+                  type: number
+                  description: The sheet index
+                gid:
+                  type: number
+                  description: The gid used in Google Sheets URLs (same value as sheetId)
+          error:
+            type: string
+            description: The error that occurred if metadata retrieval failed
     updateSpreadsheet:
       displayName: Update a spreadsheet
       description: Update a Google Spreadsheet with new content specified

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -301,7 +301,7 @@ export function parseWorkbookBufferToPlainText(data: ArrayBuffer | Buffer, charL
   const sheetTexts: string[] = [];
   let totalLength = 0;
   // charLimit here is a soft parsing budget; downstream callers may still apply a hard final slice.
-  const effectiveLimit = charLimit ? charLimit * 1.5 : Number.POSITIVE_INFINITY;
+  const effectiveLimit = charLimit ? charLimit * 1.5 : 100_000;
 
   for (const sheetName of workbook.SheetNames) {
     if (totalLength >= effectiveLimit) {

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from "axios";
 import Papa from "papaparse";
+import { read, utils } from "xlsx";
 import { isAxiosTimeoutError } from "../actions/util/axiosClient.js";
 
 // Custom interfaces to replace googleapis types
@@ -295,6 +296,27 @@ function parseCSVToSheetJson(csvData: string, sheetName: string = "Sheet1"): str
   return JSON.stringify([{ sheetName, headers, rows }]);
 }
 
+export function parseWorkbookBufferToPlainText(data: ArrayBuffer | Buffer, charLimit?: number): string {
+  const workbook = read(data, { type: "buffer", sheetStubs: false });
+  const sheetTexts: string[] = [];
+  let totalLength = 0;
+  // charLimit here is a soft parsing budget; downstream callers may still apply a hard final slice.
+  const effectiveLimit = charLimit ? charLimit * 1.5 : Number.POSITIVE_INFINITY;
+
+  for (const sheetName of workbook.SheetNames) {
+    if (totalLength >= effectiveLimit) {
+      break;
+    }
+
+    const sheet = workbook.Sheets[sheetName];
+    const csv = utils.sheet_to_csv(sheet);
+    sheetTexts.push(`--- Sheet: ${sheetName} ---\n${csv}`);
+    totalLength += csv.length;
+  }
+
+  return sheetTexts.join("\n").trim();
+}
+
 export function parseGoogleSheetsFromRawContentToPlainText(snapshotRawContent: GoogleSheetsSpreadsheet): string {
   if (!snapshotRawContent.sheets) return "[]";
 
@@ -517,21 +539,14 @@ export async function getGoogleSheetContent(
   axiosClient: AxiosInstance,
   sharedDriveParams: string,
 ): Promise<string> {
-  // Use CSV export as primary method - it's much faster and more reliable for large sheets
-  // The Sheets API with includeGridData can timeout on large spreadsheets
+  // Prefer XLSX export so native Google Sheets follow the same workbook parsing path as uploaded Excel files.
   try {
-    const exportUrl = `${GDRIVE_BASE_URL}${encodeURIComponent(fileId)}/export?mimeType=text/csv${sharedDriveParams}`;
+    const exportUrl = `${GDRIVE_BASE_URL}${encodeURIComponent(fileId)}/export?mimeType=application/vnd.openxmlformats-officedocument.spreadsheetml.sheet${sharedDriveParams}`;
     const exportRes = await axiosClient.get(exportUrl, {
       headers: { Authorization: `Bearer ${authToken}` },
-      responseType: "text",
+      responseType: "arraybuffer",
     });
-    // Clean up trailing commas and convert to JSON format
-    const cleanedCsv = exportRes.data
-      .split("\n")
-      .map((line: string) => line.replace(/,+$/, ""))
-      .map((line: string) => line.replace(/,{2,}/g, ","))
-      .join("\n");
-    return parseCSVToSheetJson(cleanedCsv);
+    return parseWorkbookBufferToPlainText(exportRes.data);
   } catch (exportError) {
     // Check if it's a 404 or permission error
     if (exportError && typeof exportError === "object" && "status" in exportError) {
@@ -542,20 +557,34 @@ export async function getGoogleSheetContent(
       }
     }
 
-    // If CSV export fails, try the Sheets API as fallback (but this is slower)
+    // If XLSX export fails, fall back to the prior CSV-first behavior.
     try {
-      const sheetsUrl = `https://sheets.googleapis.com/v4/spreadsheets/${fileId}?includeGridData=true`;
-      const sheetsRes = await axiosClient.get(sheetsUrl, {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
+      const csvExportUrl = `${GDRIVE_BASE_URL}${encodeURIComponent(fileId)}/export?mimeType=text/csv${sharedDriveParams}`;
+      const csvExportRes = await axiosClient.get(csvExportUrl, {
+        headers: { Authorization: `Bearer ${authToken}` },
+        responseType: "text",
       });
-      return parseGoogleSheetsFromRawContentToPlainText(sheetsRes.data);
-    } catch (sheetsError) {
-      if (isAxiosTimeoutError(sheetsError)) {
-        throw new Error("Request timed out using Google Sheets API", { cause: sheetsError });
+      const cleanedCsv = csvExportRes.data
+        .split("\n")
+        .map((line: string) => line.replace(/,+$/, ""))
+        .map((line: string) => line.replace(/,{2,}/g, ","))
+        .join("\n");
+      return parseCSVToSheetJson(cleanedCsv);
+    } catch {
+      try {
+        const sheetsUrl = `https://sheets.googleapis.com/v4/spreadsheets/${fileId}?includeGridData=true`;
+        const sheetsRes = await axiosClient.get(sheetsUrl, {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        });
+        return parseGoogleSheetsFromRawContentToPlainText(sheetsRes.data);
+      } catch (sheetsError) {
+        if (isAxiosTimeoutError(sheetsError)) {
+          throw new Error("Request timed out using Google Sheets API", { cause: sheetsError });
+        }
+        throw new Error(`Unable to access spreadsheet content: ${fileId}`, { cause: sheetsError });
       }
-      throw new Error(`Unable to access spreadsheet content: ${fileId}`, { cause: sheetsError });
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a new `getSpreadsheetMetadata` action for Google Sheets that returns the spreadsheet title and a list of sheets (sheetId, title, index, gid) without downloading any cell data. Useful for agents that need to discover sheet names/IDs before performing targeted reads or writes.

- Refactors `getGoogleSheetContent` to export via XLSX instead of CSV as the primary path, unifying it with the existing Excel file handling path. The fallback chain is: XLSX → CSV → Sheets API.

- Extracts `parseWorkbookBufferToPlainText` into `src/utils/google.ts` as a shared utility, removing duplicated workbook parsing logic from `getDriveFileContentById.ts`.

## Spreadsheet type coverage

All three spreadsheet types are handled:
| Type | MIME | Path |
|------|------|------|
| Native Google Sheets | `application/vnd.google-apps.spreadsheet` | `getGoogleSheetContent` → XLSX export → `parseWorkbookBufferToPlainText` |
| Excel `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | direct download → `parseWorkbookBufferToPlainText` |
| Legacy Excel `.xls` | `application/vnd.ms-excel` | direct download → `parseWorkbookBufferToPlainText` |
| CSV | `text/csv` | direct download as plain text (unchanged) |

## Notes

- `gid` in the sheet descriptor is aliased to `sheetId` (same integer as the `#gid=` URL fragment) — added explicitly per feedback on #533
- `scopes: []` is consistent with all other Google Sheets actions in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)