### PR TITLE
Add thread reply support to Slack sendMessage, return message metadata

### DIFF
--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -696,7 +696,7 @@ export const slackCreateChannelDefinition: ActionTemplate = {
 };
 export const slackSendMessageDefinition: ActionTemplate = {
   displayName: "Send a message",
-  description: "Sends a message to a Slack channel",
+  description: "Sends a message to a Slack channel, optionally as a reply in a thread",
   scopes: ["chat:write"],
   tags: [],
   parameters: {
@@ -720,6 +720,16 @@ export const slackSendMessageDefinition: ActionTemplate = {
         type: "boolean",
         description: "Whether to enable unfurling of links in the message (defaults to true)",
       },
+      threadTs: {
+        type: "string",
+        description:
+          "The timestamp (ts) of a parent message to reply to in a thread. Obtain this from the `timestamp` field returned by a previous sendMessage call, or from the trailing path segment of a Slack message permalink (e.g. `p1234567890123456` → `1234567890.123456`).",
+      },
+      replyBroadcast: {
+        type: "boolean",
+        description:
+          "When replying in a thread (threadTs provided), also post the reply to the channel. Defaults to false.",
+      },
     },
   },
   output: {
@@ -734,9 +744,22 @@ export const slackSendMessageDefinition: ActionTemplate = {
         type: "string",
         description: "The error that occurred if the message was not sent successfully",
       },
-      messageId: {
+      channelId: {
         type: "string",
-        description: "The ID of the message that was sent",
+        description: "The ID of the channel the message was sent to",
+      },
+      timestamp: {
+        type: "string",
+        description:
+          "The Slack timestamp (ts) of the sent message. Use this as `threadTs` on a subsequent sendMessage call to reply in a thread.",
+      },
+      threadTs: {
+        type: "string",
+        description: "The timestamp of the parent message, if this message was sent as a threaded reply",
+      },
+      permalink: {
+        type: "string",
+        description: "The permalink URL to the sent message",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -541,6 +541,16 @@ export const slackSendMessageParamsSchema = z.object({
     .boolean()
     .describe("Whether to enable unfurling of links in the message (defaults to true)")
     .optional(),
+  threadTs: z
+    .string()
+    .describe(
+      "The timestamp (ts) of a parent message to reply to in a thread. Obtain this from the `timestamp` field returned by a previous sendMessage call, or from the trailing path segment of a Slack message permalink (e.g. `p1234567890123456` → `1234567890.123456`).",
+    )
+    .optional(),
+  replyBroadcast: z
+    .boolean()
+    .describe("When replying in a thread (threadTs provided), also post the reply to the channel. Defaults to false.")
+    .optional(),
 });
 
 export type slackSendMessageParamsType = z.infer<typeof slackSendMessageParamsSchema>;
@@ -548,7 +558,18 @@ export type slackSendMessageParamsType = z.infer<typeof slackSendMessageParamsSc
 export const slackSendMessageOutputSchema = z.object({
   success: z.boolean().describe("Whether the message was sent successfully"),
   error: z.string().describe("The error that occurred if the message was not sent successfully").optional(),
-  messageId: z.string().describe("The ID of the message that was sent").optional(),
+  channelId: z.string().describe("The ID of the channel the message was sent to").optional(),
+  timestamp: z
+    .string()
+    .describe(
+      "The Slack timestamp (ts) of the sent message. Use this as `threadTs` on a subsequent sendMessage call to reply in a thread.",
+    )
+    .optional(),
+  threadTs: z
+    .string()
+    .describe("The timestamp of the parent message, if this message was sent as a threaded reply")
+    .optional(),
+  permalink: z.string().describe("The permalink URL to the sent message").optional(),
 });
 
 export type slackSendMessageOutputType = z.infer<typeof slackSendMessageOutputSchema>;

--- a/src/actions/providers/slack/sendMessage.ts
+++ b/src/actions/providers/slack/sendMessage.ts
@@ -20,7 +20,7 @@ const sendMessage: slackSendMessageFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  const { channelId: inputChannelId, channelName, message, unfurlLinks } = params;
+  const { channelId: inputChannelId, channelName, message, unfurlLinks, threadTs, replyBroadcast } = params;
   if (!inputChannelId && !channelName) {
     throw Error("Either channelId or channelName must be provided");
   }
@@ -36,12 +36,18 @@ const sendMessage: slackSendMessageFunction = async ({
     throw Error(`Channel with name ${channelName} not found`);
   }
 
-  try {
-    // First try sending as Markdown blocks (mrkdwn)
-    await client.chat.postMessage({
-      channel: channelId,
-      text: message, // Fallback text for notifications/clients that don't render blocks
+  const threadArgs: { thread_ts: string; reply_broadcast: boolean } | { thread_ts: string } | object = threadTs
+    ? replyBroadcast
+      ? { thread_ts: threadTs, reply_broadcast: true }
+      : { thread_ts: threadTs }
+    : {};
+
+  const postAsBlocks = () =>
+    client.chat.postMessage({
+      channel: channelId!,
+      text: message,
       unfurl_links: unfurlLinks,
+      ...threadArgs,
       blocks: [
         {
           type: "section",
@@ -52,18 +58,48 @@ const sendMessage: slackSendMessageFunction = async ({
         },
       ],
     });
+
+  const postAsPlainText = () =>
+    client.chat.postMessage({
+      channel: channelId!,
+      text: message,
+      unfurl_links: unfurlLinks,
+      ...threadArgs,
+    });
+
+  const buildSuccess = async (result: Awaited<ReturnType<typeof postAsBlocks>>) => {
+    const ts = result.ts;
+    const resolvedChannelId = result.channel ?? channelId!;
+
+    let permalink: string | undefined;
+    if (ts) {
+      try {
+        const permalinkResult = await client.chat.getPermalink({
+          channel: resolvedChannelId,
+          message_ts: ts,
+        });
+        permalink = permalinkResult.permalink;
+      } catch {
+        // Permalink fetch failed, but the message was sent successfully
+      }
+    }
+
     return slackSendMessageOutputSchema.parse({
       success: true,
+      channelId: resolvedChannelId,
+      timestamp: ts,
+      threadTs: threadTs,
+      permalink,
     });
+  };
+
+  try {
+    const result = await postAsBlocks();
+    return await buildSuccess(result);
   } catch {
-    // On any error, retry once with plain text only (no blocks)
     try {
-      await client.chat.postMessage({
-        channel: channelId,
-        text: message,
-        unfurl_links: unfurlLinks,
-      });
-      return slackSendMessageOutputSchema.parse({ success: true });
+      const result = await postAsPlainText();
+      return await buildSuccess(result);
     } catch (retryError) {
       return slackSendMessageOutputSchema.parse({
         success: false,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -481,7 +481,7 @@ actions:
             description: The error that occurred if the channel was not created successfully
     sendMessage:
       displayName: Send a message
-      description: Sends a message to a Slack channel
+      description: Sends a message to a Slack channel, optionally as a reply in a thread
       scopes:
         - chat:write
       parameters:
@@ -501,6 +501,12 @@ actions:
           unfurlLinks:
             type: boolean
             description: Whether to enable unfurling of links in the message (defaults to true)
+          threadTs:
+            type: string
+            description: The timestamp (ts) of a parent message to reply to in a thread. Obtain this from the `timestamp` field returned by a previous sendMessage call, or from the trailing path segment of a Slack message permalink (e.g. `p1234567890123456` → `1234567890.123456`).
+          replyBroadcast:
+            type: boolean
+            description: When replying in a thread (threadTs provided), also post the reply to the channel. Defaults to false.
       output:
         type: object
         required: [success]
@@ -511,9 +517,18 @@ actions:
           error:
             type: string
             description: The error that occurred if the message was not sent successfully
-          messageId:
+          channelId:
             type: string
-            description: The ID of the message that was sent
+            description: The ID of the channel the message was sent to
+          timestamp:
+            type: string
+            description: The Slack timestamp (ts) of the sent message. Use this as `threadTs` on a subsequent sendMessage call to reply in a thread.
+          threadTs:
+            type: string
+            description: The timestamp of the parent message, if this message was sent as a threaded reply
+          permalink:
+            type: string
+            description: The permalink URL to the sent message
     getChannelMessages:
       displayName: List messages in a channel
       description: Gets messages from a Slack channel


### PR DESCRIPTION
Adds `threadTs` and `replyBroadcast` params to slack.sendMessage so agents can reply within a thread. The action now also returns `channelId`, `timestamp`, `threadTs`, and `permalink` on success, so callers can reference the sent message (e.g. to reply in-thread on a follow-up call) instead of just getting a success boolean.

Replaces the previously unpopulated `messageId` output field.