### PR TITLE
Don't remove inner limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.210",
+  "version": "0.2.211",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.210",
+      "version": "0.2.211",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.210",
+  "version": "0.2.211",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
+++ b/src/actions/providers/salesforce/getSalesforceRecordsByQuery.ts
@@ -29,11 +29,13 @@ const getSalesforceRecordsByQuery: salesforceGetSalesforceRecordsByQueryFunction
   let finalQuery = query;
 
   if (!containsAggregateFunction) {
-    // Strip out existing LIMIT clause if it exists
-    const limitRegex = /\bLIMIT\s+(\d+)\b/i;
-    const existingLimitMatch = query.match(limitRegex);
+    // Strip out existing LIMIT clause only if it's at the end of the query
+    // (so we don't remove LIMITs inside subqueries). Allow an optional trailing
+    // OFFSET clause and trailing whitespace/semicolons.
+    const trailingLimitRegex = /\bLIMIT\s+(\d+)(\s+OFFSET\s+\d+)?\s*;?\s*$/i;
+    const existingLimitMatch = query.match(trailingLimitRegex);
     const queryLimit = existingLimitMatch ? parseInt(existingLimitMatch[1], 10) : null;
-    const queryWithoutLimit = query.replace(limitRegex, "").trim();
+    const queryWithoutLimit = query.replace(trailingLimitRegex, "").trim();
 
     // Recompute final limit
     const finalLimit = Math.min(limit ?? queryLimit ?? MAX_RECORDS_LIMIT, MAX_RECORDS_LIMIT);

--- a/tests/salesforce/testGetSalesforceRecordsByQuery.ts
+++ b/tests/salesforce/testGetSalesforceRecordsByQuery.ts
@@ -61,11 +61,10 @@ async function runTest() {
   // Check that at least one result has a non-null Industry (skip null values from GROUP BY)
   const resultWithIndustry = groupByQueryResult.results?.find(
     (r) =>
-      (r as { content?: { Industry?: string | null } }).content?.Industry !==
-      null
+      (r as { contents?: { Industry?: string | null } }).contents?.Industry != null
   );
   assert.ok(
-    (resultWithIndustry as { content?: { Industry?: string | null } })?.content
+    (resultWithIndustry as { contents?: { Industry?: string | null } })?.contents
       ?.Industry !== undefined
   );
 
@@ -161,6 +160,37 @@ async function runTest() {
   )) as salesforceGetSalesforceRecordsByQueryOutputType;
   assert.strictEqual(whitespaceLimitQueryResult.success, true);
   assert.ok(whitespaceLimitQueryResult.results?.length ?? 0 <= 4);
+
+  // Test 10: Query with LIMIT inside a subquery and no trailing LIMIT.
+  // The inner LIMIT must be preserved (not stripped) and an outer LIMIT added.
+  const subqueryLimitResult = (await runAction(
+    "getSalesforceRecordsByQuery",
+    "salesforce",
+    {
+      authToken: accessToken,
+      baseUrl: instanceUrl,
+    },
+    {
+      query:
+        "SELECT Id, Name, (SELECT Id, Name FROM Contacts LIMIT 2) FROM Account ORDER BY Name ASC",
+      limit: 3,
+    }
+  )) as salesforceGetSalesforceRecordsByQueryOutputType;
+  assert.strictEqual(subqueryLimitResult.success, true);
+  // Outer LIMIT applied
+  assert.ok((subqueryLimitResult.results?.length ?? 0) <= 3);
+  // Inner LIMIT preserved: each account's Contacts subquery should have <= 2 records
+  for (const r of subqueryLimitResult.results ?? []) {
+    const contacts = (
+      r as { contents?: { Contacts?: { records?: unknown[] } | null } }
+    ).contents?.Contacts;
+    if (contacts && Array.isArray(contacts.records)) {
+      assert.ok(
+        contacts.records.length <= 2,
+        `Inner LIMIT was not preserved: got ${contacts.records.length} contacts`
+      );
+    }
+  }
 
   console.log("All tests passed!");
 }


### PR DESCRIPTION
The way we were handling limits was stripping out useful limits in the middle of the query. That was causing the action to get erroneously truncated.