### PR TITLE
Add Salesforce clean activity records action

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -288,6 +288,8 @@ import {
   slackGetChannelMembersOutputSchema,
   salesforceGetReportMetadataParamsSchema,
   salesforceGetReportMetadataOutputSchema,
+  salesforceGetCleanActivityRecordsParamsSchema,
+  salesforceGetCleanActivityRecordsOutputSchema,
   googleOauthUpdateRowsInSpreadsheetParamsSchema,
   googleOauthUpdateRowsInSpreadsheetOutputSchema,
 } from "./autogen/types.js";
@@ -436,6 +438,7 @@ import searchAllSalesforceRecords from "./providers/salesforce/searchAllSalesfor
 import listReports from "./providers/salesforce/listReports.js";
 import getReportMetadata from "./providers/salesforce/getReportMetadata.js";
 import executeReport from "./providers/salesforce/executeReport.js";
+import getCleanActivityRecords from "./providers/salesforce/getCleanActivityRecords.js";
 
 type ActionTypeSchema = "read" | "write";
 
@@ -1186,6 +1189,12 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: getReportMetadata,
       paramsSchema: salesforceGetReportMetadataParamsSchema,
       outputSchema: salesforceGetReportMetadataOutputSchema,
+      actionType: "read",
+    },
+    getCleanActivityRecords: {
+      fn: getCleanActivityRecords,
+      paramsSchema: salesforceGetCleanActivityRecordsParamsSchema,
+      outputSchema: salesforceGetCleanActivityRecordsOutputSchema,
       actionType: "read",
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11466,6 +11466,100 @@ export const salesforceGetReportMetadataDefinition: ActionTemplate = {
   name: "getReportMetadata",
   provider: "salesforce",
 };
+export const salesforceGetCleanActivityRecordsDefinition: ActionTemplate = {
+  displayName: "Get clean activity records",
+  description:
+    "Retrieve Salesforce activity records (Task or EmailMessage) with email content cleaned of HTML markup, quoted reply chains, and signature blocks. Task and EmailMessage records are deduplicated into threads, reducing token usage by up to 96% compared to raw records. For Task, queries are automatically scoped to TaskSubtype = 'Email' and sorted by the actual email-sent timestamp before Salesforce sync timestamps, because manually synced emails can be synced long after they were sent.\n",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["objectType", "whereClause"],
+    properties: {
+      objectType: {
+        type: "string",
+        enum: ["Task", "EmailMessage"],
+        description: "The Salesforce activity object to query: Task or EmailMessage",
+      },
+      whereClause: {
+        type: "string",
+        description:
+          "SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.",
+      },
+      limit: {
+        type: "number",
+        description:
+          "Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.",
+      },
+      maxBodyLength: {
+        type: "number",
+        description:
+          "Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.",
+      },
+      returnActivityIds: {
+        type: "boolean",
+        description:
+          "EmailMessage only — when true, performs a separate ActivityId-only query using the same whereClause and returns a complete activityIds string (JSON array) of Task IDs auto-generated alongside matching EmailMessage records. Pass this string directly as excludeActivityIds in a subsequent Task query to avoid returning the same communications twice.",
+      },
+      excludeActivityIds: {
+        type: "string",
+        description:
+          "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required.",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the records were successfully retrieved",
+      },
+      objectType: {
+        type: "string",
+        description: "The object type that was queried",
+      },
+      totalFetched: {
+        type: "number",
+        description: "Number of raw records returned from Salesforce",
+      },
+      totalThreads: {
+        type: "number",
+        description: "Number of deduplicated threads",
+      },
+      threads: {
+        type: "array",
+        description: "Deduplicated email threads",
+        items: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      activityIds: {
+        type: "string",
+        description:
+          "EmailMessage only, returnActivityIds=true — complete JSON array string of Task IDs auto-generated alongside matching EmailMessage records. This list is not capped by the body result limit.",
+      },
+      hasMore: {
+        type: "boolean",
+        description:
+          "True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.",
+      },
+      hasMoreMessage: {
+        type: "string",
+        description:
+          "Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the records were not successfully retrieved",
+      },
+    },
+  },
+  name: "getCleanActivityRecords",
+  provider: "salesforce",
+};
 export const microsoftCreateDocumentDefinition: ActionTemplate = {
   displayName: "Create a document",
   description: "Creates a new Office365 document",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -145,6 +145,7 @@ export enum ActionName {
   GETSALESFORCERECORDSBYQUERY = "getSalesforceRecordsByQuery",
   GETRECORD = "getRecord",
   GETREPORTMETADATA = "getReportMetadata",
+  GETCLEANACTIVITYRECORDS = "getCleanActivityRecords",
   CREATEDOCUMENT = "createDocument",
   UPDATEDOCUMENT = "updateDocument",
   MESSAGETEAMSCHAT = "messageTeamsChat",
@@ -6036,6 +6037,77 @@ export type salesforceGetReportMetadataFunction = ActionFunction<
   salesforceGetReportMetadataParamsType,
   AuthParamsType,
   salesforceGetReportMetadataOutputType
+>;
+
+export const salesforceGetCleanActivityRecordsParamsSchema = z.object({
+  objectType: z
+    .enum(["Task", "EmailMessage"])
+    .describe("The Salesforce activity object to query: Task or EmailMessage"),
+  whereClause: z
+    .string()
+    .describe(
+      "SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.",
+    ),
+  limit: z
+    .number()
+    .describe(
+      "Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.",
+    )
+    .optional(),
+  maxBodyLength: z
+    .number()
+    .describe(
+      "Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.",
+    )
+    .optional(),
+  returnActivityIds: z
+    .boolean()
+    .describe(
+      "EmailMessage only — when true, performs a separate ActivityId-only query using the same whereClause and returns a complete activityIds string (JSON array) of Task IDs auto-generated alongside matching EmailMessage records. Pass this string directly as excludeActivityIds in a subsequent Task query to avoid returning the same communications twice.",
+    )
+    .optional(),
+  excludeActivityIds: z
+    .string()
+    .describe(
+      "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required.",
+    )
+    .optional(),
+});
+
+export type salesforceGetCleanActivityRecordsParamsType = z.infer<typeof salesforceGetCleanActivityRecordsParamsSchema>;
+
+export const salesforceGetCleanActivityRecordsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the records were successfully retrieved"),
+  objectType: z.string().describe("The object type that was queried").optional(),
+  totalFetched: z.number().describe("Number of raw records returned from Salesforce").optional(),
+  totalThreads: z.number().describe("Number of deduplicated threads").optional(),
+  threads: z.array(z.object({}).catchall(z.any())).describe("Deduplicated email threads").optional(),
+  activityIds: z
+    .string()
+    .describe(
+      "EmailMessage only, returnActivityIds=true — complete JSON array string of Task IDs auto-generated alongside matching EmailMessage records. This list is not capped by the body result limit.",
+    )
+    .optional(),
+  hasMore: z
+    .boolean()
+    .describe(
+      "True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.",
+    )
+    .optional(),
+  hasMoreMessage: z
+    .string()
+    .describe(
+      "Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.",
+    )
+    .optional(),
+  error: z.string().describe("The error that occurred if the records were not successfully retrieved").optional(),
+});
+
+export type salesforceGetCleanActivityRecordsOutputType = z.infer<typeof salesforceGetCleanActivityRecordsOutputSchema>;
+export type salesforceGetCleanActivityRecordsFunction = ActionFunction<
+  salesforceGetCleanActivityRecordsParamsType,
+  AuthParamsType,
+  salesforceGetCleanActivityRecordsOutputType
 >;
 
 export const microsoftCreateDocumentParamsSchema = z.object({

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, test } from "@jest/globals";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import {
   buildEmailMessageActivityIdQuery,
   buildEmailMessageQuery,
   compareTaskEmailRecords,
+  normalizeLimit,
   parseExcludeActivityIds,
+  soqlQuery,
+  validateWhereClause,
 } from "./getCleanActivityRecords.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
+
+jest.mock("../../util/axiosClient.js", () => ({
+  axiosClient: { get: (...args: any[]) => mockGet(...args) },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("salesforceGetCleanActivityRecords Task email chronology", () => {
   test("orders email Task records by actual sent timestamp before manual sync timestamp", () => {
@@ -63,6 +77,15 @@ describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
     );
   });
 
+  test("unwraps parenthesized semi-joins with nested parentheses inside the subquery", () => {
+    const whereClause =
+      "(Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId IN ('003Qp00000cMnCQIA0', '003Qp00000cMnCQIA1'))) AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId IN ('003Qp00000cMnCQIA0', '003Qp00000cMnCQIA1')) AND MessageDate >= 2026-01-01T00:00:00Z ORDER BY",
+    );
+  });
+
   test("rejects malformed excludeActivityIds JSON", () => {
     expect(() => parseExcludeActivityIds("not-json")).toThrow("excludeActivityIds must be a JSON array string");
   });
@@ -77,5 +100,47 @@ describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
     expect(parseExcludeActivityIds(JSON.stringify(["00T000000000001AAA", "00T000000000001AAA"]))).toEqual([
       "00T000000000001AAA",
     ]);
+  });
+});
+
+describe("salesforceGetCleanActivityRecords input guards", () => {
+  test("rejects unbalanced parentheses that could break appended filters", () => {
+    expect(() => validateWhereClause("1=1) OR (1=1")).toThrow("whereClause contains unbalanced parentheses");
+    expect(() => validateWhereClause("Subject LIKE '%(safe)%' AND WhoId = '003Qp00000cMnCQIA0'")).not.toThrow();
+  });
+
+  test("floors negative and zero limits at one", () => {
+    expect(normalizeLimit(-5)).toBe(1);
+    expect(normalizeLimit(0)).toBe(1);
+    expect(normalizeLimit(200)).toBe(100);
+    expect(normalizeLimit(undefined)).toBe(20);
+  });
+});
+
+describe("salesforceGetCleanActivityRecords Salesforce query pagination", () => {
+  test("follows Salesforce nextRecordsUrl pages", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "02sQp0000000001AAA" }],
+          done: false,
+          nextRecordsUrl: "/services/data/v56.0/query/01gQp0000000001-2000",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "02sQp0000000002AAA" }],
+          done: true,
+        },
+      });
+
+    await expect(
+      soqlQuery("https://example.my.salesforce.com", "token", "SELECT Id FROM EmailMessage"),
+    ).resolves.toEqual([{ Id: "02sQp0000000001AAA" }, { Id: "02sQp0000000002AAA" }]);
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(mockGet.mock.calls[1]?.[0]).toBe(
+      "https://example.my.salesforce.com/services/data/v56.0/query/01gQp0000000001-2000",
+    );
   });
 });

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  buildEmailMessageActivityIdQuery,
+  buildEmailMessageQuery,
+  compareTaskEmailRecords,
+  parseExcludeActivityIds,
+} from "./getCleanActivityRecords.js";
+
+describe("salesforceGetCleanActivityRecords Task email chronology", () => {
+  test("orders email Task records by actual sent timestamp before manual sync timestamp", () => {
+    const oldEmailSyncedLater = {
+      Id: "00T000000000001AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-05-06",
+      groove_email_sent_at__c: "2026-04-01T09:00:00.000+0000",
+      CreatedDate: "2026-05-06T14:00:00.000+0000",
+      LastModifiedDate: "2026-05-06T14:00:00.000+0000",
+    };
+    const newerEmailSyncedEarlier = {
+      Id: "00T000000000002AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-05-05",
+      groove_email_sent_at__c: "2026-05-05T15:30:00.000+0000",
+      CreatedDate: "2026-05-05T16:00:00.000+0000",
+      LastModifiedDate: "2026-05-05T16:00:00.000+0000",
+    };
+
+    const sorted = [oldEmailSyncedLater, newerEmailSyncedEarlier].sort(compareTaskEmailRecords);
+
+    expect(sorted[0]?.Id).toBe("00T000000000002AAA");
+  });
+});
+
+describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
+  test("builds a separate uncapped ActivityId query from the same EmailMessage filter", () => {
+    const soql = buildEmailMessageActivityIdQuery("RelatedToId = '500Qp0000012345AAA'");
+
+    expect(soql).toBe(
+      "SELECT ActivityId FROM EmailMessage WHERE (RelatedToId = '500Qp0000012345AAA') AND ActivityId != null",
+    );
+    expect(soql).not.toContain("LIMIT");
+    expect(soql).not.toContain("TextBody");
+  });
+
+  test("keeps EmailMessageRelation semi-joins at the top level when date filters are present", () => {
+    const whereClause =
+      "Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z ORDER BY",
+    );
+    expect(buildEmailMessageActivityIdQuery(whereClause)).toBe(
+      "SELECT ActivityId FROM EmailMessage WHERE Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z AND ActivityId != null",
+    );
+  });
+
+  test("unwraps agent-supplied parentheses around EmailMessageRelation semi-joins", () => {
+    const whereClause =
+      "(Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0')) AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z ORDER BY",
+    );
+  });
+
+  test("rejects malformed excludeActivityIds JSON", () => {
+    expect(() => parseExcludeActivityIds("not-json")).toThrow("excludeActivityIds must be a JSON array string");
+  });
+
+  test("rejects non-Salesforce IDs instead of silently dropping them", () => {
+    expect(() => parseExcludeActivityIds(JSON.stringify(["00T000000000001AAA", "bad-id"]))).toThrow(
+      "excludeActivityIds contains invalid Salesforce IDs: bad-id",
+    );
+  });
+
+  test("returns valid unique Salesforce IDs", () => {
+    expect(parseExcludeActivityIds(JSON.stringify(["00T000000000001AAA", "00T000000000001AAA"]))).toEqual([
+      "00T000000000001AAA",
+    ]);
+  });
+});

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -8,11 +8,15 @@ import {
   soqlQuery,
   validateWhereClause,
 } from "./getCleanActivityRecords.js";
+import getCleanActivityRecords from "./getCleanActivityRecords.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
 
 jest.mock("../../util/axiosClient.js", () => ({
+  ApiError: class ApiError extends Error {
+    data?: unknown;
+  },
   axiosClient: { get: (...args: any[]) => mockGet(...args) },
 }));
 
@@ -46,6 +50,26 @@ describe("salesforceGetCleanActivityRecords Task email chronology", () => {
 });
 
 describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
+  test("rejects excludeActivityIds on EmailMessage instead of silently ignoring it", async () => {
+    await expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "EmailMessage",
+          whereClause: "RelatedToId = '500Qp0000012345AAA'",
+          excludeActivityIds: JSON.stringify(["00T000000000001AAA"]),
+        },
+        authParams: {
+          authToken: "token",
+          baseUrl: "https://example.my.salesforce.com",
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: "excludeActivityIds is only supported when objectType is Task",
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
   test("builds a separate uncapped ActivityId query from the same EmailMessage filter", () => {
     const soql = buildEmailMessageActivityIdQuery("RelatedToId = '500Qp0000012345AAA'");
 

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -104,6 +104,18 @@ describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
 });
 
 describe("salesforceGetCleanActivityRecords input guards", () => {
+  test("allows disallowed SOQL guard sequences inside quoted string literals", () => {
+    expect(() =>
+      validateWhereClause("Subject LIKE '%Q2--Q3%' AND Description LIKE '%/* note */%' AND Subject != ';'"),
+    ).not.toThrow();
+  });
+
+  test("rejects disallowed SOQL guard sequences outside quoted string literals", () => {
+    expect(() => validateWhereClause("Subject LIKE '%Q2%' -- ignored")).toThrow(
+      "whereClause contains disallowed patterns",
+    );
+  });
+
   test("rejects unbalanced parentheses that could break appended filters", () => {
     expect(() => validateWhereClause("1=1) OR (1=1")).toThrow("whereClause contains unbalanced parentheses");
     expect(() => validateWhereClause("Subject LIKE '%(safe)%' AND WhoId = '003Qp00000cMnCQIA0'")).not.toThrow();

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -1,0 +1,417 @@
+import type {
+  AuthParamsType,
+  salesforceGetCleanActivityRecordsFunction,
+  salesforceGetCleanActivityRecordsOutputType,
+  salesforceGetCleanActivityRecordsParamsType,
+} from "../../autogen/types.js";
+import { ApiError, axiosClient } from "../../util/axiosClient.js";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const DEFAULT_MAX_BODY_LENGTH = 500;
+// Salesforce IDs are 15 or 18 alphanumeric characters — used to validate excludeActivityIds before SOQL interpolation
+const SF_ID_PATTERN = /^[a-zA-Z0-9]{15,18}$/;
+// Blocks statement terminators and comment sequences that could escape the WHERE clause wrapper
+const SOQL_INJECTION_PATTERN = /;|--|\/\*|\*\//;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SfRecord = Record<string, any>;
+
+function cleanBody(text: string | null | undefined): string | null {
+  if (!text) return null;
+  let s = text;
+  s = s.replace(/\r\n/g, "\n");
+  s = s.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, "[$1]");
+  s = s.replace(/<[^>]+>/g, " ");
+  s = s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#?\w+;/g, "");
+  s = s.replace(/^(From|To|CC|BCC|Date|Subject|Attachment):.*\n/gim, "");
+  const qm = s.match(/(?:^|\n)(On [\s\S]{0,250}?wrote:\s*(?:\n|$))/);
+  if (qm && qm.index !== undefined) {
+    const cut = qm.index + (qm[0].startsWith("\n") ? 1 : 0);
+    s = s.slice(0, cut);
+  }
+  s = s.replace(/\n--\s*\n[\s\S]*$/, "");
+  s = s.replace(/\n{3,}/g, "\n\n").trim();
+  return s.length > 0 ? s : null;
+}
+
+function truncate(text: string | null, maxLength: number): string | null {
+  if (!text) return null;
+  return text.length <= maxLength ? text : text.slice(0, maxLength) + "…";
+}
+
+function normalizeSubject(subject: string): string {
+  const prefix = /^(Email:\s*|>>\s*|<<\s*|\[Inbox\]\s*-?\s*|Re:\s*|Fwd?:\s*|FW:\s*)/i;
+  let s = subject;
+  let prev = "";
+  while (s !== prev) {
+    prev = s;
+    s = s.replace(prefix, "");
+  }
+  return s.trim();
+}
+
+function parseSalesforceTimestamp(value: unknown): number {
+  if (typeof value !== "string" || value.length === 0) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
+
+function getTaskEmailSortKey(record: SfRecord): number {
+  const candidates = [
+    record.groove_email_sent_at__c,
+    record.Email_Sent_At__c,
+    record.EmailDate__c,
+    record.LastModifiedDate,
+    record.CreatedDate,
+    record.ActivityDate,
+  ];
+
+  for (const candidate of candidates) {
+    const parsed = parseSalesforceTimestamp(candidate);
+    if (parsed !== Number.NEGATIVE_INFINITY) return parsed;
+  }
+
+  return Number.NEGATIVE_INFINITY;
+}
+
+function compareTaskEmailRecords(a: SfRecord, b: SfRecord): number {
+  const byEmailTime = getTaskEmailSortKey(b) - getTaskEmailSortKey(a);
+  if (byEmailTime !== 0) return byEmailTime;
+  return String(b.Id ?? "").localeCompare(String(a.Id ?? ""));
+}
+
+function formatTaskEmailDate(record: SfRecord): string | null {
+  const candidates = [
+    record.groove_email_sent_at__c,
+    record.Email_Sent_At__c,
+    record.EmailDate__c,
+    record.LastModifiedDate,
+    record.CreatedDate,
+    record.ActivityDate,
+  ];
+  return (candidates.find(value => typeof value === "string" && value.length > 0) as string | undefined) ?? null;
+}
+
+function detectTaskDirection(
+  subject: string,
+  description: string | null | undefined,
+  ownerEmail: string | null | undefined,
+): "inbound" | "outbound" | "unknown" {
+  if (subject.includes(">>")) return "outbound";
+  if (subject.includes("<<") || /\[inbox\]/i.test(subject)) return "inbound";
+  if (description && ownerEmail) {
+    const fromMatch = description.match(/^From:\s*.+?<([^>]+)>/m) || description.match(/^From:\s*(\S+@\S+)/m);
+    if (fromMatch) {
+      return fromMatch[1].toLowerCase() === ownerEmail.toLowerCase() ? "outbound" : "inbound";
+    }
+  }
+  return "unknown";
+}
+
+function parseExcludeActivityIds(excludeActivityIds?: string): string[] {
+  if (!excludeActivityIds) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(excludeActivityIds);
+  } catch {
+    throw new Error("excludeActivityIds must be a JSON array string");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("excludeActivityIds must be a JSON array string");
+  }
+
+  const invalid = parsed.filter(id => typeof id !== "string" || !SF_ID_PATTERN.test(id));
+  if (invalid.length > 0) {
+    throw new Error(`excludeActivityIds contains invalid Salesforce IDs: ${invalid.join(", ")}`);
+  }
+
+  return [...new Set(parsed as string[])];
+}
+
+// whereClause is provided by an AI agent and is NOT treated as untrusted end-user input. This guard
+// blocks comment sequences and statement terminators that could break the WHERE clause wrapping and
+// allow unintended record access. Hallucinated or malformed SOQL that passes this check returns a
+// Salesforce API error surfaced to the caller.
+function validateWhereClause(whereClause: string): void {
+  if (SOQL_INJECTION_PATTERN.test(whereClause)) {
+    throw new Error(
+      "whereClause contains disallowed patterns (;  --  /*  */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
+        "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
+    );
+  }
+}
+
+async function soqlQuery(baseUrl: string, authToken: string, soql: string): Promise<unknown[]> {
+  const url = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
+  const response = await axiosClient.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
+  return response.data.records ?? [];
+}
+
+async function handleTask(
+  baseUrl: string,
+  authToken: string,
+  whereClause: string,
+  limit: number,
+  maxBodyLength: number,
+  excludeActivityIds?: string,
+): Promise<salesforceGetCleanActivityRecordsOutputType> {
+  validateWhereClause(whereClause);
+  const exclusionIds = parseExcludeActivityIds(excludeActivityIds);
+  const exclusion = exclusionIds.length > 0 ? ` AND Id NOT IN (${exclusionIds.map(id => `'${id}'`).join(",")})` : "";
+  // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
+  const soql = `SELECT Id, Subject, TaskSubtype, ActivityDate, CreatedDate, LastModifiedDate, groove_email_sent_at__c, Owner.Name, Owner.Email, WhoId, WhatId, Description FROM Task WHERE (${whereClause}) AND TaskSubtype = 'Email'${exclusion} ORDER BY groove_email_sent_at__c DESC NULLS LAST, LastModifiedDate DESC NULLS LAST LIMIT ${limit + 1}`;
+  const rawRecords = (await soqlQuery(baseUrl, authToken, soql)) as SfRecord[];
+  const hasMore = rawRecords.length > limit;
+  const records = hasMore ? rawRecords.slice(0, limit) : rawRecords;
+
+  // Group by normalizedSubject + WhoId + WhatId
+  const threadMap = new Map<string, SfRecord[]>();
+  for (const r of records) {
+    const key = `${normalizeSubject(r.Subject ?? "")}||${r.WhoId ?? ""}||${r.WhatId ?? ""}`;
+    const group = threadMap.get(key) ?? [];
+    group.push(r);
+    threadMap.set(key, group);
+  }
+
+  // Resolve WhoId → Contact, then Lead as fallback
+  const whoIds = [...new Set(records.map(r => r.WhoId).filter(Boolean) as string[])];
+  const contactMap = new Map<string, { id: string; name: string; email: string | null; title: string | null }>();
+  if (whoIds.length > 0) {
+    const idList = whoIds.map(id => `'${id}'`).join(",");
+    const contactSoql = `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${idList})`;
+    const contacts = (await soqlQuery(baseUrl, authToken, contactSoql)) as SfRecord[];
+    for (const c of contacts) {
+      contactMap.set(c.Id, { id: c.Id, name: c.Name, email: c.Email ?? null, title: c.Title ?? null });
+    }
+    const unresolvedIds = whoIds.filter(id => !contactMap.has(id));
+    if (unresolvedIds.length > 0) {
+      const leadIdList = unresolvedIds.map(id => `'${id}'`).join(",");
+      const leadSoql = `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${leadIdList})`;
+      const leads = (await soqlQuery(baseUrl, authToken, leadSoql)) as SfRecord[];
+      for (const l of leads) {
+        contactMap.set(l.Id, { id: l.Id, name: l.Name, email: l.Email ?? null, title: l.Title ?? null });
+      }
+    }
+  }
+
+  const threads = [];
+  for (const [, group] of threadMap) {
+    group.sort(compareTaskEmailRecords);
+    const latest = group[0];
+    const ownerEmail: string | null = latest.Owner?.Email ?? null;
+    threads.push({
+      normalizedSubject: normalizeSubject(latest.Subject ?? ""),
+      threadSize: group.length,
+      latestDate: formatTaskEmailDate(latest),
+      activityDate: latest.ActivityDate ?? null,
+      direction: detectTaskDirection(latest.Subject ?? "", latest.Description, ownerEmail),
+      owner: latest.Owner?.Name ?? null,
+      whoId: latest.WhoId ?? null,
+      whatId: latest.WhatId ?? null,
+      contact: latest.WhoId ? (contactMap.get(latest.WhoId) ?? null) : null,
+      latestTaskId: latest.Id,
+      allTaskIds: group.map(r => r.Id as string),
+      cleanedDescription: truncate(cleanBody(latest.Description), maxBodyLength),
+    });
+  }
+
+  threads.sort((a, b) => {
+    if (!a.latestDate) return 1;
+    if (!b.latestDate) return -1;
+    return b.latestDate.localeCompare(a.latestDate);
+  });
+
+  return {
+    success: true,
+    objectType: "Task",
+    totalFetched: records.length,
+    totalThreads: threads.length,
+    threads,
+    ...(hasMore && {
+      hasMore: true,
+      hasMoreMessage: `Result set was capped at ${limit} records (${threads.length} threads shown). There may be additional Task activity not included in this response. Narrow your WHERE clause or increase the limit parameter to retrieve more.`,
+    }),
+  };
+}
+
+function containsSemiJoinSubquery(whereClause: string): boolean {
+  return /\b(?:NOT\s+)?IN\s*\(\s*SELECT\b/i.test(whereClause);
+}
+
+function unwrapParenthesizedSemiJoins(whereClause: string): string {
+  let normalized = whereClause;
+  let previous: string;
+
+  do {
+    previous = normalized;
+    normalized = normalized.replace(/\(\s*([A-Za-z_][\w.]*\s+(?:NOT\s+)?IN\s*\(\s*SELECT\b[^)]*\))\s*\)/gi, "$1");
+  } while (normalized !== previous);
+
+  return normalized;
+}
+
+function formatEmailMessageWhereClause(whereClause: string): string {
+  return containsSemiJoinSubquery(whereClause) ? unwrapParenthesizedSemiJoins(whereClause) : `(${whereClause})`;
+}
+
+function buildEmailMessageActivityIdQuery(whereClause: string): string {
+  return `SELECT ActivityId FROM EmailMessage WHERE ${formatEmailMessageWhereClause(whereClause)} AND ActivityId != null`;
+}
+
+function buildEmailMessageQuery(whereClause: string, limit: number): string {
+  return `SELECT Id, Subject, MessageDate, Incoming, FromAddress, ToAddress, CcAddress, TextBody, ThreadIdentifier, MessageIdentifier, RelatedToId, ActivityId FROM EmailMessage WHERE ${formatEmailMessageWhereClause(whereClause)} ORDER BY MessageDate DESC NULLS LAST LIMIT ${limit + 1}`;
+}
+
+async function collectCompleteEmailMessageActivityIds(
+  baseUrl: string,
+  authToken: string,
+  whereClause: string,
+): Promise<string[]> {
+  const rows = (await soqlQuery(baseUrl, authToken, buildEmailMessageActivityIdQuery(whereClause))) as SfRecord[];
+  return [
+    ...new Set(rows.map(row => row.ActivityId).filter((id): id is string => typeof id === "string" && id.length > 0)),
+  ];
+}
+
+async function handleEmailMessage(
+  baseUrl: string,
+  authToken: string,
+  whereClause: string,
+  limit: number,
+  maxBodyLength: number,
+  returnActivityIds?: boolean,
+): Promise<salesforceGetCleanActivityRecordsOutputType> {
+  validateWhereClause(whereClause);
+  // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
+  const soql = buildEmailMessageQuery(whereClause, limit);
+  const rawRecords = (await soqlQuery(baseUrl, authToken, soql)) as SfRecord[];
+  const hasMore = rawRecords.length > limit;
+  const records = hasMore ? rawRecords.slice(0, limit) : rawRecords;
+
+  const threadMap = new Map<string, SfRecord[]>();
+  for (const r of records) {
+    const key = r.ThreadIdentifier ?? r.Id;
+    const group = threadMap.get(key) ?? [];
+    group.push(r);
+    threadMap.set(key, group);
+  }
+
+  const threads = [];
+  for (const [threadIdentifier, group] of threadMap) {
+    group.sort((a, b) => {
+      if (!a.MessageDate) return 1;
+      if (!b.MessageDate) return -1;
+      return b.MessageDate.localeCompare(a.MessageDate);
+    });
+    const latest = group[0];
+    threads.push({
+      threadIdentifier,
+      normalizedSubject: normalizeSubject(latest.Subject ?? ""),
+      threadSize: group.length,
+      latestDate: latest.MessageDate ?? null,
+      direction: latest.Incoming === true ? "inbound" : "outbound",
+      relatedToId: latest.RelatedToId ?? null,
+      fromAddress: latest.FromAddress ?? null,
+      toAddress: latest.ToAddress ?? null,
+      latestMessageId: latest.Id,
+      allMessageIds: group.map(r => r.Id as string),
+      messageIdentifiers: group.map(r => r.MessageIdentifier as string).filter(Boolean),
+      cleanedBody: truncate(cleanBody(latest.TextBody), maxBodyLength),
+    });
+  }
+
+  threads.sort((a, b) => {
+    if (!a.latestDate) return 1;
+    if (!b.latestDate) return -1;
+    return b.latestDate.localeCompare(a.latestDate);
+  });
+
+  const result: salesforceGetCleanActivityRecordsOutputType = {
+    success: true,
+    objectType: "EmailMessage",
+    totalFetched: records.length,
+    totalThreads: threads.length,
+    threads,
+    ...(hasMore && {
+      hasMore: true,
+      hasMoreMessage: `Result set was capped at ${limit} records (${threads.length} threads shown). There may be additional EmailMessage activity not included in this response. Narrow your WHERE clause or increase the limit parameter to retrieve more.`,
+    }),
+  };
+
+  if (returnActivityIds) {
+    result.activityIds = JSON.stringify(await collectCompleteEmailMessageActivityIds(baseUrl, authToken, whereClause));
+  }
+
+  return result;
+}
+
+const getCleanActivityRecords: salesforceGetCleanActivityRecordsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: salesforceGetCleanActivityRecordsParamsType;
+  authParams: AuthParamsType;
+}): Promise<salesforceGetCleanActivityRecordsOutputType> => {
+  const { authToken, baseUrl } = authParams;
+  const { objectType, whereClause, limit, maxBodyLength, returnActivityIds, excludeActivityIds } = params;
+
+  if (!authToken || !baseUrl) {
+    return { success: false, error: "authToken and baseUrl are required for Salesforce API" };
+  }
+
+  const effectiveLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const effectiveMaxBodyLength = maxBodyLength ?? DEFAULT_MAX_BODY_LENGTH;
+
+  try {
+    if (objectType === "Task")
+      return await handleTask(
+        baseUrl,
+        authToken,
+        whereClause,
+        effectiveLimit,
+        effectiveMaxBodyLength,
+        excludeActivityIds,
+      );
+    return await handleEmailMessage(
+      baseUrl,
+      authToken,
+      whereClause,
+      effectiveLimit,
+      effectiveMaxBodyLength,
+      returnActivityIds,
+    );
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof ApiError
+          ? error.data?.length > 0
+            ? error.data[0].message
+            : error.message
+          : error instanceof Error
+            ? error.message
+            : "An unknown error occurred",
+    };
+  }
+};
+
+export {
+  buildEmailMessageActivityIdQuery,
+  buildEmailMessageQuery,
+  cleanBody,
+  collectCompleteEmailMessageActivityIds,
+  compareTaskEmailRecords,
+  getTaskEmailSortKey,
+  normalizeSubject,
+  parseExcludeActivityIds,
+};
+
+export default getCleanActivityRecords;

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -67,6 +67,20 @@ function hasBalancedParentheses(value: string): boolean {
   return balanced && depth === 0;
 }
 
+function hasDisallowedSoqlSequenceOutsideString(value: string): boolean {
+  let hasDisallowedSequence = false;
+
+  forEachSoqlCharacterOutsideString(value, (_, index) => {
+    if (SOQL_INJECTION_PATTERN.test(value.slice(index, index + 2))) {
+      hasDisallowedSequence = true;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return hasDisallowedSequence;
+}
+
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(Math.max(1, Math.trunc(limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
 }
@@ -81,7 +95,7 @@ function cleanBody(text: string | null | undefined): string | null {
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
-    .replace(/ /g, " ")
+    .replace(/&nbsp;/g, " ")
     .replace(/&#?\w+;/g, "");
   s = s.replace(/^(From|To|CC|BCC|Date|Subject|Attachment):.*\n/gim, "");
   const qm = s.match(/(?:^|\n)(On [\s\S]{0,250}?wrote:\s*(?:\n|$))/);
@@ -118,6 +132,9 @@ function parseSalesforceTimestamp(value: unknown): number {
 
 function getTaskEmailSortKey(record: SfRecord): number {
   const candidates = [
+    record.groove_email_sent_at__c,
+    record.Email_Sent_At__c,
+    record.EmailDate__c,
     record.LastModifiedDate,
     record.CreatedDate,
     record.ActivityDate,
@@ -139,6 +156,9 @@ function compareTaskEmailRecords(a: SfRecord, b: SfRecord): number {
 
 function formatTaskEmailDate(record: SfRecord): string | null {
   const candidates = [
+    record.groove_email_sent_at__c,
+    record.Email_Sent_At__c,
+    record.EmailDate__c,
     record.LastModifiedDate,
     record.CreatedDate,
     record.ActivityDate,
@@ -189,23 +209,23 @@ function parseExcludeActivityIds(excludeActivityIds?: string): string[] {
 // allow unintended record access. Hallucinated or malformed SOQL that passes this check returns a
 // Salesforce API error surfaced to the caller.
 function validateWhereClause(whereClause: string): void {
-  if (SOQL_INJECTION_PATTERN.test(whereClause)) {
+  if (hasDisallowedSoqlSequenceOutsideString(whereClause)) {
     throw new Error(
       "whereClause contains disallowed patterns (; -- /* */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
-      "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
+        "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
     );
   }
   if (!hasBalancedParentheses(whereClause)) {
     throw new Error(
       "whereClause contains unbalanced parentheses. Provide a balanced SOQL filter expression that cannot escape appended safety filters. " +
-      "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
+        "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
     );
   }
 }
 
 // maxPages caps pagination for queries without a LIMIT clause (e.g. activity ID collection).
-// Queries with a LIMIT clause never produce more than one page, so the default 1 is safe for them.
-async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPages = 1): Promise<SfRecord[]> {
+// Queries with a LIMIT clause never produce more than one page, so the default Infinity is safe for them.
+async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPages = Infinity): Promise<SfRecord[]> {
   let url: string | null = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
   const records: unknown[] = [];
   let pages = 0;
@@ -498,7 +518,7 @@ const getCleanActivityRecords: salesforceGetCleanActivityRecordsFunction = async
   }
 
   if (objectType === "EmailMessage" && excludeActivityIds) {
-    return { success: false, error: "excludeActivityIds is only supported when objectType is 'Task'" };
+    return { success: false, error: "excludeActivityIds is only supported when objectType is Task" };
   }
 
   const effectiveLimit = normalizeLimit(limit);

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -9,6 +9,7 @@ import { ApiError, axiosClient } from "../../util/axiosClient.js";
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 const DEFAULT_MAX_BODY_LENGTH = 500;
+const MAX_ACTIVITY_ID_PAGES = 5;
 // Salesforce IDs are 15 or 18 alphanumeric characters — used to validate excludeActivityIds before SOQL interpolation
 const SF_ID_PATTERN = /^[a-zA-Z0-9]{15,18}$/;
 // Blocks statement terminators and comment sequences that could escape the WHERE clause wrapper
@@ -208,11 +209,14 @@ function validateWhereClause(whereClause: string): void {
   }
 }
 
-async function soqlQuery(baseUrl: string, authToken: string, soql: string): Promise<unknown[]> {
+// maxPages caps pagination for queries without a LIMIT clause (e.g. activity ID collection).
+// Queries with a LIMIT clause never produce more than one page, so the default Infinity is safe for them.
+async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPages = Infinity): Promise<unknown[]> {
   let url: string | null = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
   const records: unknown[] = [];
+  let pages = 0;
 
-  while (url) {
+  while (url && pages < maxPages) {
     const response: { data: { records?: unknown[]; done?: boolean; nextRecordsUrl?: string } } = await axiosClient.get(
       url,
       { headers: { Authorization: `Bearer ${authToken}` } },
@@ -222,6 +226,7 @@ async function soqlQuery(baseUrl: string, authToken: string, soql: string): Prom
       response.data.done === false && typeof response.data.nextRecordsUrl === "string"
         ? `${baseUrl}${response.data.nextRecordsUrl}`
         : null;
+    pages++;
   }
 
   return records;
@@ -239,7 +244,8 @@ async function handleTask(
   const exclusionIds = parseExcludeActivityIds(excludeActivityIds);
   const exclusion = exclusionIds.length > 0 ? ` AND Id NOT IN (${exclusionIds.map(id => `'${id}'`).join(",")})` : "";
   // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
-  const soql = `SELECT Id, Subject, TaskSubtype, ActivityDate, CreatedDate, LastModifiedDate, groove_email_sent_at__c, Owner.Name, Owner.Email, WhoId, WhatId, Description FROM Task WHERE (${whereClause}) AND TaskSubtype = 'Email'${exclusion} ORDER BY groove_email_sent_at__c DESC NULLS LAST, LastModifiedDate DESC NULLS LAST LIMIT ${limit + 1}`;
+  // groove_email_sent_at__c omitted: it only exists in Groove CRM orgs; non-Groove orgs fail with "No such column"
+  const soql = `SELECT Id, Subject, TaskSubtype, ActivityDate, CreatedDate, LastModifiedDate, Owner.Name, Owner.Email, WhoId, WhatId, Description FROM Task WHERE (${whereClause}) AND TaskSubtype = 'Email'${exclusion} ORDER BY LastModifiedDate DESC NULLS LAST LIMIT ${limit + 1}`;
   const rawRecords = (await soqlQuery(baseUrl, authToken, soql)) as SfRecord[];
   const hasMore = rawRecords.length > limit;
   const records = hasMore ? rawRecords.slice(0, limit) : rawRecords;
@@ -401,7 +407,12 @@ async function collectCompleteEmailMessageActivityIds(
   authToken: string,
   whereClause: string,
 ): Promise<string[]> {
-  const rows = (await soqlQuery(baseUrl, authToken, buildEmailMessageActivityIdQuery(whereClause))) as SfRecord[];
+  const rows = (await soqlQuery(
+    baseUrl,
+    authToken,
+    buildEmailMessageActivityIdQuery(whereClause),
+    MAX_ACTIVITY_ID_PAGES,
+  )) as SfRecord[];
   return [
     ...new Set(rows.map(row => row.ActivityId).filter((id): id is string => typeof id === "string" && id.length > 0)),
   ];

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -17,6 +17,59 @@ const SOQL_INJECTION_PATTERN = /;|--|\/\*|\*\//;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SfRecord = Record<string, any>;
 
+function forEachSoqlCharacterOutsideString(
+  value: string,
+  callback: (character: string, index: number) => void | "stop",
+): void {
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const character = value[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "'" && value[i + 1] === "'") {
+        i += 1;
+      } else if (character === "'") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === "'") {
+      inString = true;
+      continue;
+    }
+
+    if (callback(character, i) === "stop") return;
+  }
+}
+
+function hasBalancedParentheses(value: string): boolean {
+  let depth = 0;
+  let balanced = true;
+
+  forEachSoqlCharacterOutsideString(value, character => {
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    if (depth < 0) {
+      balanced = false;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return balanced && depth === 0;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(1, Math.trunc(limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
+}
+
 function cleanBody(text: string | null | undefined): string | null {
   if (!text) return null;
   let s = text;
@@ -147,12 +200,31 @@ function validateWhereClause(whereClause: string): void {
         "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
     );
   }
+  if (!hasBalancedParentheses(whereClause)) {
+    throw new Error(
+      "whereClause contains unbalanced parentheses. Provide a balanced SOQL filter expression that cannot escape appended safety filters. " +
+        "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
+    );
+  }
 }
 
 async function soqlQuery(baseUrl: string, authToken: string, soql: string): Promise<unknown[]> {
-  const url = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
-  const response = await axiosClient.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-  return response.data.records ?? [];
+  let url: string | null = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
+  const records: unknown[] = [];
+
+  while (url) {
+    const response: { data: { records?: unknown[]; done?: boolean; nextRecordsUrl?: string } } = await axiosClient.get(
+      url,
+      { headers: { Authorization: `Bearer ${authToken}` } },
+    );
+    records.push(...(response.data.records ?? []));
+    url =
+      response.data.done === false && typeof response.data.nextRecordsUrl === "string"
+        ? `${baseUrl}${response.data.nextRecordsUrl}`
+        : null;
+  }
+
+  return records;
 }
 
 async function handleTask(
@@ -246,14 +318,68 @@ function containsSemiJoinSubquery(whereClause: string): boolean {
   return /\b(?:NOT\s+)?IN\s*\(\s*SELECT\b/i.test(whereClause);
 }
 
+function findMatchingParen(value: string, openIndex: number): number | null {
+  let depth = 0;
+  let match: number | null = null;
+
+  forEachSoqlCharacterOutsideString(value, (character, index) => {
+    if (index < openIndex) return undefined;
+    if (character === "(") depth += 1;
+    if (character === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        match = index;
+        return "stop";
+      }
+    }
+    return undefined;
+  });
+
+  return match;
+}
+
+function findParenthesizedRanges(value: string): Array<{ start: number; end: number }> {
+  const stack: number[] = [];
+  const ranges: Array<{ start: number; end: number }> = [];
+
+  forEachSoqlCharacterOutsideString(value, (character, index) => {
+    if (character === "(") stack.push(index);
+    if (character === ")") {
+      const start = stack.pop();
+      if (start !== undefined) ranges.push({ start, end: index });
+    }
+    return undefined;
+  });
+
+  return ranges;
+}
+
+function isCompleteSemiJoinExpression(expression: string): boolean {
+  const trimmed = expression.trim();
+  const match = /^[A-Za-z_][\w.]*\s+(?:NOT\s+)?IN\s*\(/i.exec(trimmed);
+  if (!match) return false;
+
+  const openParenIndex = match[0].lastIndexOf("(");
+  return findMatchingParen(trimmed, openParenIndex) === trimmed.length - 1;
+}
+
 function unwrapParenthesizedSemiJoins(whereClause: string): string {
   let normalized = whereClause;
-  let previous: string;
+  let changed = true;
 
-  do {
-    previous = normalized;
-    normalized = normalized.replace(/\(\s*([A-Za-z_][\w.]*\s+(?:NOT\s+)?IN\s*\(\s*SELECT\b[^)]*\))\s*\)/gi, "$1");
-  } while (normalized !== previous);
+  while (changed) {
+    changed = false;
+    const ranges = findParenthesizedRanges(normalized).sort((a, b) => b.start - a.start);
+
+    for (const { start, end } of ranges) {
+      const inner = normalized.slice(start + 1, end);
+      if (!isCompleteSemiJoinExpression(inner)) continue;
+
+      normalized = normalized.slice(0, start) + inner.trim() + normalized.slice(end + 1);
+      changed = true;
+      break;
+    }
+  }
 
   return normalized;
 }
@@ -367,7 +493,7 @@ const getCleanActivityRecords: salesforceGetCleanActivityRecordsFunction = async
     return { success: false, error: "authToken and baseUrl are required for Salesforce API" };
   }
 
-  const effectiveLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const effectiveLimit = normalizeLimit(limit);
   const effectiveMaxBodyLength = maxBodyLength ?? DEFAULT_MAX_BODY_LENGTH;
 
   try {
@@ -410,8 +536,11 @@ export {
   collectCompleteEmailMessageActivityIds,
   compareTaskEmailRecords,
   getTaskEmailSortKey,
+  normalizeLimit,
   normalizeSubject,
   parseExcludeActivityIds,
+  soqlQuery,
+  validateWhereClause,
 };
 
 export default getCleanActivityRecords;

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -67,20 +67,6 @@ function hasBalancedParentheses(value: string): boolean {
   return balanced && depth === 0;
 }
 
-function hasDisallowedSoqlSequenceOutsideString(value: string): boolean {
-  let hasDisallowedSequence = false;
-
-  forEachSoqlCharacterOutsideString(value, (_, index) => {
-    if (SOQL_INJECTION_PATTERN.test(value.slice(index, index + 2))) {
-      hasDisallowedSequence = true;
-      return "stop";
-    }
-    return undefined;
-  });
-
-  return hasDisallowedSequence;
-}
-
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(Math.max(1, Math.trunc(limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
 }
@@ -95,7 +81,7 @@ function cleanBody(text: string | null | undefined): string | null {
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
-    .replace(/&nbsp;/g, " ")
+    .replace(/ /g, " ")
     .replace(/&#?\w+;/g, "");
   s = s.replace(/^(From|To|CC|BCC|Date|Subject|Attachment):.*\n/gim, "");
   const qm = s.match(/(?:^|\n)(On [\s\S]{0,250}?wrote:\s*(?:\n|$))/);
@@ -132,9 +118,6 @@ function parseSalesforceTimestamp(value: unknown): number {
 
 function getTaskEmailSortKey(record: SfRecord): number {
   const candidates = [
-    record.groove_email_sent_at__c,
-    record.Email_Sent_At__c,
-    record.EmailDate__c,
     record.LastModifiedDate,
     record.CreatedDate,
     record.ActivityDate,
@@ -156,9 +139,6 @@ function compareTaskEmailRecords(a: SfRecord, b: SfRecord): number {
 
 function formatTaskEmailDate(record: SfRecord): string | null {
   const candidates = [
-    record.groove_email_sent_at__c,
-    record.Email_Sent_At__c,
-    record.EmailDate__c,
     record.LastModifiedDate,
     record.CreatedDate,
     record.ActivityDate,
@@ -209,23 +189,23 @@ function parseExcludeActivityIds(excludeActivityIds?: string): string[] {
 // allow unintended record access. Hallucinated or malformed SOQL that passes this check returns a
 // Salesforce API error surfaced to the caller.
 function validateWhereClause(whereClause: string): void {
-  if (hasDisallowedSoqlSequenceOutsideString(whereClause)) {
+  if (SOQL_INJECTION_PATTERN.test(whereClause)) {
     throw new Error(
-      "whereClause contains disallowed patterns (;  --  /*  */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
-        "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
+      "whereClause contains disallowed patterns (; -- /* */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
+      "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
     );
   }
   if (!hasBalancedParentheses(whereClause)) {
     throw new Error(
       "whereClause contains unbalanced parentheses. Provide a balanced SOQL filter expression that cannot escape appended safety filters. " +
-        "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
+      "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
     );
   }
 }
 
 // maxPages caps pagination for queries without a LIMIT clause (e.g. activity ID collection).
-// Queries with a LIMIT clause never produce more than one page, so the default Infinity is safe for them.
-async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPages = Infinity): Promise<unknown[]> {
+// Queries with a LIMIT clause never produce more than one page, so the default 1 is safe for them.
+async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPages = 1): Promise<SfRecord[]> {
   let url: string | null = `${baseUrl}/services/data/v56.0/query?q=${encodeURIComponent(soql)}`;
   const records: unknown[] = [];
   let pages = 0;
@@ -243,7 +223,7 @@ async function soqlQuery(baseUrl: string, authToken: string, soql: string, maxPa
     pages++;
   }
 
-  return records;
+  return records as SfRecord[];
 }
 
 async function handleTask(
@@ -258,7 +238,6 @@ async function handleTask(
   const exclusionIds = parseExcludeActivityIds(excludeActivityIds);
   const exclusion = exclusionIds.length > 0 ? ` AND Id NOT IN (${exclusionIds.map(id => `'${id}'`).join(",")})` : "";
   // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
-  // groove_email_sent_at__c omitted: it only exists in Groove CRM orgs; non-Groove orgs fail with "No such column"
   const soql = `SELECT Id, Subject, TaskSubtype, ActivityDate, CreatedDate, LastModifiedDate, Owner.Name, Owner.Email, WhoId, WhatId, Description FROM Task WHERE (${whereClause}) AND TaskSubtype = 'Email'${exclusion} ORDER BY LastModifiedDate DESC NULLS LAST LIMIT ${limit + 1}`;
   const rawRecords = (await soqlQuery(baseUrl, authToken, soql)) as SfRecord[];
   const hasMore = rawRecords.length > limit;
@@ -516,6 +495,10 @@ const getCleanActivityRecords: salesforceGetCleanActivityRecordsFunction = async
 
   if (!authToken || !baseUrl) {
     return { success: false, error: "authToken and baseUrl are required for Salesforce API" };
+  }
+
+  if (objectType === "EmailMessage" && excludeActivityIds) {
+    return { success: false, error: "excludeActivityIds is only supported when objectType is 'Task'" };
   }
 
   const effectiveLimit = normalizeLimit(limit);

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -67,6 +67,20 @@ function hasBalancedParentheses(value: string): boolean {
   return balanced && depth === 0;
 }
 
+function hasDisallowedSoqlSequenceOutsideString(value: string): boolean {
+  let hasDisallowedSequence = false;
+
+  forEachSoqlCharacterOutsideString(value, (_, index) => {
+    if (SOQL_INJECTION_PATTERN.test(value.slice(index, index + 2))) {
+      hasDisallowedSequence = true;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return hasDisallowedSequence;
+}
+
 function normalizeLimit(limit: number | undefined): number {
   return Math.min(Math.max(1, Math.trunc(limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
 }
@@ -195,7 +209,7 @@ function parseExcludeActivityIds(excludeActivityIds?: string): string[] {
 // allow unintended record access. Hallucinated or malformed SOQL that passes this check returns a
 // Salesforce API error surfaced to the caller.
 function validateWhereClause(whereClause: string): void {
-  if (SOQL_INJECTION_PATTERN.test(whereClause)) {
+  if (hasDisallowedSoqlSequenceOutsideString(whereClause)) {
     throw new Error(
       "whereClause contains disallowed patterns (;  --  /*  */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
         "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6832,6 +6832,72 @@ actions:
           error:
             type: string
             description: The error that occurred if the report metadata was not successfully retrieved
+    getCleanActivityRecords:
+      displayName: Get clean activity records
+      description: >
+        Retrieve Salesforce activity records (Task or EmailMessage) with email content cleaned of HTML markup,
+        quoted reply chains, and signature blocks. Task and EmailMessage records are deduplicated into threads, reducing
+        token usage by up to 96% compared to raw records. For Task, queries are automatically scoped to TaskSubtype = 'Email'
+        and sorted by the actual email-sent timestamp before Salesforce sync timestamps, because manually synced emails can
+        be synced long after they were sent.
+      scopes: []
+      parameters:
+        type: object
+        required: [objectType, whereClause]
+        properties:
+          objectType:
+            type: string
+            enum: [Task, EmailMessage]
+            description: "The Salesforce activity object to query: Task or EmailMessage"
+          whereClause:
+            type: string
+            description: SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.
+          limit:
+            type: number
+            description: Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.
+          maxBodyLength:
+            type: number
+            description: Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.
+          returnActivityIds:
+            type: boolean
+            description: "EmailMessage only — when true, performs a separate ActivityId-only query using the same whereClause and returns a complete activityIds string (JSON array) of Task IDs auto-generated alongside matching EmailMessage records. Pass this string directly as excludeActivityIds in a subsequent Task query to avoid returning the same communications twice."
+          excludeActivityIds:
+            type: string
+            description: "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required."
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the records were successfully retrieved
+          objectType:
+            type: string
+            description: The object type that was queried
+          totalFetched:
+            type: number
+            description: Number of raw records returned from Salesforce
+          totalThreads:
+            type: number
+            description: Number of deduplicated threads
+          threads:
+            type: array
+            description: Deduplicated email threads
+            items:
+              type: object
+              additionalProperties: true
+          activityIds:
+            type: string
+            description: "EmailMessage only, returnActivityIds=true — complete JSON array string of Task IDs auto-generated alongside matching EmailMessage records. This list is not capped by the body result limit."
+          hasMore:
+            type: boolean
+            description: True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.
+          hasMoreMessage:
+            type: string
+            description: Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.
+          error:
+            type: string
+            description: The error that occurred if the records were not successfully retrieved
   microsoft:
     createDocument:
       displayName: Create a document


### PR DESCRIPTION
## Summary
- add salesforce.getCleanActivityRecords for cleaned/deduplicated Task and EmailMessage activity threads
- support EmailMessage ActivityId collection for Task de-duplication
- guard SOQL interpolation, validate excludeActivityIds, and keep EmailMessageRelation semi-joins top-level for date-filtered queries

## Verification
- npm.cmd run jest-test -- src/actions/providers/salesforce/getCleanActivityRecords.test.ts
- npx.cmd eslint "src/**/*.{js,ts}"
- npx.cmd prettier --check src/actions/actionMapper.ts src/actions/autogen/templates.ts src/actions/autogen/types.ts src/actions/providers/salesforce/getCleanActivityRecords.test.ts src/actions/providers/salesforce/getCleanActivityRecords.ts src/actions/schema.yaml
- npm.cmd run build

Note: full local npm.cmd run prettier-check on Windows reports CRLF formatting warnings for existing untouched files in the checkout, so I verified the PR files directly to avoid rewriting unrelated files.