### PR TITLE
Add salesforce/getCleanActivityRecords action

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -288,6 +288,8 @@ import {
   slackGetChannelMembersOutputSchema,
   salesforceGetReportMetadataParamsSchema,
   salesforceGetReportMetadataOutputSchema,
+  salesforceGetCleanActivityRecordsParamsSchema,
+  salesforceGetCleanActivityRecordsOutputSchema,
   googleOauthUpdateRowsInSpreadsheetParamsSchema,
   googleOauthUpdateRowsInSpreadsheetOutputSchema,
 } from "./autogen/types.js";
@@ -436,6 +438,7 @@ import searchAllSalesforceRecords from "./providers/salesforce/searchAllSalesfor
 import listReports from "./providers/salesforce/listReports.js";
 import getReportMetadata from "./providers/salesforce/getReportMetadata.js";
 import executeReport from "./providers/salesforce/executeReport.js";
+import getCleanActivityRecords from "./providers/salesforce/getCleanActivityRecords.js";
 
 type ActionTypeSchema = "read" | "write";
 
@@ -1186,6 +1189,12 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: getReportMetadata,
       paramsSchema: salesforceGetReportMetadataParamsSchema,
       outputSchema: salesforceGetReportMetadataOutputSchema,
+      actionType: "read",
+    },
+    getCleanActivityRecords: {
+      fn: getCleanActivityRecords,
+      paramsSchema: salesforceGetCleanActivityRecordsParamsSchema,
+      outputSchema: salesforceGetCleanActivityRecordsOutputSchema,
       actionType: "read",
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11466,6 +11466,106 @@ export const salesforceGetReportMetadataDefinition: ActionTemplate = {
   name: "getReportMetadata",
   provider: "salesforce",
 };
+export const salesforceGetCleanActivityRecordsDefinition: ActionTemplate = {
+  displayName: "Get clean activity records",
+  description:
+    "Retrieve Salesforce email activity from Task or EmailMessage records, clean email bodies, and deduplicate results into threads. Use this when an agent needs concise email history related to a record, contact, lead, or case.\n",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["objectType", "whereClause"],
+    properties: {
+      objectType: {
+        type: "string",
+        enum: ["Task", "EmailMessage"],
+        description: "The Salesforce activity object to query: Task or EmailMessage",
+      },
+      whereClause: {
+        type: "string",
+        description:
+          "SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.",
+      },
+      limit: {
+        type: "number",
+        description:
+          "Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.",
+      },
+      maxBodyLength: {
+        type: "number",
+        description:
+          "Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.",
+      },
+      returnActivityIds: {
+        type: "boolean",
+        description:
+          "EmailMessage only — when true, returns an activityIds string (JSON array) of Task IDs auto-generated alongside the fetched EmailMessage records. The IDs are limited to the EmailMessages returned by this call and can be passed directly as excludeActivityIds in a subsequent Task query over the same scope.",
+      },
+      excludeActivityIds: {
+        type: "string",
+        description:
+          "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required.",
+      },
+      taskDateTimeTieBreakerField: {
+        type: "string",
+        description:
+          "Task only — optional Task Date/Time field API name used before ActivityDate to order synced email Tasks by true sent time. This is intended for Groove-style fields such as groove_email_sent_at__c. The field API name must match [A-Za-z_][A-Za-z0-9_]* — names failing this check are rejected immediately. Unrecognized but syntactically valid field names produce a Salesforce API error at query time.",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the records were successfully retrieved",
+      },
+      objectType: {
+        type: "string",
+        description: "The object type that was queried",
+      },
+      totalFetched: {
+        type: "number",
+        description: "Number of raw records returned from Salesforce",
+      },
+      totalThreads: {
+        type: "number",
+        description: "Number of deduplicated threads",
+      },
+      threads: {
+        type: "array",
+        description:
+          "Deduplicated email threads. EmailMessage threads include: parentId (Case ID when email is associated with a Case via Email-to-Case; null for Enhanced Email / inbox sync records — ParentId refers only to Case per Salesforce docs); status (0=New, 1=Read, 2=Replied, 3=Sent, 4=Forwarded — Draft records are excluded); hasAttachment; fromName; replyToEmailMessageId (set for Email-to-Case reply chains), ccAddress.",
+        items: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      activityIds: {
+        type: "string",
+        description:
+          "EmailMessage only, returnActivityIds=true — JSON array string of non-null ActivityId values from the fetched EmailMessage records. This is 1:1 with the current result window and does not include ActivityIds beyond the applied limit.",
+      },
+      hasMore: {
+        type: "boolean",
+        description:
+          "True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.",
+      },
+      hasMoreMessage: {
+        type: "string",
+        description:
+          "Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the records were not successfully retrieved",
+      },
+    },
+  },
+  name: "getCleanActivityRecords",
+  provider: "salesforce",
+};
 export const microsoftCreateDocumentDefinition: ActionTemplate = {
   displayName: "Create a document",
   description: "Creates a new Office365 document",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -145,6 +145,7 @@ export enum ActionName {
   GETSALESFORCERECORDSBYQUERY = "getSalesforceRecordsByQuery",
   GETRECORD = "getRecord",
   GETREPORTMETADATA = "getReportMetadata",
+  GETCLEANACTIVITYRECORDS = "getCleanActivityRecords",
   CREATEDOCUMENT = "createDocument",
   UPDATEDOCUMENT = "updateDocument",
   MESSAGETEAMSCHAT = "messageTeamsChat",
@@ -6036,6 +6037,88 @@ export type salesforceGetReportMetadataFunction = ActionFunction<
   salesforceGetReportMetadataParamsType,
   AuthParamsType,
   salesforceGetReportMetadataOutputType
+>;
+
+export const salesforceGetCleanActivityRecordsParamsSchema = z.object({
+  objectType: z
+    .enum(["Task", "EmailMessage"])
+    .describe("The Salesforce activity object to query: Task or EmailMessage"),
+  whereClause: z
+    .string()
+    .describe(
+      "SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.",
+    ),
+  limit: z
+    .number()
+    .describe(
+      "Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.",
+    )
+    .optional(),
+  maxBodyLength: z
+    .number()
+    .describe(
+      "Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.",
+    )
+    .optional(),
+  returnActivityIds: z
+    .boolean()
+    .describe(
+      "EmailMessage only — when true, returns an activityIds string (JSON array) of Task IDs auto-generated alongside the fetched EmailMessage records. The IDs are limited to the EmailMessages returned by this call and can be passed directly as excludeActivityIds in a subsequent Task query over the same scope.",
+    )
+    .optional(),
+  excludeActivityIds: z
+    .string()
+    .describe(
+      "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required.",
+    )
+    .optional(),
+  taskDateTimeTieBreakerField: z
+    .string()
+    .describe(
+      "Task only — optional Task Date/Time field API name used before ActivityDate to order synced email Tasks by true sent time. This is intended for Groove-style fields such as groove_email_sent_at__c. The field API name must match [A-Za-z_][A-Za-z0-9_]* — names failing this check are rejected immediately. Unrecognized but syntactically valid field names produce a Salesforce API error at query time.",
+    )
+    .optional(),
+});
+
+export type salesforceGetCleanActivityRecordsParamsType = z.infer<typeof salesforceGetCleanActivityRecordsParamsSchema>;
+
+export const salesforceGetCleanActivityRecordsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the records were successfully retrieved"),
+  objectType: z.string().describe("The object type that was queried").optional(),
+  totalFetched: z.number().describe("Number of raw records returned from Salesforce").optional(),
+  totalThreads: z.number().describe("Number of deduplicated threads").optional(),
+  threads: z
+    .array(z.object({}).catchall(z.any()))
+    .describe(
+      "Deduplicated email threads. EmailMessage threads include: parentId (Case ID when email is associated with a Case via Email-to-Case; null for Enhanced Email / inbox sync records — ParentId refers only to Case per Salesforce docs); status (0=New, 1=Read, 2=Replied, 3=Sent, 4=Forwarded — Draft records are excluded); hasAttachment; fromName; replyToEmailMessageId (set for Email-to-Case reply chains), ccAddress.",
+    )
+    .optional(),
+  activityIds: z
+    .string()
+    .describe(
+      "EmailMessage only, returnActivityIds=true — JSON array string of non-null ActivityId values from the fetched EmailMessage records. This is 1:1 with the current result window and does not include ActivityIds beyond the applied limit.",
+    )
+    .optional(),
+  hasMore: z
+    .boolean()
+    .describe(
+      "True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.",
+    )
+    .optional(),
+  hasMoreMessage: z
+    .string()
+    .describe(
+      "Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.",
+    )
+    .optional(),
+  error: z.string().describe("The error that occurred if the records were not successfully retrieved").optional(),
+});
+
+export type salesforceGetCleanActivityRecordsOutputType = z.infer<typeof salesforceGetCleanActivityRecordsOutputSchema>;
+export type salesforceGetCleanActivityRecordsFunction = ActionFunction<
+  salesforceGetCleanActivityRecordsParamsType,
+  AuthParamsType,
+  salesforceGetCleanActivityRecordsOutputType
 >;
 
 export const microsoftCreateDocumentParamsSchema = z.object({

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -1,0 +1,905 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  buildEmailMessageQuery,
+  cleanBody,
+  compareTaskEmailRecords,
+  detectTaskDirection,
+  normalizeEmailHeaderText,
+  normalizeLimit,
+  normalizeSubject,
+  parseExcludeActivityIds,
+  soqlQuery,
+  truncate,
+  validateWhereClause,
+} from "./getCleanActivityRecords.js";
+import getCleanActivityRecords from "./getCleanActivityRecords.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
+
+jest.mock("../../util/axiosClient.js", () => ({
+  ApiError: class ApiError extends Error {
+    data?: unknown;
+  },
+  axiosClient: { get: (...args: any[]) => mockGet(...args) },
+}));
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe("salesforceGetCleanActivityRecords non-Groove Task body cleaning", () => {
+  test("strips Body: label from Salesforce Gmail extension format", () => {
+    const desc = [
+      "To: customer@example.com",
+      "CC: ",
+      "BCC: ",
+      "Attachment: --none--",
+      "",
+      "Subject: Re: ExampleCo Installation Next Steps",
+      "Body:",
+      "Hey Customer,",
+      "I hope you're having an excellent week.",
+      "",
+    ].join("\n");
+
+    const result = cleanBody(desc);
+    expect(result).not.toContain("Body:");
+    expect(result).toContain("Hey Customer");
+    expect(result).not.toContain("To:");
+    expect(result).not.toContain("Subject:");
+  });
+
+  test("strips Additional To: label from BCC-to-Salesforce format", () => {
+    const desc = [
+      "Additional To: customer@example.com",
+      "CC: ",
+      "BCC: ",
+      "Attachment: ",
+      "",
+      "Subject: ExampleCo Case - Re: Invoice",
+      "Body:",
+      "Thank you for reaching out to the ExampleCo Customer Experience Team!",
+      "",
+    ].join("\n");
+
+    const result = cleanBody(desc);
+    expect(result).not.toContain("Additional To:");
+    expect(result).not.toContain("Body:");
+    expect(result).toContain("Thank you for reaching out");
+  });
+
+  test("converts entity-encoded email addresses to bracket notation", () => {
+    const body = "Please reply to &lt;support@example.com&gt; for help.";
+    const result = cleanBody(body);
+    expect(result).toContain("[support@example.com]");
+    expect(result).not.toContain("&lt;");
+    expect(result).not.toContain("&gt;");
+  });
+
+  test("strips quoted reply that begins with '> On ... wrote:'", () => {
+    const body =
+      "From: customer@example.com\r\nTo: Rep Example <rep@example.com>\r\n\r\nThis is different usually I just get an invoice\r\n \r\nExample Customer, Owner\r\n\r\n> On 05/05/2026 7:08 PM EDT Example App <system@example.com> wrote:\r\n>  \r\n> \r\n> Some quoted body content\r\n";
+    const result = cleanBody(body);
+    expect(result).toContain("This is different usually I just get an invoice");
+    expect(result).not.toContain("> On 05/05/2026");
+    expect(result).not.toContain("Some quoted body content");
+  });
+
+  test("strips headers from HTML Task descriptions that use br line breaks", () => {
+    const desc =
+      "To: customer@example.com<br>CC: <br>BCC: <br>Attachment: --none--<br><br>Subject: Re: Install<br>Body:<br>Here is the update.";
+
+    const result = cleanBody(desc);
+
+    expect(result).toBe("Here is the update.");
+    expect(result).not.toContain("To:");
+    expect(result).not.toContain("Subject:");
+    expect(result).not.toContain("Body:");
+  });
+});
+
+describe("salesforceGetCleanActivityRecords non-Groove Task direction detection", () => {
+  test("detects outbound from To: header when owner is the sender", () => {
+    const desc = "To: customer@example.com\nCC: \nBCC: \n\nSubject: Re: Install\nBody:\nHey Customer";
+    expect(detectTaskDirection("Email: Re: Install", desc, "rep@example.com")).toBe("outbound");
+  });
+
+  test("detects inbound from To: header when owner is the recipient", () => {
+    const desc = "To: rep@example.com\nCC: \nBCC: \n\nSubject: Re: Install\nBody:\nHey Rep";
+    expect(detectTaskDirection("Email: Re: Install", desc, "rep@example.com")).toBe("inbound");
+  });
+
+  test("returns unknown when no direction signals and no ownerEmail", () => {
+    const desc = "To: customer@example.com\nCC: \n\nSome body text";
+    expect(detectTaskDirection("Email: Re: Install", desc, null)).toBe("unknown");
+  });
+
+  test("still detects Groove outbound from >> subject marker", () => {
+    const desc = "From: rep@example.com\nTo: customer@example.com\n\nHey there";
+    expect(detectTaskDirection("Email: >> Re: Proposal", desc, "rep@example.com")).toBe("outbound");
+  });
+
+  test("still detects Groove inbound from << subject marker", () => {
+    const desc = "From: customer@example.com\nTo: rep@example.com\n\nHey there";
+    expect(detectTaskDirection("Email: << [Inbox] - Re: Proposal", desc, "rep@example.com")).toBe("inbound");
+  });
+});
+
+describe("salesforceGetCleanActivityRecords Task email chronology", () => {
+  test("orders email Task records by standard ActivityDate instead of custom fields or sync timestamps", () => {
+    const olderEmailSyncedLater = {
+      Id: "00T000000000001AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-04-01",
+      CreatedDate: "2026-05-06T14:00:00.000+0000",
+      LastModifiedDate: "2026-05-06T14:00:00.000+0000",
+    };
+    const newerEmailSyncedEarlier = {
+      Id: "00T000000000002AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-05-05",
+      CreatedDate: "2026-05-05T16:00:00.000+0000",
+      LastModifiedDate: "2026-05-05T16:00:00.000+0000",
+    };
+
+    const sorted = [olderEmailSyncedLater, newerEmailSyncedEarlier].sort(compareTaskEmailRecords);
+
+    expect(sorted[0]?.Id).toBe("00T000000000002AAA");
+  });
+
+  test("normalizes bounced email subject prefixes into the base thread subject", () => {
+    expect(normalizeSubject("Bounced: >> Re: Pricing follow-up")).toBe("Pricing follow-up");
+  });
+
+  test("uses custom Task DateTime field ahead of ActivityDate when provided", () => {
+    const olderActivityDateSentLater = {
+      Id: "00T000000000001AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-04-01",
+      groove_email_sent_at__c: "2026-05-06T14:00:00.000+0000",
+      CreatedDate: "2026-04-01T14:00:00.000+0000",
+      LastModifiedDate: "2026-04-01T14:00:00.000+0000",
+    };
+    const newerActivityDateSentEarlier = {
+      Id: "00T000000000002AAA",
+      Subject: "Email: >> Pricing follow-up",
+      ActivityDate: "2026-05-05",
+      groove_email_sent_at__c: "2026-05-05T16:00:00.000+0000",
+      CreatedDate: "2026-05-05T16:00:00.000+0000",
+      LastModifiedDate: "2026-05-05T16:00:00.000+0000",
+    };
+
+    const sorted = [olderActivityDateSentLater, newerActivityDateSentEarlier].sort((a, b) =>
+      compareTaskEmailRecords(a, b, "groove_email_sent_at__c"),
+    );
+
+    expect(sorted[0]?.Id).toBe("00T000000000001AAA");
+  });
+});
+
+describe("salesforceGetCleanActivityRecords EmailMessage exclusions", () => {
+  test("rejects excludeActivityIds on EmailMessage instead of silently ignoring it", async () => {
+    await expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "EmailMessage",
+          whereClause: "RelatedToId = '500Qp0000012345AAA'",
+          excludeActivityIds: JSON.stringify(["00T000000000001AAA"]),
+        },
+        authParams: {
+          authToken: "token",
+          baseUrl: "https://example.my.salesforce.com",
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: "excludeActivityIds is only supported when objectType is Task",
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test("wraps compound semi-join clause to protect appended AND filters from OR precedence", () => {
+    const whereClause =
+      "Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE (Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z) AND IsDeleted = false AND Status != '5' ORDER BY",
+    );
+  });
+
+  test("unwraps agent-supplied parentheses around EmailMessageRelation semi-joins then re-wraps the compound expression", () => {
+    const whereClause =
+      "(Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0')) AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE (Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003Qp00000cMnCQIA0') AND MessageDate >= 2026-01-01T00:00:00Z) AND IsDeleted = false AND Status != '5' ORDER BY",
+    );
+  });
+
+  test("unwraps parenthesized semi-joins with nested parentheses inside the subquery then re-wraps the compound expression", () => {
+    const whereClause =
+      "(Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId IN ('003Qp00000cMnCQIA0', '003Qp00000cMnCQIA1'))) AND MessageDate >= 2026-01-01T00:00:00Z";
+
+    expect(buildEmailMessageQuery(whereClause, 100)).toContain(
+      "FROM EmailMessage WHERE (Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId IN ('003Qp00000cMnCQIA0', '003Qp00000cMnCQIA1')) AND MessageDate >= 2026-01-01T00:00:00Z) AND IsDeleted = false AND Status != '5' ORDER BY",
+    );
+  });
+
+  test("rejects malformed excludeActivityIds JSON", () => {
+    expect(() => parseExcludeActivityIds("not-json")).toThrow("excludeActivityIds must be a JSON array string");
+  });
+
+  test("rejects non-Salesforce IDs instead of silently dropping them", () => {
+    expect(() => parseExcludeActivityIds(JSON.stringify(["00T000000000001AAA", "bad-id"]))).toThrow(
+      "excludeActivityIds contains invalid Salesforce IDs: bad-id",
+    );
+  });
+
+  test("returns valid unique Salesforce IDs", () => {
+    expect(parseExcludeActivityIds(JSON.stringify(["00T000000000001AAA", "00T000000000001AAA"]))).toEqual([
+      "00T000000000001AAA",
+    ]);
+  });
+});
+
+describe("salesforceGetCleanActivityRecords Task filters", () => {
+  test("only queries completed email Tasks", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [],
+        done: true,
+      },
+    });
+
+    await getCleanActivityRecords({
+      params: {
+        objectType: "Task",
+        whereClause: "WhatId = 'a3bQp000001h4J7IAI'",
+      },
+      authParams: {
+        authToken: "token",
+        baseUrl: "https://example.my.salesforce.com",
+      },
+    });
+
+    const requestUrl = String(mockGet.mock.calls[0]?.[0]);
+    const soql = decodeURIComponent(new URL(requestUrl).searchParams.get("q") ?? "");
+    expect(soql).toContain("TaskSubtype = 'Email'");
+    expect(soql).toContain("Status = 'Completed'");
+    expect(soql).toContain("IsDeleted = false");
+    expect(soql).toContain("CompletedDateTime");
+    expect(soql).toContain("ORDER BY ActivityDate DESC NULLS LAST, CompletedDateTime DESC NULLS LAST");
+    expect(soql).not.toContain("__c");
+  });
+
+  test("uses an optional Task DateTime tie-breaker field for Groove-style same-day email chronology", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "00T000000000001AAA",
+            Subject: "Email: >> Re: ExampleCo Inquiry",
+            ActivityDate: "2026-05-05",
+            CompletedDateTime: "2026-05-05T20:00:00.000+0000",
+            groove_email_sent_at__c: "2026-05-05T10:00:00.000+0000",
+            Description: "From: rep@example.com\nTo: customer@example.com\n\nEarlier reply",
+          },
+          {
+            Id: "00T000000000002AAA",
+            Subject: "Email: >> Re: ExampleCo Inquiry",
+            ActivityDate: "2026-05-05",
+            CompletedDateTime: "2026-05-05T19:00:00.000+0000",
+            groove_email_sent_at__c: "2026-05-05T15:00:00.000+0000",
+            Description: "From: rep@example.com\nTo: customer@example.com\n\nLater reply",
+          },
+        ],
+        done: true,
+      },
+    });
+
+    const result = await getCleanActivityRecords({
+      params: {
+        objectType: "Task",
+        whereClause: "WhatId = 'a3bQp000001h4J7IAI'",
+        taskDateTimeTieBreakerField: "groove_email_sent_at__c",
+      },
+      authParams: {
+        authToken: "token",
+        baseUrl: "https://example.my.salesforce.com",
+      },
+    });
+
+    const taskRequestUrl = String(mockGet.mock.calls[0]?.[0]);
+    const taskSoql = decodeURIComponent(new URL(taskRequestUrl).searchParams.get("q") ?? "");
+    expect(taskSoql).toContain("groove_email_sent_at__c");
+    expect(taskSoql).toContain(
+      "ORDER BY groove_email_sent_at__c DESC NULLS LAST, ActivityDate DESC NULLS LAST, CompletedDateTime DESC NULLS LAST",
+    );
+    expect(result).toMatchObject({
+      success: true,
+      threads: [{ latestTaskId: "00T000000000002AAA", latestDate: "2026-05-05T15:00:00.000+0000" }],
+    });
+  });
+
+  test("does not merge unrelated Tasks when subject and related records are missing", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "00T000000000001AAA",
+            Subject: null,
+            ActivityDate: "2026-05-05",
+            CompletedDateTime: "2026-05-05T20:00:00.000+0000",
+            WhoId: null,
+            WhatId: null,
+            Description: "First unrelated email",
+          },
+          {
+            Id: "00T000000000002AAA",
+            Subject: "",
+            ActivityDate: "2026-05-04",
+            CompletedDateTime: "2026-05-04T20:00:00.000+0000",
+            WhoId: null,
+            WhatId: null,
+            Description: "Second unrelated email",
+          },
+        ],
+        done: true,
+      },
+    });
+
+    const result = await getCleanActivityRecords({
+      params: {
+        objectType: "Task",
+        whereClause: "OwnerId = '005Qp0000012345AAA'",
+      },
+      authParams: {
+        authToken: "token",
+        baseUrl: "https://example.my.salesforce.com",
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      totalFetched: 2,
+      totalThreads: 2,
+      threads: [
+        { latestTaskId: "00T000000000001AAA", threadSize: 1, allTaskIds: ["00T000000000001AAA"] },
+        { latestTaskId: "00T000000000002AAA", threadSize: 1, allTaskIds: ["00T000000000002AAA"] },
+      ],
+    });
+  });
+
+  test("rejects taskDateTimeTieBreakerField values that are not valid field API names", () => {
+    return expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "Task",
+          whereClause: "WhatId = 'a3bQp000001h4J7IAI'",
+          taskDateTimeTieBreakerField: "bad field name!",
+        },
+        authParams: {
+          authToken: "token",
+          baseUrl: "https://example.my.salesforce.com",
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: "taskDateTimeTieBreakerField must be a valid Task field API name",
+    });
+  });
+});
+
+describe("salesforceGetCleanActivityRecords input guards", () => {
+  test("allows disallowed SOQL guard sequences inside quoted string literals", () => {
+    expect(() =>
+      validateWhereClause("Subject LIKE '%Q2--Q3%' AND Description LIKE '%/* note */%' AND Subject != ';'"),
+    ).not.toThrow();
+  });
+
+  test("allows disallowed SOQL guard sequences after an escaped quote inside a string literal", () => {
+    expect(() => validateWhereClause("Subject LIKE 'Bob\\'s -- note%'")).not.toThrow();
+    expect(() => validateWhereClause("Subject LIKE 'Bob\\'s /* note */%'")).not.toThrow();
+  });
+
+  test("ignores parentheses and semi-join-looking text inside escaped string literals", () => {
+    const whereClause = "Subject LIKE 'Bob\\'s IN (SELECT phase%)' OR WhatId = '500Qp0000012345AAA'";
+
+    expect(() => validateWhereClause(whereClause)).not.toThrow();
+    expect(buildEmailMessageQuery(whereClause, 20)).toContain(`WHERE (${whereClause})`);
+  });
+
+  test("rejects disallowed SOQL guard sequences outside quoted string literals", () => {
+    expect(() => validateWhereClause("Subject LIKE '%Q2%' -- ignored")).toThrow(
+      "whereClause contains disallowed patterns",
+    );
+  });
+
+  test("rejects unbalanced parentheses that could break appended filters", () => {
+    expect(() => validateWhereClause("1=1) OR (1=1")).toThrow("whereClause contains unbalanced parentheses");
+    expect(() => validateWhereClause("Subject LIKE '%(safe)%' AND WhoId = '003Qp00000cMnCQIA0'")).not.toThrow();
+  });
+
+  test("floors negative and zero limits at one", () => {
+    expect(normalizeLimit(-5)).toBe(1);
+    expect(normalizeLimit(0)).toBe(1);
+    expect(normalizeLimit(200)).toBe(100);
+    expect(normalizeLimit(undefined)).toBe(20);
+  });
+});
+
+describe("salesforceGetCleanActivityRecords Salesforce query pagination", () => {
+  test("follows Salesforce nextRecordsUrl pages", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "02sQp0000000001AAA" }],
+          done: false,
+          nextRecordsUrl: "/services/data/v56.0/query/01gQp0000000001-2000",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "02sQp0000000002AAA" }],
+          done: true,
+        },
+      });
+
+    await expect(
+      soqlQuery("https://example.my.salesforce.com", "token", "SELECT Id FROM EmailMessage"),
+    ).resolves.toEqual([{ Id: "02sQp0000000001AAA" }, { Id: "02sQp0000000002AAA" }]);
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(mockGet.mock.calls[1]?.[0]).toBe(
+      "https://example.my.salesforce.com/services/data/v56.0/query/01gQp0000000001-2000",
+    );
+  });
+});
+
+describe("salesforceGetCleanActivityRecords — queryAll endpoint", () => {
+  test("Task query uses /queryAll not /query", async () => {
+    mockGet.mockResolvedValueOnce({ data: { records: [], done: true } });
+
+    await getCleanActivityRecords({
+      params: { objectType: "Task", whereClause: "WhatId = 'a3bQp000001h4J7IAI'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    const requestUrl = String(mockGet.mock.calls[0]?.[0]);
+    expect(requestUrl).toContain("/queryAll?");
+    expect(requestUrl).not.toContain("/query?");
+  });
+
+  test("EmailMessage query uses /queryAll not /query", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: { records: [], done: true } })
+      .mockResolvedValueOnce({ data: { records: [], done: true } });
+
+    await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    const requestUrl = String(mockGet.mock.calls[0]?.[0]);
+    expect(requestUrl).toContain("/queryAll?");
+    expect(requestUrl).not.toContain("/query?");
+  });
+
+  test("returnActivityIds returns only ActivityIds from fetched EmailMessage records", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            {
+              Id: "02sQp0000000001AAA",
+              Subject: "Re: Invoice",
+              MessageDate: "2026-05-01T10:00:00.000+0000",
+              Incoming: true,
+              IsBounced: false,
+              FromAddress: "customer@example.com",
+              ToAddress: "rep@example.com",
+              TextBody: "First message.",
+              ThreadIdentifier: "thread-activity-ids",
+              MessageIdentifier: "msg-001",
+              RelatedToId: "500Qp0000012345AAA",
+              ActivityId: "00TQp000001abcDEF",
+            },
+            {
+              Id: "02sQp0000000002AAA",
+              Subject: "Re: Invoice",
+              MessageDate: "2026-05-01T11:00:00.000+0000",
+              Incoming: false,
+              IsBounced: false,
+              FromAddress: "rep@example.com",
+              ToAddress: "customer@example.com",
+              TextBody: "Second message.",
+              ThreadIdentifier: "thread-activity-ids",
+              MessageIdentifier: "msg-002",
+              RelatedToId: "500Qp0000012345AAA",
+              ActivityId: "00TQp000001abcDEG",
+            },
+            {
+              Id: "02sQp0000000003AAA",
+              Subject: "Re: Invoice",
+              MessageDate: "2026-05-01T12:00:00.000+0000",
+              Incoming: false,
+              IsBounced: false,
+              FromAddress: "rep@example.com",
+              ToAddress: "customer@example.com",
+              TextBody: "Overflow message.",
+              ThreadIdentifier: "thread-activity-ids",
+              MessageIdentifier: "msg-003",
+              RelatedToId: "500Qp0000012345AAA",
+              ActivityId: "00TQp000001abcDEH",
+            },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({ data: { records: [], done: true } });
+
+    const result = await getCleanActivityRecords({
+      params: {
+        objectType: "EmailMessage",
+        whereClause: "RelatedToId = '500Qp0000012345AAA'",
+        limit: 2,
+        returnActivityIds: true,
+      },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    expect(result).toMatchObject({ success: true, totalFetched: 2, hasMore: true });
+    expect(result.activityIds).toBe(JSON.stringify(["00TQp000001abcDEF", "00TQp000001abcDEG"]));
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(decodeURIComponent(new URL(String(mockGet.mock.calls[0]?.[0])).searchParams.get("q") ?? "")).toContain(
+      "LIMIT 3",
+    );
+  });
+});
+
+describe("salesforceGetCleanActivityRecords EmailMessage people resolution", () => {
+  test("resolves people via EmailMessageRelation → Contact", async () => {
+    // 1. Main EmailMessage query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "02sQp0000000001AAA",
+            Subject: "Re: Invoice",
+            MessageDate: "2026-05-01T10:00:00.000+0000",
+            Incoming: true,
+            IsBounced: false,
+            FromAddress: "customer@example.com",
+            ToAddress: "rep@butterflymx.com",
+            TextBody: "Please send the updated invoice.",
+            ThreadIdentifier: "thread-abc",
+            MessageIdentifier: "msg-001",
+            RelatedToId: "500Qp0000012345AAA",
+            ActivityId: "00TQp000001abcDEF",
+          },
+        ],
+        done: true,
+      },
+    });
+    // 2. EmailMessageRelation query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          { EmailMessageId: "02sQp0000000001AAA", RelationId: "003Qp00000HyTFBIA3", RelationObjectType: "Contact" },
+        ],
+        done: true,
+      },
+    });
+    // 3. Contact query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [{ Id: "003Qp00000HyTFBIA3", Name: "Alice Smith", Email: "customer@example.com", Title: "Manager" }],
+        done: true,
+      },
+    });
+
+    const result = await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      threads: [
+        {
+          threadIdentifier: "thread-abc",
+          people: [{ id: "003Qp00000HyTFBIA3", name: "Alice Smith", email: "customer@example.com", title: "Manager" }],
+        },
+      ],
+    });
+    // Verify the EmailMessageRelation query was actually issued
+    const relationCall = mockGet.mock.calls[1]?.[0] as string;
+    expect(decodeURIComponent(new URL(relationCall).searchParams.get("q") ?? "")).toContain("EmailMessageRelation");
+  });
+
+  test("returns CcAddress from the latest EmailMessage thread record", async () => {
+    // 1. Main EmailMessage query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "02sQp0000000003AAA",
+            Subject: "Re: Invoice",
+            MessageDate: "2026-05-03T10:00:00.000+0000",
+            Incoming: false,
+            IsBounced: false,
+            FromAddress: "rep@butterflymx.com",
+            ToAddress: "customer@example.com",
+            CcAddress: "accounting@example.com",
+            TextBody: "Looping in accounting.",
+            ThreadIdentifier: "thread-cc",
+            MessageIdentifier: "msg-003",
+            RelatedToId: "500Qp0000012345AAA",
+            ActivityId: "00TQp000001abcDEG",
+          },
+        ],
+        done: true,
+      },
+    });
+    // 2. EmailMessageRelation query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          { EmailMessageId: "02sQp0000000003AAA", RelationId: "003Qp00000HyTFBIA3", RelationObjectType: "Contact" },
+        ],
+        done: true,
+      },
+    });
+    // 3. Contact query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [{ Id: "003Qp00000HyTFBIA3", Name: "Alice Smith", Email: "customer@example.com", Title: "Manager" }],
+        done: true,
+      },
+    });
+
+    const result = await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      threads: [
+        {
+          threadIdentifier: "thread-cc",
+          toAddress: "customer@example.com",
+          ccAddress: "accounting@example.com",
+          people: [{ id: "003Qp00000HyTFBIA3", name: "Alice Smith", email: "customer@example.com", title: "Manager" }],
+        },
+      ],
+    });
+  });
+
+  test("falls back to Lead when Contact lookup returns no results", async () => {
+    // 1. Main EmailMessage query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "02sQp0000000002AAA",
+            Subject: "Demo request",
+            MessageDate: "2026-05-02T09:00:00.000+0000",
+            Incoming: true,
+            IsBounced: false,
+            FromAddress: "lead@prospect.com",
+            ToAddress: "rep@butterflymx.com",
+            TextBody: "I would like a demo.",
+            ThreadIdentifier: "thread-xyz",
+            MessageIdentifier: "msg-002",
+            RelatedToId: null,
+            ActivityId: null,
+          },
+        ],
+        done: true,
+      },
+    });
+    // 2. EmailMessageRelation query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          { EmailMessageId: "02sQp0000000002AAA", RelationId: "00QQp00000HyTFBIA3", RelationObjectType: "Lead" },
+        ],
+        done: true,
+      },
+    });
+    // 3. Contact query — returns nothing (it's a Lead)
+    mockGet.mockResolvedValueOnce({ data: { records: [], done: true } });
+    // 4. Lead fallback query
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [{ Id: "00QQp00000HyTFBIA3", Name: "Bob Lead", Email: "lead@prospect.com", Title: null }],
+        done: true,
+      },
+    });
+
+    const result = await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      threads: [
+        {
+          people: [{ id: "00QQp00000HyTFBIA3", name: "Bob Lead", email: "lead@prospect.com", title: null }],
+        },
+      ],
+    });
+  });
+});
+
+describe("salesforceGetCleanActivityRecords EmailMessage bounced semantics", () => {
+  test("thread is bounced when any message in the thread bounced, not just the latest", async () => {
+    // Main EmailMessage query — two messages in same thread; older one bounced, latest did not
+    mockGet.mockResolvedValueOnce({
+      data: {
+        records: [
+          {
+            Id: "02sQp0000000002AAA",
+            Subject: "Delivery notification",
+            MessageDate: "2026-05-02T12:00:00.000+0000",
+            Incoming: false,
+            IsBounced: false,
+            FromAddress: "rep@butterflymx.com",
+            ToAddress: "customer@example.com",
+            TextBody: "Retry send.",
+            ThreadIdentifier: "thread-bounce",
+            MessageIdentifier: "msg-002",
+            RelatedToId: null,
+            ActivityId: null,
+          },
+          {
+            Id: "02sQp0000000001AAA",
+            Subject: "Delivery notification",
+            MessageDate: "2026-05-01T10:00:00.000+0000",
+            Incoming: false,
+            IsBounced: true,
+            FromAddress: "rep@butterflymx.com",
+            ToAddress: "customer@example.com",
+            TextBody: "Original send.",
+            ThreadIdentifier: "thread-bounce",
+            MessageIdentifier: "msg-001",
+            RelatedToId: null,
+            ActivityId: null,
+          },
+        ],
+        done: true,
+      },
+    });
+    // EmailMessageRelation — no relations for these messages
+    mockGet.mockResolvedValueOnce({ data: { records: [], done: true } });
+
+    const result = await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      threads: [{ threadIdentifier: "thread-bounce", bounced: true }],
+    });
+  });
+});
+
+describe("salesforceGetCleanActivityRecords normalizeEmailHeaderText", () => {
+  test("detects Task direction from HTML-encoded From header", () => {
+    const normalized = normalizeEmailHeaderText("<div>From: John Doe &lt;john@example.com&gt;</div>");
+    expect(detectTaskDirection("Email: Follow-up", normalized, "rep@example.com")).toBe("inbound");
+    expect(detectTaskDirection("Email: Follow-up", normalized, "john@example.com")).toBe("outbound");
+  });
+
+  test("strips HTML tags and decodes entities leaving plain text", () => {
+    const result = normalizeEmailHeaderText("<p>Hello &amp; goodbye</p><br/>Next line");
+    expect(result).not.toContain("<");
+    expect(result).toContain("Hello & goodbye");
+    expect(result).toContain("Next line");
+  });
+
+  test("returns null for null or empty input", () => {
+    expect(normalizeEmailHeaderText(null)).toBeNull();
+    expect(normalizeEmailHeaderText("")).toBeNull();
+    expect(normalizeEmailHeaderText("   ")).toBeNull();
+  });
+});
+
+describe("salesforceGetCleanActivityRecords containsSemiJoinSubquery string-literal safety", () => {
+  test("wraps clause in parens when IN (SELECT appears only inside a quoted literal", () => {
+    // The literal '%IN (SELECT phase%' must not be confused with a real semi-join subquery.
+    // Without this fix, the clause would skip the (…) wrapper, breaking OR operator precedence.
+    const whereClause = "Subject LIKE '%IN (SELECT phase%' OR WhatId = '500Qp0000012345AAA'";
+    expect(buildEmailMessageQuery(whereClause, 20)).toContain(`WHERE (${whereClause})`);
+  });
+
+  test("emits a bare lone semi-join without outer parens (Salesforce rejects the wrapped form)", () => {
+    const whereClause = "WhoId IN (SELECT ContactId FROM CampaignMember WHERE CampaignId = '001Qp000000abcDEF')";
+    const query = buildEmailMessageQuery(whereClause, 20);
+    expect(query).toContain(`WHERE ${whereClause}`);
+    expect(query).not.toContain(`WHERE (${whereClause})`);
+  });
+
+  test("rejects a semi-join combined with top-level OR because Salesforce SOQL does not support it", () => {
+    const whereClause =
+      "WhoId IN (SELECT ContactId FROM CampaignMember WHERE CampaignId = '001Qp000000abcDEF') OR WhatId = '001Qp000000xyzAAA'";
+    expect(() => buildEmailMessageQuery(whereClause, 20)).toThrow(
+      "whereClause contains a semi-join subquery combined with OR",
+    );
+  });
+});
+
+describe("salesforceGetCleanActivityRecords excludeActivityIds size limit", () => {
+  test("rejects excludeActivityIds lists that exceed MAX_EXCLUDE_IDS", () => {
+    const ids = Array.from({ length: 501 }, (_, i) => `00T${String(i).padStart(15, "0")}`);
+    expect(() => parseExcludeActivityIds(JSON.stringify(ids))).toThrow(/exceeds the limit of \d+/);
+  });
+
+  test("accepts excludeActivityIds lists at exactly the limit", () => {
+    const ids = Array.from({ length: 500 }, (_, i) => `00T${String(i).padStart(15, "0")}`);
+    expect(() => parseExcludeActivityIds(JSON.stringify(ids))).not.toThrow();
+  });
+});
+
+describe("salesforceGetCleanActivityRecords returnActivityIds guard", () => {
+  test("rejects returnActivityIds when objectType is Task", () => {
+    return expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "Task",
+          whereClause: "WhatId = 'a3bQp000001h4J7IAI'",
+          returnActivityIds: true,
+        },
+        authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: "returnActivityIds is only supported when objectType is EmailMessage",
+    });
+  });
+});
+
+describe("salesforceGetCleanActivityRecords empty excludeActivityIds on EmailMessage", () => {
+  test("allows an empty excludeActivityIds array on EmailMessage without error", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: { records: [], done: true } })
+      .mockResolvedValueOnce({ data: { records: [], done: true } });
+
+    await expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "EmailMessage",
+          whereClause: "RelatedToId = '500Qp0000012345AAA'",
+          excludeActivityIds: "[]",
+        },
+        authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+      }),
+    ).resolves.toMatchObject({ success: true });
+  });
+});
+
+describe("salesforceGetCleanActivityRecords truncate", () => {
+  test("returns text unchanged when at or below the limit", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  test("truncates to exactly maxLength characters including the ellipsis", () => {
+    const result = truncate("hello world", 8);
+    expect(result).toHaveLength(8);
+    expect(result).toBe("hello w…");
+  });
+
+  test("returns null for falsy input", () => {
+    expect(truncate(null, 10)).toBeNull();
+    expect(truncate("", 10)).toBeNull();
+  });
+
+  test("returns null when maxLength is zero", () => {
+    expect(truncate("hello", 0)).toBeNull();
+  });
+});

--- a/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.test.ts
@@ -389,6 +389,94 @@ describe("salesforceGetCleanActivityRecords Task filters", () => {
       error: "taskDateTimeTieBreakerField must be a valid Task field API name",
     });
   });
+
+  test("rejects injected taskDateTimeTieBreakerField values before querying Salesforce", async () => {
+    await expect(
+      getCleanActivityRecords({
+        params: {
+          objectType: "Task",
+          whereClause: "WhatId = 'a3bQp000001h4J7IAI'",
+          taskDateTimeTieBreakerField: "validField__c, (SELECT Id FROM Account)",
+        },
+        authParams: {
+          authToken: "token",
+          baseUrl: "https://example.my.salesforce.com",
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: "taskDateTimeTieBreakerField must be a valid Task field API name",
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test("partitions Contact and Lead WhoId values before Task person lookups", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            {
+              Id: "00T000000000001AAA",
+              Subject: "Email: >> Re: Contact thread",
+              ActivityDate: "2026-05-05",
+              CompletedDateTime: "2026-05-05T20:00:00.000+0000",
+              WhoId: "003Qp00000HyTFBIA3",
+              WhatId: "001Qp0000012345AAA",
+              Description: "From: rep@example.com\nTo: contact@example.com\n\nContact follow-up",
+            },
+            {
+              Id: "00T000000000002AAA",
+              Subject: "Email: >> Re: Lead thread",
+              ActivityDate: "2026-05-04",
+              CompletedDateTime: "2026-05-04T20:00:00.000+0000",
+              WhoId: "00QQp00000HyTFBIA4",
+              WhatId: "001Qp0000012345AAA",
+              Description: "From: rep@example.com\nTo: lead@example.com\n\nLead follow-up",
+            },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            { Id: "003Qp00000HyTFBIA3", Name: "Alice Contact", Email: "contact@example.com", Title: "Manager" },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "00QQp00000HyTFBIA4", Name: "Bob Lead", Email: "lead@example.com", Title: null }],
+          done: true,
+        },
+      });
+
+    const result = await getCleanActivityRecords({
+      params: {
+        objectType: "Task",
+        whereClause: "WhatId = '001Qp0000012345AAA'",
+      },
+      authParams: {
+        authToken: "token",
+        baseUrl: "https://example.my.salesforce.com",
+      },
+    });
+
+    const contactSoql = decodeURIComponent(new URL(String(mockGet.mock.calls[1]?.[0])).searchParams.get("q") ?? "");
+    const leadSoql = decodeURIComponent(new URL(String(mockGet.mock.calls[2]?.[0])).searchParams.get("q") ?? "");
+    expect(contactSoql).toContain("FROM Contact WHERE Id IN ('003Qp00000HyTFBIA3')");
+    expect(contactSoql).not.toContain("00QQp00000HyTFBIA4");
+    expect(leadSoql).toContain("FROM Lead WHERE Id IN ('00QQp00000HyTFBIA4')");
+    expect(leadSoql).not.toContain("003Qp00000HyTFBIA3");
+    expect(result).toMatchObject({
+      success: true,
+      threads: [
+        { contact: { id: "003Qp00000HyTFBIA3", name: "Alice Contact", email: "contact@example.com" } },
+        { contact: { id: "00QQp00000HyTFBIA4", name: "Bob Lead", email: "lead@example.com" } },
+      ],
+    });
+  });
 });
 
 describe("salesforceGetCleanActivityRecords input guards", () => {
@@ -709,9 +797,7 @@ describe("salesforceGetCleanActivityRecords EmailMessage people resolution", () 
         done: true,
       },
     });
-    // 3. Contact query — returns nothing (it's a Lead)
-    mockGet.mockResolvedValueOnce({ data: { records: [], done: true } });
-    // 4. Lead fallback query
+    // 3. Lead query
     mockGet.mockResolvedValueOnce({
       data: {
         records: [{ Id: "00QQp00000HyTFBIA3", Name: "Bob Lead", Email: "lead@prospect.com", Title: null }],
@@ -729,6 +815,77 @@ describe("salesforceGetCleanActivityRecords EmailMessage people resolution", () 
       threads: [
         {
           people: [{ id: "00QQp00000HyTFBIA3", name: "Bob Lead", email: "lead@prospect.com", title: null }],
+        },
+      ],
+    });
+  });
+
+  test("partitions Contact and Lead EmailMessageRelation values before person lookups", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            {
+              Id: "02sQp0000000004AAA",
+              Subject: "Mixed relations",
+              MessageDate: "2026-05-04T10:00:00.000+0000",
+              Incoming: true,
+              IsBounced: false,
+              FromAddress: "contact@example.com",
+              ToAddress: "rep@butterflymx.com",
+              TextBody: "Contact and lead on this thread.",
+              ThreadIdentifier: "thread-mixed",
+              MessageIdentifier: "msg-004",
+              RelatedToId: "500Qp0000012345AAA",
+              ActivityId: "00TQp000001abcDEH",
+            },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            { EmailMessageId: "02sQp0000000004AAA", RelationId: "003Qp00000HyTFBIA3", RelationObjectType: "Contact" },
+            { EmailMessageId: "02sQp0000000004AAA", RelationId: "00QQp00000HyTFBIA4", RelationObjectType: "Lead" },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            { Id: "003Qp00000HyTFBIA3", Name: "Alice Contact", Email: "contact@example.com", Title: "Manager" },
+          ],
+          done: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ Id: "00QQp00000HyTFBIA4", Name: "Bob Lead", Email: "lead@example.com", Title: null }],
+          done: true,
+        },
+      });
+
+    const result = await getCleanActivityRecords({
+      params: { objectType: "EmailMessage", whereClause: "RelatedToId = '500Qp0000012345AAA'" },
+      authParams: { authToken: "token", baseUrl: "https://example.my.salesforce.com" },
+    });
+
+    const contactSoql = decodeURIComponent(new URL(String(mockGet.mock.calls[2]?.[0])).searchParams.get("q") ?? "");
+    const leadSoql = decodeURIComponent(new URL(String(mockGet.mock.calls[3]?.[0])).searchParams.get("q") ?? "");
+    expect(contactSoql).toContain("FROM Contact WHERE Id IN ('003Qp00000HyTFBIA3')");
+    expect(contactSoql).not.toContain("00QQp00000HyTFBIA4");
+    expect(leadSoql).toContain("FROM Lead WHERE Id IN ('00QQp00000HyTFBIA4')");
+    expect(leadSoql).not.toContain("003Qp00000HyTFBIA3");
+    expect(result).toMatchObject({
+      success: true,
+      threads: [
+        {
+          people: [
+            { id: "003Qp00000HyTFBIA3", name: "Alice Contact", email: "contact@example.com", title: "Manager" },
+            { id: "00QQp00000HyTFBIA4", name: "Bob Lead", email: "lead@example.com", title: null },
+          ],
         },
       ],
     });

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -1,0 +1,780 @@
+import type {
+  AuthParamsType,
+  salesforceGetCleanActivityRecordsFunction,
+  salesforceGetCleanActivityRecordsOutputType,
+  salesforceGetCleanActivityRecordsParamsType,
+} from "../../autogen/types.js";
+import { ApiError, axiosClient } from "../../util/axiosClient.js";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const DEFAULT_MAX_BODY_LENGTH = 500;
+const MAX_EXCLUDE_IDS = 500;
+// Salesforce IDs are 15 or 18 alphanumeric characters — used to validate excludeActivityIds before SOQL interpolation
+const SF_ID_PATTERN = /^[a-zA-Z0-9]{15}$|^[a-zA-Z0-9]{18}$/;
+const TASK_FIELD_API_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Blocks statement terminators and comment sequences that could escape the WHERE clause wrapper
+const SOQL_INJECTION_PATTERN = /;|--|\/\*|\*\//;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SfRecord = Record<string, any>;
+
+function forEachSoqlCharacterOutsideString(
+  value: string,
+  callback: (character: string, index: number) => void | "stop",
+): void {
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const character = value[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "'" && value[i + 1] === "'") {
+        i += 1;
+      } else if (character === "'") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === "'") {
+      inString = true;
+      continue;
+    }
+
+    if (callback(character, i) === "stop") return;
+  }
+}
+
+function hasBalancedParentheses(value: string): boolean {
+  let depth = 0;
+  let balanced = true;
+
+  forEachSoqlCharacterOutsideString(value, character => {
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    if (depth < 0) {
+      balanced = false;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return balanced && depth === 0;
+}
+
+function hasDisallowedSoqlSequenceOutsideString(value: string): boolean {
+  let hasDisallowedSequence = false;
+
+  forEachSoqlCharacterOutsideString(value, (_, index) => {
+    if (SOQL_INJECTION_PATTERN.test(value.slice(index, index + 2))) {
+      hasDisallowedSequence = true;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return hasDisallowedSequence;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(Math.max(1, Math.trunc(limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
+}
+
+function cleanBody(text: string | null | undefined): string | null {
+  if (!text) return null;
+  let s = text;
+  s = s.replace(/\r\n/g, "\n");
+  s = s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#?\w+;/g, "");
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<\/(?:div|p|li|tr|h[1-6])>/gi, "\n");
+  s = s.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, "[$1]");
+  s = s.replace(/<[^>]+>/g, " ");
+  s = s.replace(/^(From|To|CC|BCC|Date|Subject|Attachment|Body|Additional\s+To):.*\n/gim, "");
+  const qm = s.match(/(?:^|\n)((?:>\s*)?On [\s\S]{0,250}?wrote:\s*(?:\n|$))/);
+  if (qm && qm.index !== undefined) {
+    const cut = qm.index + (qm[0].startsWith("\n") ? 1 : 0);
+    s = s.slice(0, cut);
+  }
+  s = s.replace(/\n--\s*\n[\s\S]*$/, "");
+  s = s.replace(/\n{3,}/g, "\n\n").trim();
+  return s.length > 0 ? s : null;
+}
+
+// Strips HTML markup from a Task Description before direction detection, without the
+// quote-chain truncation that cleanBody applies. Handles entity-encoded angle brackets
+// produced by some Salesforce email-sync integrations (e.g., &lt;email@domain&gt;).
+function normalizeEmailHeaderText(text: string | null | undefined): string | null {
+  if (!text) return null;
+  let s = text.replace(/\r\n/g, "\n");
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<\/(?:div|p|li|tr|h[1-6])>/gi, "\n");
+  s = s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#?\w+;/g, "");
+  s = s.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, "[$1]");
+  s = s.replace(/<[^>]+>/g, " ");
+  s = s.replace(/[ \t]+/g, " ");
+  s = s.replace(/\n\s+/g, "\n").trim();
+  return s.length > 0 ? s : null;
+}
+
+function truncate(text: string | null, maxLength: number): string | null {
+  if (!text) return null;
+  if (text.length <= maxLength) return text;
+  return maxLength > 0 ? text.slice(0, maxLength - 1) + "…" : null;
+}
+
+function normalizeSubject(subject: string): string {
+  const prefix = /^(Email:\s*|Bounced:\s*|>>\s*|<<\s*|\[Inbox\]\s*-?\s*|Re:\s*|Fwd?:\s*|FW:\s*)/i;
+  let s = subject;
+  let prev = "";
+  while (s !== prev) {
+    prev = s;
+    s = s.replace(prefix, "");
+  }
+  return s.trim();
+}
+
+function parseSalesforceTimestamp(value: unknown): number {
+  if (typeof value !== "string" || value.length === 0) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
+
+function compareTaskDateCandidates(a: SfRecord, b: SfRecord, taskDateTimeTieBreakerField?: string): number {
+  const candidates = [
+    taskDateTimeTieBreakerField,
+    "ActivityDate",
+    "CompletedDateTime",
+    "LastModifiedDate",
+    "CreatedDate",
+  ].filter((field): field is string => typeof field === "string" && field.length > 0);
+
+  for (const field of candidates) {
+    const byField = parseSalesforceTimestamp(b[field]) - parseSalesforceTimestamp(a[field]);
+    if (byField !== 0) return byField;
+  }
+
+  return 0;
+}
+
+function compareTaskEmailRecords(a: SfRecord, b: SfRecord, taskDateTimeTieBreakerField?: string): number {
+  const byEmailTime = compareTaskDateCandidates(a, b, taskDateTimeTieBreakerField);
+  if (byEmailTime !== 0) return byEmailTime;
+  return String(b.Id ?? "").localeCompare(String(a.Id ?? ""));
+}
+
+function formatTaskEmailDate(record: SfRecord, taskDateTimeTieBreakerField?: string): string | null {
+  const candidates = [
+    taskDateTimeTieBreakerField ? record[taskDateTimeTieBreakerField] : undefined,
+    record.ActivityDate,
+    record.CompletedDateTime,
+    record.LastModifiedDate,
+    record.CreatedDate,
+  ];
+  return (candidates.find(value => typeof value === "string" && value.length > 0) as string | undefined) ?? null;
+}
+
+function detectTaskDirection(
+  subject: string,
+  description: string | null | undefined,
+  ownerEmail: string | null | undefined,
+): "inbound" | "outbound" | "unknown" {
+  if (subject.includes(">>")) return "outbound";
+  if (subject.includes("<<") || /\[inbox\]/i.test(subject)) return "inbound";
+  if (description && ownerEmail) {
+    const fromMatch =
+      description.match(/^From:\s*.*?\[([^\]]+@[^\]]+)\]/im) ||
+      description.match(/^From:\s*.*?<([^>]+)>/im) ||
+      description.match(/^From:\s*(\S+@\S+)/im);
+    if (fromMatch) {
+      const fromEmail = fromMatch[1]
+        .trim()
+        .replace(/[>,;]+$/, "")
+        .toLowerCase();
+      return fromEmail === ownerEmail.toLowerCase() ? "outbound" : "inbound";
+    }
+    const toMatch = description.match(/^To:\s*(.+)/m);
+    if (toMatch) {
+      return toMatch[1].toLowerCase().includes(ownerEmail.toLowerCase()) ? "inbound" : "outbound";
+    }
+  }
+  return "unknown";
+}
+
+function parseExcludeActivityIds(excludeActivityIds?: string): string[] {
+  if (!excludeActivityIds) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(excludeActivityIds);
+  } catch {
+    throw new Error("excludeActivityIds must be a JSON array string");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("excludeActivityIds must be a JSON array string");
+  }
+
+  const invalid = parsed.filter(id => typeof id !== "string" || !SF_ID_PATTERN.test(id));
+  if (invalid.length > 0) {
+    throw new Error(`excludeActivityIds contains invalid Salesforce IDs: ${invalid.join(", ")}`);
+  }
+
+  const unique = [...new Set(parsed as string[])];
+  if (unique.length > MAX_EXCLUDE_IDS) {
+    throw new Error(
+      `excludeActivityIds contains ${unique.length} IDs, which exceeds the limit of ${MAX_EXCLUDE_IDS}. ` +
+        "Use a narrower whereClause to reduce the EmailMessage result set before collecting activity IDs.",
+    );
+  }
+
+  return unique;
+}
+
+// whereClause is provided by an AI agent and is NOT treated as untrusted end-user input. This guard
+// blocks comment sequences and statement terminators that could break the WHERE clause wrapping and
+// allow unintended record access. Hallucinated or malformed SOQL that passes this check returns a
+// Salesforce API error surfaced to the caller.
+function validateWhereClause(whereClause: string): void {
+  if (hasDisallowedSoqlSequenceOutsideString(whereClause)) {
+    throw new Error(
+      "whereClause contains disallowed patterns (; -- /* */). Provide a plain SOQL filter expression without statement terminators or comment sequences. " +
+        "Example: \"WhatId = '001Qp000003abcDEF' AND ActivityDate >= 2024-01-01\"",
+    );
+  }
+  if (!hasBalancedParentheses(whereClause)) {
+    throw new Error(
+      "whereClause contains unbalanced parentheses. Provide a balanced SOQL filter expression that cannot escape appended safety filters. " +
+        "Example: \"(WhatId = '001Qp000003abcDEF' OR WhoId = '003Qp000003abcDEF') AND ActivityDate >= 2024-01-01\"",
+    );
+  }
+}
+
+// maxPages caps pagination for queries without a LIMIT clause (e.g. activity ID collection).
+// Queries with a LIMIT clause never produce more than one page, so the default Infinity is safe for them.
+async function soqlQuery(
+  baseUrl: string,
+  authToken: string,
+  soql: string,
+  maxPages = Infinity,
+  useQueryAll = false,
+): Promise<SfRecord[]> {
+  const endpoint = useQueryAll ? "queryAll" : "query";
+  let url: string | null = `${baseUrl}/services/data/v56.0/${endpoint}?q=${encodeURIComponent(soql)}`;
+  const records: unknown[] = [];
+  let pages = 0;
+
+  while (url && pages < maxPages) {
+    const response: { data: { records?: unknown[]; done?: boolean; nextRecordsUrl?: string } } = await axiosClient.get(
+      url,
+      { headers: { Authorization: `Bearer ${authToken}` } },
+    );
+    records.push(...(response.data.records ?? []));
+    url =
+      response.data.done === false && typeof response.data.nextRecordsUrl === "string"
+        ? `${baseUrl}${response.data.nextRecordsUrl}`
+        : null;
+    pages++;
+  }
+
+  return records as SfRecord[];
+}
+
+async function handleTask(
+  baseUrl: string,
+  authToken: string,
+  whereClause: string,
+  limit: number,
+  maxBodyLength: number,
+  excludeActivityIds?: string,
+  taskDateTimeTieBreakerField?: string,
+): Promise<salesforceGetCleanActivityRecordsOutputType> {
+  validateWhereClause(whereClause);
+  const exclusionIds = parseExcludeActivityIds(excludeActivityIds);
+  const exclusion = exclusionIds.length > 0 ? ` AND Id NOT IN (${exclusionIds.map(id => `'${id}'`).join(",")})` : "";
+  const selectFields = [
+    "Id",
+    "Subject",
+    "TaskSubtype",
+    "ActivityDate",
+    taskDateTimeTieBreakerField,
+    "CompletedDateTime",
+    "CreatedDate",
+    "LastModifiedDate",
+    "Owner.Name",
+    "Owner.Email",
+    "WhoId",
+    "WhatId",
+    "Description",
+  ].filter((field): field is string => typeof field === "string" && field.length > 0);
+  const orderByFields = [
+    taskDateTimeTieBreakerField ? `${taskDateTimeTieBreakerField} DESC NULLS LAST` : undefined,
+    "ActivityDate DESC NULLS LAST",
+    "CompletedDateTime DESC NULLS LAST",
+  ].filter((field): field is string => typeof field === "string" && field.length > 0);
+  // Task email processing is optimized for Groove-style synced email Tasks:
+  // Groove writes direction markers into Subject (>>, <<, Bounced: >>) and can expose a true Date/Time
+  // sent field such as groove_email_sent_at__c. Agents should pass that field through
+  // taskDateTimeTieBreakerField when available; otherwise the portable fallback is ActivityDate with
+  // CompletedDateTime as a sync-time tie-breaker.
+  // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
+  const soql = `SELECT ${selectFields.join(", ")} FROM Task WHERE ${formatActivityWhereClause(whereClause)} AND TaskSubtype = 'Email' AND Status = 'Completed' AND IsDeleted = false${exclusion} ORDER BY ${orderByFields.join(", ")} LIMIT ${limit + 1}`;
+  const rawRecords = (await soqlQuery(baseUrl, authToken, soql, Infinity, true)) as SfRecord[];
+  const hasMore = rawRecords.length > limit;
+  const records = hasMore ? rawRecords.slice(0, limit) : rawRecords;
+
+  // Group by normalizedSubject + WhoId + WhatId
+  const threadMap = new Map<string, SfRecord[]>();
+  for (const r of records) {
+    const normalizedSubject = normalizeSubject(r.Subject ?? "");
+    const whoId = r.WhoId ?? "";
+    const whatId = r.WhatId ?? "";
+    const key = normalizedSubject || whoId || whatId ? `${normalizedSubject}||${whoId}||${whatId}` : String(r.Id);
+    const group = threadMap.get(key) ?? [];
+    group.push(r);
+    threadMap.set(key, group);
+  }
+
+  // Resolve WhoId → Contact, then Lead as fallback
+  const whoIds = [...new Set(records.map(r => r.WhoId).filter(Boolean) as string[])];
+  const contactMap = new Map<string, { id: string; name: string; email: string | null; title: string | null }>();
+  if (whoIds.length > 0) {
+    const idList = whoIds.map(id => `'${id}'`).join(",");
+    const contactSoql = `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${idList})`;
+    const contacts = (await soqlQuery(baseUrl, authToken, contactSoql)) as SfRecord[];
+    for (const c of contacts) {
+      contactMap.set(c.Id, { id: c.Id, name: c.Name, email: c.Email ?? null, title: c.Title ?? null });
+    }
+    const unresolvedIds = whoIds.filter(id => !contactMap.has(id));
+    if (unresolvedIds.length > 0) {
+      const leadIdList = unresolvedIds.map(id => `'${id}'`).join(",");
+      const leadSoql = `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${leadIdList})`;
+      const leads = (await soqlQuery(baseUrl, authToken, leadSoql)) as SfRecord[];
+      for (const l of leads) {
+        contactMap.set(l.Id, { id: l.Id, name: l.Name, email: l.Email ?? null, title: l.Title ?? null });
+      }
+    }
+  }
+
+  const threads = [];
+  for (const [, group] of threadMap) {
+    group.sort((a, b) => compareTaskEmailRecords(a, b, taskDateTimeTieBreakerField));
+    const latest = group[0];
+    const ownerEmail: string | null = latest.Owner?.Email ?? null;
+    threads.push({
+      normalizedSubject: normalizeSubject(latest.Subject ?? ""),
+      threadSize: group.length,
+      latestDate: formatTaskEmailDate(latest, taskDateTimeTieBreakerField),
+      activityDate: latest.ActivityDate ?? null,
+      direction: detectTaskDirection(latest.Subject ?? "", normalizeEmailHeaderText(latest.Description), ownerEmail),
+      owner: latest.Owner?.Name ?? null,
+      whoId: latest.WhoId ?? null,
+      whatId: latest.WhatId ?? null,
+      contact: latest.WhoId ? (contactMap.get(latest.WhoId) ?? null) : null,
+      latestTaskId: latest.Id,
+      allTaskIds: group.map(r => r.Id as string),
+      cleanedDescription: truncate(cleanBody(latest.Description), maxBodyLength),
+    });
+  }
+
+  threads.sort((a, b) => parseSalesforceTimestamp(b.latestDate) - parseSalesforceTimestamp(a.latestDate));
+
+  return {
+    success: true,
+    objectType: "Task",
+    totalFetched: records.length,
+    totalThreads: threads.length,
+    threads,
+    ...(hasMore && {
+      hasMore: true,
+      hasMoreMessage: `Result set was capped at ${limit} records (${threads.length} threads shown). There may be additional Task activity not included in this response. Narrow your WHERE clause or increase the limit parameter to retrieve more.`,
+    }),
+  };
+}
+
+function containsSemiJoinSubquery(whereClause: string): boolean {
+  let found = false;
+  forEachSoqlCharacterOutsideString(whereClause, (char, index) => {
+    // Only check at positions that are the start of a word (preceded by non-word char or start of string)
+    if (/\w/.test(char) && (index === 0 || !/\w/.test(whereClause[index - 1]))) {
+      if (/^(?:NOT\s+)?IN\s*\(\s*SELECT\b/i.test(whereClause.slice(index))) {
+        found = true;
+        return "stop";
+      }
+    }
+    return undefined;
+  });
+  return found;
+}
+
+function findMatchingParen(value: string, openIndex: number): number | null {
+  let depth = 0;
+  let match: number | null = null;
+
+  forEachSoqlCharacterOutsideString(value, (character, index) => {
+    if (index < openIndex) return undefined;
+    if (character === "(") depth += 1;
+    if (character === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        match = index;
+        return "stop";
+      }
+    }
+    return undefined;
+  });
+
+  return match;
+}
+
+function findParenthesizedRanges(value: string): Array<{ start: number; end: number }> {
+  const stack: number[] = [];
+  const ranges: Array<{ start: number; end: number }> = [];
+
+  forEachSoqlCharacterOutsideString(value, (character, index) => {
+    if (character === "(") stack.push(index);
+    if (character === ")") {
+      const start = stack.pop();
+      if (start !== undefined) ranges.push({ start, end: index });
+    }
+    return undefined;
+  });
+
+  return ranges;
+}
+
+function stripEnclosingParentheses(value: string): string {
+  let trimmed = value.trim();
+  let changed = true;
+
+  while (changed && trimmed.startsWith("(") && trimmed.endsWith(")")) {
+    changed = false;
+    const match = findMatchingParen(trimmed, 0);
+    if (match === trimmed.length - 1) {
+      trimmed = trimmed.slice(1, -1).trim();
+      changed = true;
+    }
+  }
+
+  return trimmed;
+}
+
+function hasTopLevelOr(value: string): boolean {
+  let depth = 0;
+  let found = false;
+  const normalized = stripEnclosingParentheses(value);
+
+  forEachSoqlCharacterOutsideString(normalized, (character, index) => {
+    if (character === "(") {
+      depth += 1;
+      return undefined;
+    }
+    if (character === ")") {
+      depth -= 1;
+      return undefined;
+    }
+    if (depth === 0 && /^OR\b/i.test(normalized.slice(index)) && (index === 0 || !/\w/.test(normalized[index - 1]))) {
+      found = true;
+      return "stop";
+    }
+    return undefined;
+  });
+
+  return found;
+}
+
+function isCompleteSemiJoinExpression(expression: string): boolean {
+  const trimmed = expression.trim();
+  const match = /^[A-Za-z_][\w.]*\s+(?:NOT\s+)?IN\s*\(/i.exec(trimmed);
+  if (!match) return false;
+
+  const openParenIndex = match[0].lastIndexOf("(");
+  return findMatchingParen(trimmed, openParenIndex) === trimmed.length - 1;
+}
+
+function unwrapParenthesizedSemiJoins(whereClause: string): string {
+  let normalized = whereClause;
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    const ranges = findParenthesizedRanges(normalized).sort((a, b) => b.start - a.start);
+
+    for (const { start, end } of ranges) {
+      const inner = normalized.slice(start + 1, end);
+      if (!isCompleteSemiJoinExpression(inner)) continue;
+
+      normalized = normalized.slice(0, start) + inner.trim() + normalized.slice(end + 1);
+      changed = true;
+      break;
+    }
+  }
+
+  return normalized;
+}
+
+function formatActivityWhereClause(whereClause: string): string {
+  if (!containsSemiJoinSubquery(whereClause)) {
+    return `(${whereClause})`;
+  }
+  if (hasTopLevelOr(whereClause)) {
+    throw new Error(
+      "whereClause contains a semi-join subquery combined with OR, which Salesforce SOQL does not support. Split the query into multiple calls or rewrite the filter without OR.",
+    );
+  }
+  const unwrapped = unwrapParenthesizedSemiJoins(whereClause);
+  // Salesforce rejects outer parens around a bare lone semi-join, e.g. (WhoId IN (SELECT ...)).
+  // But a compound expression such as (WhoId IN (SELECT ...) AND ...) is valid and must be
+  // wrapped so that appended AND filters apply to the entire caller-provided expression.
+  return isCompleteSemiJoinExpression(unwrapped) ? unwrapped : `(${unwrapped})`;
+}
+
+function buildEmailMessageQuery(whereClause: string, limit: number): string {
+  return `SELECT Id, Subject, MessageDate, Incoming, IsBounced, Status, HasAttachment, FromName, FromAddress, ToAddress, CcAddress, TextBody, ThreadIdentifier, MessageIdentifier, ReplyToEmailMessageId, RelatedToId, ParentId, ActivityId FROM EmailMessage WHERE ${formatActivityWhereClause(whereClause)} AND IsDeleted = false AND Status != '5' ORDER BY MessageDate DESC NULLS LAST LIMIT ${limit + 1}`;
+}
+
+async function handleEmailMessage(
+  baseUrl: string,
+  authToken: string,
+  whereClause: string,
+  limit: number,
+  maxBodyLength: number,
+  returnActivityIds?: boolean,
+): Promise<salesforceGetCleanActivityRecordsOutputType> {
+  validateWhereClause(whereClause);
+  // Fetch limit+1 to determine whether additional records exist without relying on Salesforce pagination metadata
+  const soql = buildEmailMessageQuery(whereClause, limit);
+  const rawRecords = (await soqlQuery(baseUrl, authToken, soql, Infinity, true)) as SfRecord[];
+  const hasMore = rawRecords.length > limit;
+  const records = hasMore ? rawRecords.slice(0, limit) : rawRecords;
+
+  const threadMap = new Map<string, SfRecord[]>();
+  for (const r of records) {
+    // Email to Case: ParentId is the Case ID — the definitive thread container (ThreadIdentifier is not
+    // set for On-Demand Email-to-Case per Salesforce docs). Enhanced Email / inbox sync: ThreadIdentifier.
+    const key = r.ParentId ?? r.ThreadIdentifier ?? r.Id;
+    const group = threadMap.get(key) ?? [];
+    group.push(r);
+    threadMap.set(key, group);
+  }
+
+  // Resolve people via EmailMessageRelation → Contact, then Lead as fallback
+  const allMessageIds = records.map(r => r.Id as string).filter(Boolean);
+  const personMap = new Map<string, { id: string; name: string; email: string | null; title: string | null }>();
+  const messagePersonMap = new Map<string, string[]>();
+
+  if (allMessageIds.length > 0) {
+    const messageIdList = allMessageIds.map(id => `'${id}'`).join(",");
+    const relationSoql = `SELECT EmailMessageId, RelationId, RelationObjectType FROM EmailMessageRelation WHERE EmailMessageId IN (${messageIdList}) AND RelationObjectType IN ('Contact', 'Lead')`;
+    const relations = (await soqlQuery(baseUrl, authToken, relationSoql)) as SfRecord[];
+
+    const relationIdSet = new Set<string>();
+    for (const rel of relations) {
+      if (!rel.EmailMessageId || !rel.RelationId) continue;
+      const existing = messagePersonMap.get(rel.EmailMessageId) ?? [];
+      existing.push(rel.RelationId);
+      messagePersonMap.set(rel.EmailMessageId, existing);
+      relationIdSet.add(rel.RelationId);
+    }
+    const relationIds = [...relationIdSet];
+
+    if (relationIds.length > 0) {
+      const idList = relationIds.map(id => `'${id}'`).join(",");
+      const contacts = (await soqlQuery(
+        baseUrl,
+        authToken,
+        `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${idList})`,
+      )) as SfRecord[];
+      for (const c of contacts) {
+        personMap.set(c.Id, { id: c.Id, name: c.Name, email: c.Email ?? null, title: c.Title ?? null });
+      }
+      const unresolvedIds = relationIds.filter(id => !personMap.has(id));
+      if (unresolvedIds.length > 0) {
+        const leadIdList = unresolvedIds.map(id => `'${id}'`).join(",");
+        const leads = (await soqlQuery(
+          baseUrl,
+          authToken,
+          `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${leadIdList})`,
+        )) as SfRecord[];
+        for (const l of leads) {
+          personMap.set(l.Id, { id: l.Id, name: l.Name, email: l.Email ?? null, title: l.Title ?? null });
+        }
+      }
+    }
+  }
+
+  const threads = [];
+  for (const [threadIdentifier, group] of threadMap) {
+    group.sort((a, b) => parseSalesforceTimestamp(b.MessageDate) - parseSalesforceTimestamp(a.MessageDate));
+    const latest = group[0];
+    const threadPersonIds = new Set<string>();
+    for (const msg of group) {
+      for (const pid of messagePersonMap.get(msg.Id) ?? []) {
+        threadPersonIds.add(pid);
+      }
+    }
+    const people = [...threadPersonIds].map(id => personMap.get(id)).filter(Boolean);
+    threads.push({
+      threadIdentifier,
+      normalizedSubject: normalizeSubject(latest.Subject ?? ""),
+      threadSize: group.length,
+      latestDate: latest.MessageDate ?? null,
+      direction: latest.Incoming === true ? "inbound" : "outbound",
+      bounced: group.some(r => r.IsBounced === true),
+      hasAttachment: group.some(r => r.HasAttachment === true),
+      status: latest.Status ?? null,
+      relatedToId: latest.RelatedToId ?? null,
+      parentId: latest.ParentId ?? null,
+      fromName: latest.FromName ?? null,
+      fromAddress: latest.FromAddress ?? null,
+      toAddress: latest.ToAddress ?? null,
+      ccAddress: latest.CcAddress ?? null,
+      people,
+      latestMessageId: latest.Id,
+      allMessageIds: group.map(r => r.Id as string),
+      messageIdentifiers: group.map(r => r.MessageIdentifier as string).filter(Boolean),
+      replyToEmailMessageId: latest.ReplyToEmailMessageId ?? null,
+      cleanedBody: truncate(cleanBody(latest.TextBody), maxBodyLength),
+    });
+  }
+
+  threads.sort((a, b) => parseSalesforceTimestamp(b.latestDate) - parseSalesforceTimestamp(a.latestDate));
+
+  const result: salesforceGetCleanActivityRecordsOutputType = {
+    success: true,
+    objectType: "EmailMessage",
+    totalFetched: records.length,
+    totalThreads: threads.length,
+    threads,
+    ...(hasMore && {
+      hasMore: true,
+      hasMoreMessage: `Result set was capped at ${limit} records (${threads.length} threads shown). There may be additional EmailMessage activity not included in this response. Narrow your WHERE clause or increase the limit parameter to retrieve more.`,
+    }),
+  };
+
+  if (returnActivityIds) {
+    result.activityIds = JSON.stringify([
+      ...new Set(
+        records.map(record => record.ActivityId).filter((id): id is string => typeof id === "string" && id.length > 0),
+      ),
+    ]);
+  }
+
+  return result;
+}
+
+const getCleanActivityRecords: salesforceGetCleanActivityRecordsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: salesforceGetCleanActivityRecordsParamsType;
+  authParams: AuthParamsType;
+}): Promise<salesforceGetCleanActivityRecordsOutputType> => {
+  const { authToken, baseUrl } = authParams;
+  const {
+    objectType,
+    whereClause,
+    limit,
+    maxBodyLength,
+    returnActivityIds,
+    excludeActivityIds,
+    taskDateTimeTieBreakerField,
+  } = params;
+
+  if (!authToken || !baseUrl) {
+    return { success: false, error: "authToken and baseUrl are required for Salesforce API" };
+  }
+
+  if (objectType === "EmailMessage" && excludeActivityIds) {
+    // Allow an empty JSON array "[]" since it has no effect; reject any non-empty exclusion list
+    let parsedExclude: unknown;
+    try {
+      parsedExclude = JSON.parse(excludeActivityIds);
+    } catch {
+      parsedExclude = null;
+    }
+    if (!Array.isArray(parsedExclude) || parsedExclude.length > 0) {
+      return { success: false, error: "excludeActivityIds is only supported when objectType is Task" };
+    }
+  }
+
+  if (objectType === "EmailMessage" && taskDateTimeTieBreakerField) {
+    return { success: false, error: "taskDateTimeTieBreakerField is only supported when objectType is Task" };
+  }
+
+  if (objectType === "Task" && returnActivityIds) {
+    return { success: false, error: "returnActivityIds is only supported when objectType is EmailMessage" };
+  }
+
+  const effectiveLimit = normalizeLimit(limit);
+  const effectiveMaxBodyLength = Math.max(0, maxBodyLength ?? DEFAULT_MAX_BODY_LENGTH);
+
+  if (taskDateTimeTieBreakerField && !TASK_FIELD_API_NAME_PATTERN.test(taskDateTimeTieBreakerField)) {
+    return { success: false, error: "taskDateTimeTieBreakerField must be a valid Task field API name" };
+  }
+
+  try {
+    if (objectType === "Task") {
+      return await handleTask(
+        baseUrl,
+        authToken,
+        whereClause,
+        effectiveLimit,
+        effectiveMaxBodyLength,
+        excludeActivityIds,
+        taskDateTimeTieBreakerField,
+      );
+    }
+    return await handleEmailMessage(
+      baseUrl,
+      authToken,
+      whereClause,
+      effectiveLimit,
+      effectiveMaxBodyLength,
+      returnActivityIds,
+    );
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof ApiError
+          ? Array.isArray(error.data) && error.data.length > 0 && typeof error.data[0]?.message === "string"
+            ? error.data[0].message
+            : error.message
+          : error instanceof Error
+            ? error.message
+            : "An unknown error occurred",
+    };
+  }
+};
+
+export {
+  buildEmailMessageQuery,
+  cleanBody,
+  compareTaskEmailRecords,
+  detectTaskDirection,
+  normalizeEmailHeaderText,
+  normalizeLimit,
+  normalizeSubject,
+  parseExcludeActivityIds,
+  soqlQuery,
+  truncate,
+  validateWhereClause,
+};
+
+export default getCleanActivityRecords;

--- a/src/actions/providers/salesforce/getCleanActivityRecords.ts
+++ b/src/actions/providers/salesforce/getCleanActivityRecords.ts
@@ -13,11 +13,37 @@ const MAX_EXCLUDE_IDS = 500;
 // Salesforce IDs are 15 or 18 alphanumeric characters — used to validate excludeActivityIds before SOQL interpolation
 const SF_ID_PATTERN = /^[a-zA-Z0-9]{15}$|^[a-zA-Z0-9]{18}$/;
 const TASK_FIELD_API_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const CONTACT_ID_PREFIX = "003";
+const LEAD_ID_PREFIX = "00Q";
 // Blocks statement terminators and comment sequences that could escape the WHERE clause wrapper
 const SOQL_INJECTION_PATTERN = /;|--|\/\*|\*\//;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SfRecord = Record<string, any>;
+type PersonRecord = { id: string; name: string; email: string | null; title: string | null };
+
+function formatSoqlIdList(ids: string[]): string {
+  return ids.map(id => `'${id}'`).join(",");
+}
+
+function toPersonRecord(record: SfRecord): PersonRecord {
+  return { id: record.Id, name: record.Name, email: record.Email ?? null, title: record.Title ?? null };
+}
+
+function partitionPersonIdsByPrefix(ids: string[]): { contactIds: string[]; leadIds: string[] } {
+  const contactIds: string[] = [];
+  const leadIds: string[] = [];
+
+  for (const id of ids) {
+    if (id.startsWith(CONTACT_ID_PREFIX)) {
+      contactIds.push(id);
+    } else if (id.startsWith(LEAD_ID_PREFIX)) {
+      leadIds.push(id);
+    }
+  }
+
+  return { contactIds, leadIds };
+}
 
 function forEachSoqlCharacterOutsideString(
   value: string,
@@ -350,24 +376,22 @@ async function handleTask(
     threadMap.set(key, group);
   }
 
-  // Resolve WhoId → Contact, then Lead as fallback
+  // Resolve WhoId using Salesforce ID prefixes so object-specific queries never receive the wrong ID type.
   const whoIds = [...new Set(records.map(r => r.WhoId).filter(Boolean) as string[])];
-  const contactMap = new Map<string, { id: string; name: string; email: string | null; title: string | null }>();
-  if (whoIds.length > 0) {
-    const idList = whoIds.map(id => `'${id}'`).join(",");
-    const contactSoql = `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${idList})`;
+  const contactMap = new Map<string, PersonRecord>();
+  const { contactIds, leadIds } = partitionPersonIdsByPrefix(whoIds);
+  if (contactIds.length > 0) {
+    const contactSoql = `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${formatSoqlIdList(contactIds)})`;
     const contacts = (await soqlQuery(baseUrl, authToken, contactSoql)) as SfRecord[];
     for (const c of contacts) {
-      contactMap.set(c.Id, { id: c.Id, name: c.Name, email: c.Email ?? null, title: c.Title ?? null });
+      contactMap.set(c.Id, toPersonRecord(c));
     }
-    const unresolvedIds = whoIds.filter(id => !contactMap.has(id));
-    if (unresolvedIds.length > 0) {
-      const leadIdList = unresolvedIds.map(id => `'${id}'`).join(",");
-      const leadSoql = `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${leadIdList})`;
-      const leads = (await soqlQuery(baseUrl, authToken, leadSoql)) as SfRecord[];
-      for (const l of leads) {
-        contactMap.set(l.Id, { id: l.Id, name: l.Name, email: l.Email ?? null, title: l.Title ?? null });
-      }
+  }
+  if (leadIds.length > 0) {
+    const leadSoql = `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${formatSoqlIdList(leadIds)})`;
+    const leads = (await soqlQuery(baseUrl, authToken, leadSoql)) as SfRecord[];
+    for (const l of leads) {
+      contactMap.set(l.Id, toPersonRecord(l));
     }
   }
 
@@ -573,47 +597,51 @@ async function handleEmailMessage(
     threadMap.set(key, group);
   }
 
-  // Resolve people via EmailMessageRelation → Contact, then Lead as fallback
+  // Resolve people via EmailMessageRelation using RelationObjectType to keep Contact and Lead lookups separate.
   const allMessageIds = records.map(r => r.Id as string).filter(Boolean);
-  const personMap = new Map<string, { id: string; name: string; email: string | null; title: string | null }>();
+  const personMap = new Map<string, PersonRecord>();
   const messagePersonMap = new Map<string, string[]>();
 
   if (allMessageIds.length > 0) {
-    const messageIdList = allMessageIds.map(id => `'${id}'`).join(",");
+    const messageIdList = formatSoqlIdList(allMessageIds);
     const relationSoql = `SELECT EmailMessageId, RelationId, RelationObjectType FROM EmailMessageRelation WHERE EmailMessageId IN (${messageIdList}) AND RelationObjectType IN ('Contact', 'Lead')`;
     const relations = (await soqlQuery(baseUrl, authToken, relationSoql)) as SfRecord[];
 
-    const relationIdSet = new Set<string>();
+    const contactRelationIds = new Set<string>();
+    const leadRelationIds = new Set<string>();
     for (const rel of relations) {
       if (!rel.EmailMessageId || !rel.RelationId) continue;
       const existing = messagePersonMap.get(rel.EmailMessageId) ?? [];
       existing.push(rel.RelationId);
       messagePersonMap.set(rel.EmailMessageId, existing);
-      relationIdSet.add(rel.RelationId);
+      if (rel.RelationObjectType === "Contact") {
+        contactRelationIds.add(rel.RelationId);
+      } else if (rel.RelationObjectType === "Lead") {
+        leadRelationIds.add(rel.RelationId);
+      }
     }
-    const relationIds = [...relationIdSet];
 
-    if (relationIds.length > 0) {
-      const idList = relationIds.map(id => `'${id}'`).join(",");
+    const contactIds = [...contactRelationIds];
+    if (contactIds.length > 0) {
       const contacts = (await soqlQuery(
         baseUrl,
         authToken,
-        `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${idList})`,
+        `SELECT Id, Name, Email, Title FROM Contact WHERE Id IN (${formatSoqlIdList(contactIds)})`,
       )) as SfRecord[];
       for (const c of contacts) {
-        personMap.set(c.Id, { id: c.Id, name: c.Name, email: c.Email ?? null, title: c.Title ?? null });
+        personMap.set(c.Id, toPersonRecord(c));
       }
-      const unresolvedIds = relationIds.filter(id => !personMap.has(id));
-      if (unresolvedIds.length > 0) {
-        const leadIdList = unresolvedIds.map(id => `'${id}'`).join(",");
-        const leads = (await soqlQuery(
-          baseUrl,
-          authToken,
-          `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${leadIdList})`,
-        )) as SfRecord[];
-        for (const l of leads) {
-          personMap.set(l.Id, { id: l.Id, name: l.Name, email: l.Email ?? null, title: l.Title ?? null });
-        }
+    }
+
+    const leadIds = [...leadRelationIds];
+    if (leadIds.length > 0) {
+      const leads = (await soqlQuery(
+        baseUrl,
+        authToken,
+        `SELECT Id, Name, Email, Title FROM Lead WHERE Id IN (${formatSoqlIdList(leadIds)})`,
+      )) as SfRecord[];
+      for (const l of leads) {
+        personMap.set(l.Id, toPersonRecord(l));
       }
     }
   }

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6832,6 +6832,72 @@ actions:
           error:
             type: string
             description: The error that occurred if the report metadata was not successfully retrieved
+    getCleanActivityRecords:
+      displayName: Get clean activity records
+      description: >
+        Retrieve Salesforce email activity from Task or EmailMessage records, clean email bodies, and deduplicate results
+        into threads. Use this when an agent needs concise email history related to a record, contact, lead, or case.
+      scopes: []
+      parameters:
+        type: object
+        required: [objectType, whereClause]
+        properties:
+          objectType:
+            type: string
+            enum: [Task, EmailMessage]
+            description: "The Salesforce activity object to query: Task or EmailMessage"
+          whereClause:
+            type: string
+            description: SOQL WHERE clause without the WHERE keyword. The agent is responsible for valid SOQL. For Task, TaskSubtype = 'Email' is appended automatically. For EmailMessage related to a Contact, Lead, User, or other Salesforce record, use a top-level semi-join such as Id IN (SELECT EmailMessageId FROM EmailMessageRelation WHERE RelationId = '003...') AND MessageDate >= 2026-01-01T00:00:00Z. Do not rely only on ToAddress, CcAddress, or BccAddress when a Salesforce record ID is available because recipient fields can miss aliases, changed email addresses, and object relationships.
+          limit:
+            type: number
+            description: Maximum number of raw records to fetch from Salesforce before deduplication. Defaults to 20, hard-capped at 100.
+          maxBodyLength:
+            type: number
+            description: Maximum characters to return for each thread's cleaned body (cleanedDescription or cleanedBody). Defaults to 500. Increase if the agent needs fuller context on a specific thread.
+          returnActivityIds:
+            type: boolean
+            description: "EmailMessage only — when true, returns an activityIds string (JSON array) of Task IDs auto-generated alongside the fetched EmailMessage records. The IDs are limited to the EmailMessages returned by this call and can be passed directly as excludeActivityIds in a subsequent Task query over the same scope."
+          excludeActivityIds:
+            type: string
+            description: "Task only — JSON array string of Task IDs to exclude from results. Pass the activityIds string returned from a preceding EmailMessage query exactly as provided — no parsing required."
+          taskDateTimeTieBreakerField:
+            type: string
+            description: "Task only — optional Task Date/Time field API name used before ActivityDate to order synced email Tasks by true sent time. This is intended for Groove-style fields such as groove_email_sent_at__c. The field API name must match [A-Za-z_][A-Za-z0-9_]* — names failing this check are rejected immediately. Unrecognized but syntactically valid field names produce a Salesforce API error at query time."
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the records were successfully retrieved
+          objectType:
+            type: string
+            description: The object type that was queried
+          totalFetched:
+            type: number
+            description: Number of raw records returned from Salesforce
+          totalThreads:
+            type: number
+            description: Number of deduplicated threads
+          threads:
+            type: array
+            description: "Deduplicated email threads. EmailMessage threads include: parentId (Case ID when email is associated with a Case via Email-to-Case; null for Enhanced Email / inbox sync records — ParentId refers only to Case per Salesforce docs); status (0=New, 1=Read, 2=Replied, 3=Sent, 4=Forwarded — Draft records are excluded); hasAttachment; fromName; replyToEmailMessageId (set for Email-to-Case reply chains), ccAddress."
+            items:
+              type: object
+              additionalProperties: true
+          activityIds:
+            type: string
+            description: "EmailMessage only, returnActivityIds=true — JSON array string of non-null ActivityId values from the fetched EmailMessage records. This is 1:1 with the current result window and does not include ActivityIds beyond the applied limit."
+          hasMore:
+            type: boolean
+            description: True when the number of raw records returned equaled the limit, indicating additional records may exist beyond what was fetched.
+          hasMoreMessage:
+            type: string
+            description: Human-readable message explaining that the result was capped and advising the agent to narrow the WHERE clause or increase the limit.
+          error:
+            type: string
+            description: The error that occurred if the records were not successfully retrieved
   microsoft:
     createDocument:
       displayName: Create a document


### PR DESCRIPTION
## Summary

Adds a new action `salesforce/getCleanActivityRecords` that retrieves Salesforce email activity from either `Task` or `EmailMessage` records, cleans email bodies, and deduplicates results into thread-shaped output optimized for AI agent consumption.

Both paths use the `/queryAll` endpoint, with explicit `IsDeleted = false` filters to exclude recycle-bin records while still supporting historical activity analysis.

---

## Filters applied by object type

### Task

| Filter | Value | Reason |
|--------|-------|--------|
| `TaskSubtype` | `= 'Email'` | Primary identifier for Tasks created via programmatic email logging (Groove, Outreach, inbox sync). Without this, the query returns all activity types including calls, meetings, and manually created tasks. |
| `Status` | `= 'Completed'` | Excludes pending/open tasks that have not been sent. |
| `IsDeleted` | `= false` | Excludes recycle-bin records surfaced by `/queryAll`. |

### EmailMessage

| Filter | Value | Reason |
|--------|-------|--------|
| `Status` | `!= '5'` | Excludes draft messages. |
| `IsDeleted` | `= false` | Excludes recycle-bin records surfaced by `/queryAll`. |

---

## Thread grouping

```mermaid
flowchart TD
    IN([getCleanActivityRecords]) --> OT{objectType?}

    %% TASK PATH
    OT -->|Task| TF["Filter via /queryAll\nTaskSubtype = 'Email'\nStatus = 'Completed'\nIsDeleted = false"]
    TF --> TEX{excludeActivityIds\nprovided?}
    TEX -->|yes| TEXF["AND Id NOT IN\n(excluded IDs)"]
    TEX -->|no| TGK
    TEXF --> TGK

    TGK["Group key =\nnormalizedSubject\n+ WhoId + WhatId\nFallback to Id when all empty"]
    TGK --> TDIR{Direction\ndetection}
    TDIR -->|>> in subject| TOUT[outbound]
    TDIR -->|<< or Inbox in subject| TIN[inbound]
    TDIR -->|parse From/To\nvs Owner.Email| TPARSED[outbound / inbound]
    TDIR -->|no signal| TUNK[unknown]

    TOUT & TIN & TPARSED & TUNK --> TPEOPLE["Resolve WhoId\nContact -> Lead fallback\nreturns contact object"]
    TPEOPLE --> TOUT2["Output thread\nlatestTaskId, allTaskIds\nnormalizedSubject\ndirection, contact\ncleanedDescription"]

    %% EMAILMESSAGE PATH
    OT -->|EmailMessage| EMF["Filter via /queryAll\nStatus != '5' - no drafts\nIsDeleted = false"]
    EMF --> EMGK{Thread key\npriority}
    EMGK -->|ParentId set\nEmail-to-Case| GK1["Group key = ParentId\nCase ID"]
    EMGK -->|ThreadIdentifier set\nEnhanced Email / inbox sync| GK2["Group key = ThreadIdentifier\nSalesforce conversation ID"]
    EMGK -->|neither set| GK3["Group key = Id\none message = one thread"]

    GK1 & GK2 & GK3 --> EMPEOPLE["Resolve via EmailMessageRelation\nContact -> Lead fallback\nreturns people array"]
    EMPEOPLE --> EMOUT["Output thread\nlatestMessageId, allMessageIds\nmessageIdentifiers\nfromAddress, toAddress, ccAddress\npeople array"]

    EMOUT --> RETAID{returnActivityIds?}
    RETAID -->|yes| AID["activityIds =\nJSON array of Task IDs\nauto-created alongside\nthese EmailMessages"]
    RETAID -->|no| BODY
    AID -->|"pass as excludeActivityIds\nin follow-up Task query"| TEX

    %% SHARED BODY CLEANING
    TOUT2 & EMOUT --> BODY["cleanBody pipeline\nDecode entities\nPreserve HTML line breaks\nStrip headers\nTruncate reply-chain quote\nRemove signature block\nTruncate to maxBodyLength"]

    %% PAGINATION
    BODY --> PAG{rawCount\n> limit?}
    PAG -->|yes| HM["hasMore: true\nhasMoreMessage surfaced\nnarrow WHERE or increase limit"]
    PAG -->|no| DONE([Return result])
    HM --> DONE
```

> **Note:** `MessageIdentifier` (RFC 2822 Message-ID header) is distinct from `ThreadIdentifier` (Salesforce's conversation grouping field) and `Id` (Salesforce record ID). `MessageIdentifier` plays no role in grouping — it is surfaced in the output as `messageIdentifiers` for downstream systems that need to cross-reference with external mail stores.

---

## Key behaviors

- Supports both `Task` and `EmailMessage` activity sources.
- Cleans email bodies by decoding entities, preserving HTML line breaks for header stripping, removing common email headers, truncating reply chains, removing signature blocks, and enforcing `maxBodyLength`.
- Groups Task records by normalized subject plus related `WhoId`/`WhatId`, while keeping Tasks with no subject or related records separate to avoid accidental merges.
- Groups EmailMessage records by `ParentId`, then `ThreadIdentifier`, then `Id`.
- Resolves people through Contact and Lead lookups.
- Supports `returnActivityIds` and `excludeActivityIds` to deduplicate EmailMessage and Task results across follow-up calls.
- Validates caller-provided SOQL where clauses before interpolation.
- Lets callers provide `taskDateTimeTieBreakerField` for synced email Tasks with a true sent-at DateTime field.

## Review follow-up included

This fresh branch includes fixes for the Greptile review feedback from the previous PR:

- Preserve `<br>`/block HTML line breaks before stripping Task Description headers.
- Avoid Task thread-key collisions when subject, `WhoId`, and `WhatId` are all empty.
- Prioritize `taskDateTimeTieBreakerField` before date-only `ActivityDate` when provided.

Docs: No external documentation update is required for this SDK action; the generated action metadata comes from schema.yaml, and this PR documents behavior and usage notes.

## Validation

- [x] `npx jest src/actions/providers/salesforce/getCleanActivityRecords.test.ts` — 55 tests passed
- [x] `npm run lint`
- [x] `npm run prettier-check`
- [x] `npm run build`

