### PR TITLE
Mark searchSlack action as deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.214",
+  "version": "0.2.215",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.214",
+      "version": "0.2.215",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.214",
+  "version": "0.2.215",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -905,7 +905,7 @@ export const slackGetChannelMembersDefinition: ActionTemplate = {
 export const slackUserSearchSlackDefinition: ActionTemplate = {
   displayName: "Search Slack",
   description:
-    "Search Slack (DM/MPIM by emails or channel) with optional topic/time filter. Automatically hydrates each hit (full thread if threaded, otherwise a small surrounding context).",
+    "Deprecated. Please use the Slack Real-Time Search action, or ask your Credal admin to enable it if not currently available.",
   scopes: [
     "search:read",
     "channels:read",

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -626,7 +626,7 @@ actions:
   slackUser:
     searchSlack:
       displayName: Search Slack
-      description: Search Slack (DM/MPIM by emails or channel) with optional topic/time filter. Automatically hydrates each hit (full thread if threaded, otherwise a small surrounding context).
+      description: Deprecated. Please use the Slack Real-Time Search action, or ask your Credal admin to enable it if not currently available.
       scopes:
         - search:read
         - channels:read


### PR DESCRIPTION
searchSlackRTS is preferred over searchSlack. Mark this action as deprecated so people stop using it.