### PR TITLE
Confluence Data Center Create and Write to page

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -85,6 +85,8 @@ import {
   confluenceFetchPageContentOutputSchema,
   confluenceDataCenterOverwritePageParamsSchema,
   confluenceDataCenterOverwritePageOutputSchema,
+  confluenceDataCenterCreatePageParamsSchema,
+  confluenceDataCenterCreatePageOutputSchema,
   confluenceDataCenterFetchPageContentParamsSchema,
   confluenceDataCenterFetchPageContentOutputSchema,
   snowflakeRunSnowflakeQueryParamsSchema,
@@ -337,6 +339,7 @@ import getBasicFinancials from "./providers/finnhub/getBasicFinancials.js";
 import confluenceOverwritePage from "./providers/confluence/overwritePage.js";
 import confluenceFetchPageContent from "./providers/confluence/fetchPageContent.js";
 import confluenceDataCenterOverwritePage from "./providers/confluenceDataCenter/overwritePage.js";
+import confluenceDataCenterCreatePage from "./providers/confluenceDataCenter/createPage.js";
 import confluenceDataCenterFetchPageContent from "./providers/confluenceDataCenter/fetchPageContent.js";
 import runSnowflakeQuery from "./providers/snowflake/runSnowflakeQuery.js";
 import enableUserByEmail from "./providers/looker/enableUserByEmail.js";
@@ -661,6 +664,12 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: confluenceDataCenterOverwritePage,
       paramsSchema: confluenceDataCenterOverwritePageParamsSchema,
       outputSchema: confluenceDataCenterOverwritePageOutputSchema,
+      actionType: "write",
+    },
+    createPage: {
+      fn: confluenceDataCenterCreatePage,
+      paramsSchema: confluenceDataCenterCreatePageParamsSchema,
+      outputSchema: confluenceDataCenterCreatePageOutputSchema,
       actionType: "write",
     },
     fetchPageContent: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1420,6 +1420,59 @@ export const confluenceDataCenterOverwritePageDefinition: ActionTemplate = {
   name: "overwritePage",
   provider: "confluenceDataCenter",
 };
+export const confluenceDataCenterCreatePageDefinition: ActionTemplate = {
+  displayName: "Create a page",
+  description: "Creates a new Confluence Data Center page in the specified space with the given content",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["spaceKey", "title", "content"],
+    properties: {
+      spaceKey: {
+        type: "string",
+        description: "The key of the Confluence space to create the page in",
+      },
+      title: {
+        type: "string",
+        description: "The title of the page to create",
+      },
+      content: {
+        type: "string",
+        description: "The content of the page in storage format (HTML)",
+      },
+      parentId: {
+        type: "string",
+        description:
+          "Optional ID of the parent page; if provided, the new page will be created as a child of this page",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the page was successfully created",
+      },
+      error: {
+        type: "string",
+        description: "The error that occurred if the page was not successfully created",
+      },
+      pageId: {
+        type: "string",
+        description: "The ID of the newly created page",
+      },
+      pageUrl: {
+        type: "string",
+        description: "The URL of the newly created page",
+      },
+    },
+  },
+  name: "createPage",
+  provider: "confluenceDataCenter",
+};
 export const confluenceDataCenterFetchPageContentDefinition: ActionTemplate = {
   displayName: "Fetch page content",
   description: "Fetches content from a Confluence page",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -1439,7 +1439,7 @@ export const confluenceDataCenterCreatePageDefinition: ActionTemplate = {
       },
       content: {
         type: "string",
-        description: "The content of the page in storage format (HTML)",
+        description: "The content of the page in Confluence storage format (XHTML-based markup)",
       },
       parentId: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -932,7 +932,7 @@ export type confluenceDataCenterOverwritePageFunction = ActionFunction<
 export const confluenceDataCenterCreatePageParamsSchema = z.object({
   spaceKey: z.string().describe("The key of the Confluence space to create the page in"),
   title: z.string().describe("The title of the page to create"),
-  content: z.string().describe("The content of the page in storage format (HTML)"),
+  content: z.string().describe("The content of the page in Confluence storage format (XHTML-based markup)"),
   parentId: z
     .string()
     .describe("Optional ID of the parent page; if provided, the new page will be created as a child of this page")

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -58,6 +58,7 @@ export enum ActionName {
   ADD = "add",
   OVERWRITEPAGE = "overwritePage",
   FETCHPAGECONTENT = "fetchPageContent",
+  CREATEPAGE = "createPage",
   ASSIGNJIRATICKET = "assignJiraTicket",
   PUBLICCOMMENTONSERVICEDESKREQUEST = "publicCommentOnServiceDeskRequest",
   COMMENTJIRATICKET = "commentJiraTicket",
@@ -926,6 +927,32 @@ export type confluenceDataCenterOverwritePageFunction = ActionFunction<
   confluenceDataCenterOverwritePageParamsType,
   AuthParamsType,
   confluenceDataCenterOverwritePageOutputType
+>;
+
+export const confluenceDataCenterCreatePageParamsSchema = z.object({
+  spaceKey: z.string().describe("The key of the Confluence space to create the page in"),
+  title: z.string().describe("The title of the page to create"),
+  content: z.string().describe("The content of the page in storage format (HTML)"),
+  parentId: z
+    .string()
+    .describe("Optional ID of the parent page; if provided, the new page will be created as a child of this page")
+    .optional(),
+});
+
+export type confluenceDataCenterCreatePageParamsType = z.infer<typeof confluenceDataCenterCreatePageParamsSchema>;
+
+export const confluenceDataCenterCreatePageOutputSchema = z.object({
+  success: z.boolean().describe("Whether the page was successfully created"),
+  error: z.string().describe("The error that occurred if the page was not successfully created").optional(),
+  pageId: z.string().describe("The ID of the newly created page").optional(),
+  pageUrl: z.string().describe("The URL of the newly created page").optional(),
+});
+
+export type confluenceDataCenterCreatePageOutputType = z.infer<typeof confluenceDataCenterCreatePageOutputSchema>;
+export type confluenceDataCenterCreatePageFunction = ActionFunction<
+  confluenceDataCenterCreatePageParamsType,
+  AuthParamsType,
+  confluenceDataCenterCreatePageOutputType
 >;
 
 export const confluenceDataCenterFetchPageContentParamsSchema = z.object({

--- a/src/actions/providers/confluenceDataCenter/createPage.ts
+++ b/src/actions/providers/confluenceDataCenter/createPage.ts
@@ -1,0 +1,60 @@
+import type {
+  confluenceDataCenterCreatePageFunction,
+  confluenceDataCenterCreatePageParamsType,
+  confluenceDataCenterCreatePageOutputType,
+  AuthParamsType,
+} from "../../autogen/types.js";
+import { axiosClient } from "../../util/axiosClient.js";
+import { getConfluenceApi } from "./helpers.js";
+
+const confluenceDataCenterCreatePage: confluenceDataCenterCreatePageFunction = async ({
+  params,
+  authParams,
+}: {
+  params: confluenceDataCenterCreatePageParamsType;
+  authParams: AuthParamsType;
+}): Promise<confluenceDataCenterCreatePageOutputType> => {
+  const { spaceKey, title, content, parentId } = params;
+
+  try {
+    const { baseUrl, config } = getConfluenceApi(authParams);
+
+    const payload: Record<string, unknown> = {
+      type: "page",
+      title,
+      space: { key: spaceKey },
+      body: {
+        storage: {
+          value: content,
+          representation: "storage",
+        },
+      },
+    };
+
+    if (parentId) {
+      payload.ancestors = [{ id: parentId }];
+    }
+
+    const response = await axiosClient.post(`${baseUrl}/content`, payload, config);
+
+    const pageId: string | undefined = response.data?.id;
+    const links = response.data?._links ?? {};
+    const pageUrl: string | undefined = links.base && links.webui ? `${links.base}${links.webui}` : links.self;
+
+    return {
+      success: true,
+      pageId,
+      pageUrl,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred while creating the Confluence Data Center page.",
+    };
+  }
+};
+
+export default confluenceDataCenterCreatePage;

--- a/src/actions/providers/confluenceDataCenter/createPage.ts
+++ b/src/actions/providers/confluenceDataCenter/createPage.ts
@@ -39,7 +39,7 @@ const confluenceDataCenterCreatePage: confluenceDataCenterCreatePageFunction = a
 
     const pageId: string | undefined = response.data?.id;
     const links = response.data?._links ?? {};
-    const pageUrl: string | undefined = links.base && links.webui ? `${links.base}${links.webui}` : links.self;
+    const pageUrl: string | undefined = links.base && links.webui ? `${links.base}${links.webui}` : undefined;
 
     return {
       success: true,

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1047,7 +1047,7 @@ actions:
             description: The title of the page to create
           content:
             type: string
-            description: The content of the page in storage format (HTML)
+            description: The content of the page in Confluence storage format (XHTML-based markup)
           parentId:
             type: string
             description: Optional ID of the parent page; if provided, the new page will be created as a child of this page

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1031,6 +1031,42 @@ actions:
           error:
             type: string
             description: The error that occurred if the page was not successfully updated
+    createPage:
+      displayName: Create a page
+      description: Creates a new Confluence Data Center page in the specified space with the given content
+      scopes: []
+      parameters:
+        type: object
+        required: [spaceKey, title, content]
+        properties:
+          spaceKey:
+            type: string
+            description: The key of the Confluence space to create the page in
+          title:
+            type: string
+            description: The title of the page to create
+          content:
+            type: string
+            description: The content of the page in storage format (HTML)
+          parentId:
+            type: string
+            description: Optional ID of the parent page; if provided, the new page will be created as a child of this page
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the page was successfully created
+          error:
+            type: string
+            description: The error that occurred if the page was not successfully created
+          pageId:
+            type: string
+            description: The ID of the newly created page
+          pageUrl:
+            type: string
+            description: The URL of the newly created page
     fetchPageContent:
       displayName: Fetch page content
       description: Fetches content from a Confluence page


### PR DESCRIPTION
**Context:**
ACF wants to be able to create new pages in Confluence for a specific use case. They currently have access to an action that only overwrites an existing page.

**Summary:**
This action will create and write to a page based on an optional parent param to designate the location of the page that is being created. According to the documentation it only needs the parenId and computes the rest of the ancestors server side.

**Risk:**
Risks involve creating and writing to unwanted confluence pages which isn't the end of the world since Confluence has version control.

**Testing:**
I wrote a test script, but I was not able to test it since we need to pay for the Data Center version of Confluence in order to do so. Since ACF is the only one that uses it I can turn it on in their dev environment and test it out.