### PR TITLE
[CE-1740] Return labels field in Jira issue query results

### DIFF
--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -2284,6 +2284,13 @@ export const jiraGetJiraIssuesByQueryDefinition: ActionTemplate = {
                   nullable: true,
                   format: "date",
                 },
+                labels: {
+                  type: "array",
+                  description: "The labels assigned to the issue (empty array if none)",
+                  items: {
+                    type: "string",
+                  },
+                },
               },
             },
           },
@@ -3165,6 +3172,13 @@ export const jiraOrgGetJiraIssuesByQueryDefinition: ActionTemplate = {
                   nullable: true,
                   format: "date",
                 },
+                labels: {
+                  type: "array",
+                  description: "The labels assigned to the issue (empty array if none)",
+                  items: {
+                    type: "string",
+                  },
+                },
               },
             },
           },
@@ -4030,6 +4044,13 @@ export const jiraDataCenterGetJiraIssuesByQueryDefinition: ActionTemplate = {
                   type: "string",
                   nullable: true,
                   format: "date",
+                },
+                labels: {
+                  type: "array",
+                  description: "The labels assigned to the issue (empty array if none)",
+                  items: {
+                    type: "string",
+                  },
                 },
               },
             },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -1346,6 +1346,7 @@ export const jiraGetJiraIssuesByQueryOutputSchema = z.object({
             updated: z.string().datetime({ offset: true }),
             resolution: z.string().nullable().optional(),
             dueDate: z.string().date().nullable().optional(),
+            labels: z.array(z.string()).describe("The labels assigned to the issue (empty array if none)").optional(),
           })
           .describe("The result object containing issues"),
       }),
@@ -1795,6 +1796,7 @@ export const jiraOrgGetJiraIssuesByQueryOutputSchema = z.object({
             updated: z.string().datetime({ offset: true }),
             resolution: z.string().nullable().optional(),
             dueDate: z.string().date().nullable().optional(),
+            labels: z.array(z.string()).describe("The labels assigned to the issue (empty array if none)").optional(),
           })
           .describe("The result object containing issues"),
       }),
@@ -2252,6 +2254,7 @@ export const jiraDataCenterGetJiraIssuesByQueryOutputSchema = z.object({
             updated: z.string().datetime({ offset: true }),
             resolution: z.string().nullable().optional(),
             dueDate: z.string().date().nullable().optional(),
+            labels: z.array(z.string()).describe("The labels assigned to the issue (empty array if none)").optional(),
           })
           .describe("The result object containing issues"),
       }),

--- a/src/actions/providers/jira/getJiraDCIssuesByQuery.ts
+++ b/src/actions/providers/jira/getJiraDCIssuesByQuery.ts
@@ -47,6 +47,7 @@ type JiraSearchResponse = {
         name: string;
       } | null;
       duedate?: string | null;
+      labels?: string[] | null;
     };
   }[];
   startAt: number;
@@ -84,6 +85,7 @@ const getJiraDCIssuesByQuery: jiraDataCenterGetJiraIssuesByQueryFunction = async
     "updated",
     "resolution",
     "duedate",
+    "labels",
     "timeoriginalestimate",
     "timespent",
     "aggregatetimeoriginalestimate",
@@ -140,6 +142,7 @@ const getJiraDCIssuesByQuery: jiraDataCenterGetJiraIssuesByQueryFunction = async
           updated,
           resolution,
           duedate,
+          labels,
         } = fields;
 
         const ticketUrl = `${browseUrl}/browse/${key}`;
@@ -191,6 +194,7 @@ const getJiraDCIssuesByQuery: jiraDataCenterGetJiraIssuesByQueryFunction = async
             updated,
             resolution: resolution?.name || null,
             dueDate: duedate || null,
+            labels: labels ?? [],
             url: ticketUrl,
           },
         };

--- a/src/actions/providers/jira/getJiraIssuesByQuery.ts
+++ b/src/actions/providers/jira/getJiraIssuesByQuery.ts
@@ -27,6 +27,7 @@ type JiraCloudSearchResponse = {
       updated: string;
       resolution?: { name: string } | null;
       duedate?: string | null;
+      labels?: string[] | null;
     };
   }[];
   nextPageToken?: string;
@@ -60,6 +61,7 @@ const getJiraIssuesByQuery: jiraGetJiraIssuesByQueryFunction = async ({
     "updated",
     "resolution",
     "duedate",
+    "labels",
     "timeoriginalestimate",
     "timespent",
     "aggregatetimeoriginalestimate",
@@ -117,6 +119,7 @@ const getJiraIssuesByQuery: jiraGetJiraIssuesByQueryFunction = async ({
           updated,
           resolution,
           duedate,
+          labels,
         } = fields;
 
         const [assigneeInfo, reporterInfo, creatorInfo] = await Promise.all([
@@ -143,6 +146,7 @@ const getJiraIssuesByQuery: jiraGetJiraIssuesByQueryFunction = async ({
             updated,
             resolution: resolution?.name,
             dueDate: duedate,
+            labels: labels ?? [],
             url: ticketUrl,
           },
         };

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1649,6 +1649,11 @@ actions:
                       type: string
                       nullable: true
                       format: date
+                    labels:
+                      type: array
+                      description: The labels assigned to the issue (empty array if none)
+                      items:
+                        type: string
           error:
             type: string
             description: The error that occurred if the records were not successfully retrieved

--- a/tests/jira/testGetJiraIssuesByQuery.ts
+++ b/tests/jira/testGetJiraIssuesByQuery.ts
@@ -49,6 +49,10 @@ async function testGetJiraIssuesByQuery(config: JiraTestConfig) {
 
     assert.strictEqual(page2.error, undefined);
     assert.ok(page2.results && page2.results.length > 0, "page 2 should have results");
+    assert.ok(
+      Array.isArray(page2.results[0].contents.labels),
+      "page 2 result's contents should include a labels array (empty if the issue has no labels)",
+    );
 
     // Keys on page 2 must not overlap with page 1
     const page1Keys = new Set(page1.results!.map(r => r.name));

--- a/tests/jira/testGetJiraIssuesByQuery.ts
+++ b/tests/jira/testGetJiraIssuesByQuery.ts
@@ -28,6 +28,10 @@ async function testGetJiraIssuesByQuery(config: JiraTestConfig) {
   assert.ok(page1.results[0].name, "first result should have a key");
   assert.ok(page1.results[0].url, "first result should have a url");
   assert.ok(page1.results[0].contents, "first result should have contents");
+  assert.ok(
+    Array.isArray(page1.results[0].contents.labels),
+    "first result's contents should include a labels array (empty if the issue has no labels)",
+  );
 
   // Pagination: if nextPageToken is present, fetch page 2
   if (page1.nextPageToken) {


### PR DESCRIPTION
## Why

A customer (Flatiron) querying Jira via `getJiraIssuesByQuery` reported that the `labels` field was missing from every ticket's `contents`, while all other fields (summary, status, dueDate, project, assignee, …) came back fine. There was no caller-side workaround — the action exposes only `query`/`limit`, so labels could not be requested.

Tracked in [CE-1740](https://linear.app/credalai/issue/CE-1740/add-labels-field-to-jira-getjiraissuesbyquery-results).

## Root cause

`labels` was being dropped at three independent layers, so fixing any one alone would not have surfaced it:

1. **Not requested** — `labels` was absent from the `fields` array sent to the Jira search API, so Jira never returned it.
2. **Not mapped** — even if returned, `labels` was never destructured into the `contents` output object.
3. **Stripped by the schema** — the Zod output schema is a plain `z.object()`, which strips unknown keys, and had no `labels`. A mapped value would have been dropped at parse time.

## What changed

`labels` is now requested, mapped, and declared across all three Jira variants — `jira` (Cloud), `jiraOrg`, and `jiraDataCenter`.

**Where to look:**
- `src/actions/schema.yaml` is the single source of truth. `labels` was added to the shared `&jira_issue_query_item` anchor. Because `jiraDataCenter` reuses that anchor and `jiraOrg` aliases the whole `jira` block, this one edit covers all three variants — that's why the generated diff touches three schemas from a single source change.
- `autogen/types.ts` and `autogen/templates.ts` are **generated** (`npm run generate:types`) — not hand-edited. They were regenerated and `prettier-format`ted, so the diff there is exactly the three `labels` additions and nothing else.
- The two provider impls (`getJiraIssuesByQuery.ts` Cloud, `getJiraDCIssuesByQuery.ts` DC) each add `labels` to the requested fields, the response type, the destructure, and the output map.

**One deliberate decision:** `labels` is mapped as `labels ?? []`, so every ticket returns `"labels": []` even when it has none. The schema field is left **optional** (not added to `required`) to stay consistent with the sibling `resolution`/`dueDate` fields in the same object, which are likewise always populated but typed optional.

## Testing

- `npx tsc --noEmit` passes; `npm run lint` clean.
- Extended the existing integration test `tests/jira/testGetJiraIssuesByQuery.ts` to assert `contents.labels` is always an array (rather than adding a standalone test).
- Live smoke test (requires Jira creds per `tests/jira/utils.ts`): run `testGetJiraIssuesByQuery` against a project containing both labelled and unlabelled issues, and confirm `contents.labels` is a populated array on the former and `[]` on the latter. Worth exercising all three providers, since `jiraOrg` shares the Cloud impl and DC is a separate code path.

## Follow-up (separate PR)

Version bump (`0.2.220` → `0.2.221`) + publish, then bump the `@credal/actions` pin in the main app.
