### PR TITLE
[CE-1740] Bump @credal/actions to 0.2.221 for Jira labels release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.220",
+  "version": "0.2.221",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.220",
+      "version": "0.2.221",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.220",
+  "version": "0.2.221",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,


### PR DESCRIPTION
## Why

This is the release step for the Jira `labels` fix that merged in [#575](https://github.com/Credal-ai/actions-sdk/pull/575) (CE-1740). That PR added the `labels` field to `getJiraIssuesByQuery` output across all three Jira variants, but the change can't reach consumers until a new package version is published to npm. We deliberately split the version bump out of the feature PR to keep that one focused on behaviour.

## What changed

Bumps `@credal/actions` from `0.2.220` → `0.2.221`, updating `package.json` and both required self-version locations in `package-lock.json` (top-level `version` and `packages[""].version`), per the release process documented in `README.md` step 6.

Patch bump (not minor): the labels change is backward-compatible, and it matches this repo's convention of incrementing the patch digit per release (0.2.208 → 0.2.213 → 0.2.220).

## Testing

Metadata-only — no functional change. To sanity-check before publishing:

- `npm ci` — confirms the lockfile resolves cleanly against `package.json` (fails loudly if they're out of sync).
- `node -p "require('./package.json').version"` and `node -p "require('./package-lock.json').version"` — both print `0.2.221`.
- `npm publish --dry-run --access public` — confirms the tarball builds and the version is publishable.

## Release

Once merged: `npm publish --access public` (requires `npm login`), then bump the `@credal/actions` pin in the main app to `0.2.221`.
