### PR TITLE
smart sheet actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.220",
+  "version": "0.2.221",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.220",
+      "version": "0.2.221",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.220",
+  "version": "0.2.221",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -294,6 +294,14 @@ import {
   salesforceGetReportMetadataOutputSchema,
   googleOauthUpdateRowsInSpreadsheetParamsSchema,
   googleOauthUpdateRowsInSpreadsheetOutputSchema,
+  smartsheetListSheetsParamsSchema,
+  smartsheetListSheetsOutputSchema,
+  smartsheetGetSheetRowsParamsSchema,
+  smartsheetGetSheetRowsOutputSchema,
+  smartsheetAddRowToSheetParamsSchema,
+  smartsheetAddRowToSheetOutputSchema,
+  smartsheetUpdateRowParamsSchema,
+  smartsheetUpdateRowOutputSchema,
 } from "./autogen/types.js";
 import validateAddress from "./providers/googlemaps/validateAddress.js";
 import add from "./providers/math/add.js";
@@ -441,6 +449,10 @@ import searchAllSalesforceRecords from "./providers/salesforce/searchAllSalesfor
 import listReports from "./providers/salesforce/listReports.js";
 import getReportMetadata from "./providers/salesforce/getReportMetadata.js";
 import executeReport from "./providers/salesforce/executeReport.js";
+import smartsheetListSheets from "./providers/smartsheet/listSheets.js";
+import smartsheetGetSheetRows from "./providers/smartsheet/getSheetRows.js";
+import smartsheetAddRowToSheet from "./providers/smartsheet/addRowToSheet.js";
+import smartsheetUpdateRow from "./providers/smartsheet/updateRow.js";
 
 type ActionTypeSchema = "read" | "write";
 
@@ -1437,4 +1449,30 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
     },
   },
   boxUser: {},
+  smartsheet: {
+    listSheets: {
+      fn: smartsheetListSheets,
+      paramsSchema: smartsheetListSheetsParamsSchema,
+      outputSchema: smartsheetListSheetsOutputSchema,
+      actionType: "read",
+    },
+    getSheetRows: {
+      fn: smartsheetGetSheetRows,
+      paramsSchema: smartsheetGetSheetRowsParamsSchema,
+      outputSchema: smartsheetGetSheetRowsOutputSchema,
+      actionType: "read",
+    },
+    addRowToSheet: {
+      fn: smartsheetAddRowToSheet,
+      paramsSchema: smartsheetAddRowToSheetParamsSchema,
+      outputSchema: smartsheetAddRowToSheetOutputSchema,
+      actionType: "write",
+    },
+    updateRow: {
+      fn: smartsheetUpdateRow,
+      paramsSchema: smartsheetUpdateRowParamsSchema,
+      outputSchema: smartsheetUpdateRowOutputSchema,
+      actionType: "write",
+    },
+  },
 };

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15406,3 +15406,251 @@ export const hubspotGetTicketDetailsDefinition: ActionTemplate = {
   name: "getTicketDetails",
   provider: "hubspot",
 };
+export const smartsheetListSheetsDefinition: ActionTemplate = {
+  displayName: "List Smartsheet sheets",
+  description:
+    "List all Smartsheet sheets the authenticated user has access to. Use this first to find a sheet's sheetId by its name before calling other Smartsheet actions.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: [],
+    properties: {},
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the sheets were successfully listed",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      sheets: {
+        type: "array",
+        description: "The sheets the user has access to",
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "The sheet ID, passed as sheetId to other Smartsheet actions",
+            },
+            name: {
+              type: "string",
+              description: "The sheet name",
+            },
+            permalink: {
+              type: "string",
+              description: "URL to open the sheet in Smartsheet",
+            },
+          },
+        },
+      },
+    },
+  },
+  name: "listSheets",
+  provider: "smartsheet",
+};
+export const smartsheetGetSheetRowsDefinition: ActionTemplate = {
+  displayName: "Get rows from a Smartsheet sheet",
+  description:
+    "Get the columns and rows of a Smartsheet sheet. Each row's cells are returned as a map keyed by column title. Use this to read a sheet's contents and to discover column titles and row IDs before adding or updating rows.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["sheetId"],
+    properties: {
+      sheetId: {
+        type: "string",
+        description:
+          "The ID of the sheet to read. Obtain this from the listSheets action or from the user; do not guess it.",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the sheet was successfully retrieved",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      sheet: {
+        type: "object",
+        description: "The sheet's columns and rows",
+        properties: {
+          id: {
+            type: "string",
+            description: "The sheet ID",
+          },
+          name: {
+            type: "string",
+            description: "The sheet name",
+          },
+          permalink: {
+            type: "string",
+            description: "URL to open the sheet in Smartsheet",
+          },
+          columns: {
+            type: "array",
+            description: "The sheet's columns, in display order",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  description: "The column ID",
+                },
+                title: {
+                  type: "string",
+                  description:
+                    "The column title. Use these exact titles as keys in the cells parameter of addRowToSheet and updateRow.",
+                },
+                type: {
+                  type: "string",
+                  description: "The column type (e.g. TEXT_NUMBER, PICKLIST, DATE, CHECKBOX, CONTACT_LIST)",
+                },
+                options: {
+                  type: "array",
+                  description: "The valid values for PICKLIST columns",
+                  items: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+          rows: {
+            type: "array",
+            description: "The sheet's rows",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  description: "The row ID, passed as rowId to the updateRow action",
+                },
+                rowNumber: {
+                  type: "number",
+                  description: "The row's position in the sheet, starting at 1",
+                },
+                cells: {
+                  type: "object",
+                  description: "The row's cell values, keyed by column title",
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  name: "getSheetRows",
+  provider: "smartsheet",
+};
+export const smartsheetAddRowToSheetDefinition: ActionTemplate = {
+  displayName: "Add a row to a Smartsheet sheet",
+  description:
+    "Add a new row to a Smartsheet sheet. Cell values are provided as a map keyed by column title. Call getSheetRows first to see the sheet's column titles and the valid values for PICKLIST columns.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["sheetId", "cells"],
+    properties: {
+      sheetId: {
+        type: "string",
+        description:
+          "The ID of the sheet to add the row to. Obtain this from the listSheets action or from the user; do not guess it.",
+      },
+      cells: {
+        type: "object",
+        description:
+          'The new row\'s cell values, keyed by column title exactly as returned by getSheetRows, e.g. {"Task Name": "Review budget", "Status": "In Progress"}. Values may be strings, numbers, or booleans.',
+        additionalProperties: true,
+      },
+      toTop: {
+        type: "boolean",
+        description: "If true, the row is added to the top of the sheet. Defaults to false (added to the bottom).",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the row was successfully added",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      rowId: {
+        type: "string",
+        description: "The ID of the newly created row",
+      },
+    },
+  },
+  name: "addRowToSheet",
+  provider: "smartsheet",
+};
+export const smartsheetUpdateRowDefinition: ActionTemplate = {
+  displayName: "Update a row in a Smartsheet sheet",
+  description:
+    "Update cell values of an existing row in a Smartsheet sheet. Only the columns included in the cells parameter are changed. Call getSheetRows first to find the row's rowId and the sheet's column titles.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["sheetId", "rowId", "cells"],
+    properties: {
+      sheetId: {
+        type: "string",
+        description:
+          "The ID of the sheet containing the row. Obtain this from the listSheets action or from the user; do not guess it.",
+      },
+      rowId: {
+        type: "string",
+        description: "The ID of the row to update, as returned by the getSheetRows action",
+      },
+      cells: {
+        type: "object",
+        description:
+          'The cell values to change, keyed by column title exactly as returned by getSheetRows, e.g. {"Status": "Complete"}. Columns not included are left unchanged. Values may be strings, numbers, or booleans.',
+        additionalProperties: true,
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the row was successfully updated",
+      },
+      error: {
+        type: "string",
+        description: "Error message if the operation failed",
+      },
+      rowId: {
+        type: "string",
+        description: "The ID of the updated row",
+      },
+    },
+  },
+  name: "updateRow",
+  provider: "smartsheet",
+};

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -36,6 +36,7 @@ export enum ProviderName {
   GITLAB = "gitlab",
   LINEAR = "linear",
   HUBSPOT = "hubspot",
+  SMARTSHEET = "smartsheet",
   BOXUSER = "boxUser",
 }
 
@@ -178,6 +179,10 @@ export enum ActionName {
   GETDEALS = "getDeals",
   GETDEALDETAILS = "getDealDetails",
   GETTICKETS = "getTickets",
+  LISTSHEETS = "listSheets",
+  GETSHEETROWS = "getSheetRows",
+  ADDROWTOSHEET = "addRowToSheet",
+  UPDATEROW = "updateRow",
 }
 
 export type ActionFunction<P, A, O> = (input: { params: P; authParams: A }) => Promise<O>;
@@ -7835,4 +7840,150 @@ export type hubspotGetTicketDetailsFunction = ActionFunction<
   hubspotGetTicketDetailsParamsType,
   AuthParamsType,
   hubspotGetTicketDetailsOutputType
+>;
+
+export const smartsheetListSheetsParamsSchema = z.object({});
+
+export type smartsheetListSheetsParamsType = z.infer<typeof smartsheetListSheetsParamsSchema>;
+
+export const smartsheetListSheetsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the sheets were successfully listed"),
+  error: z.string().describe("Error message if the operation failed").optional(),
+  sheets: z
+    .array(
+      z.object({
+        id: z.string().describe("The sheet ID, passed as sheetId to other Smartsheet actions").optional(),
+        name: z.string().describe("The sheet name").optional(),
+        permalink: z.string().describe("URL to open the sheet in Smartsheet").optional(),
+      }),
+    )
+    .describe("The sheets the user has access to")
+    .optional(),
+});
+
+export type smartsheetListSheetsOutputType = z.infer<typeof smartsheetListSheetsOutputSchema>;
+export type smartsheetListSheetsFunction = ActionFunction<
+  smartsheetListSheetsParamsType,
+  AuthParamsType,
+  smartsheetListSheetsOutputType
+>;
+
+export const smartsheetGetSheetRowsParamsSchema = z.object({
+  sheetId: z
+    .string()
+    .describe("The ID of the sheet to read. Obtain this from the listSheets action or from the user; do not guess it."),
+});
+
+export type smartsheetGetSheetRowsParamsType = z.infer<typeof smartsheetGetSheetRowsParamsSchema>;
+
+export const smartsheetGetSheetRowsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the sheet was successfully retrieved"),
+  error: z.string().describe("Error message if the operation failed").optional(),
+  sheet: z
+    .object({
+      id: z.string().describe("The sheet ID").optional(),
+      name: z.string().describe("The sheet name").optional(),
+      permalink: z.string().describe("URL to open the sheet in Smartsheet").optional(),
+      columns: z
+        .array(
+          z.object({
+            id: z.string().describe("The column ID").optional(),
+            title: z
+              .string()
+              .describe(
+                "The column title. Use these exact titles as keys in the cells parameter of addRowToSheet and updateRow.",
+              )
+              .optional(),
+            type: z
+              .string()
+              .describe("The column type (e.g. TEXT_NUMBER, PICKLIST, DATE, CHECKBOX, CONTACT_LIST)")
+              .optional(),
+            options: z.array(z.string()).describe("The valid values for PICKLIST columns").optional(),
+          }),
+        )
+        .describe("The sheet's columns, in display order")
+        .optional(),
+      rows: z
+        .array(
+          z.object({
+            id: z.string().describe("The row ID, passed as rowId to the updateRow action").optional(),
+            rowNumber: z.coerce.number().describe("The row's position in the sheet, starting at 1").optional(),
+            cells: z.object({}).catchall(z.any()).describe("The row's cell values, keyed by column title").optional(),
+          }),
+        )
+        .describe("The sheet's rows")
+        .optional(),
+    })
+    .describe("The sheet's columns and rows")
+    .optional(),
+});
+
+export type smartsheetGetSheetRowsOutputType = z.infer<typeof smartsheetGetSheetRowsOutputSchema>;
+export type smartsheetGetSheetRowsFunction = ActionFunction<
+  smartsheetGetSheetRowsParamsType,
+  AuthParamsType,
+  smartsheetGetSheetRowsOutputType
+>;
+
+export const smartsheetAddRowToSheetParamsSchema = z.object({
+  sheetId: z
+    .string()
+    .describe(
+      "The ID of the sheet to add the row to. Obtain this from the listSheets action or from the user; do not guess it.",
+    ),
+  cells: z
+    .object({})
+    .catchall(z.any())
+    .describe(
+      'The new row\'s cell values, keyed by column title exactly as returned by getSheetRows, e.g. {"Task Name": "Review budget", "Status": "In Progress"}. Values may be strings, numbers, or booleans.',
+    ),
+  toTop: z
+    .boolean()
+    .describe("If true, the row is added to the top of the sheet. Defaults to false (added to the bottom).")
+    .optional(),
+});
+
+export type smartsheetAddRowToSheetParamsType = z.infer<typeof smartsheetAddRowToSheetParamsSchema>;
+
+export const smartsheetAddRowToSheetOutputSchema = z.object({
+  success: z.boolean().describe("Whether the row was successfully added"),
+  error: z.string().describe("Error message if the operation failed").optional(),
+  rowId: z.string().describe("The ID of the newly created row").optional(),
+});
+
+export type smartsheetAddRowToSheetOutputType = z.infer<typeof smartsheetAddRowToSheetOutputSchema>;
+export type smartsheetAddRowToSheetFunction = ActionFunction<
+  smartsheetAddRowToSheetParamsType,
+  AuthParamsType,
+  smartsheetAddRowToSheetOutputType
+>;
+
+export const smartsheetUpdateRowParamsSchema = z.object({
+  sheetId: z
+    .string()
+    .describe(
+      "The ID of the sheet containing the row. Obtain this from the listSheets action or from the user; do not guess it.",
+    ),
+  rowId: z.string().describe("The ID of the row to update, as returned by the getSheetRows action"),
+  cells: z
+    .object({})
+    .catchall(z.any())
+    .describe(
+      'The cell values to change, keyed by column title exactly as returned by getSheetRows, e.g. {"Status": "Complete"}. Columns not included are left unchanged. Values may be strings, numbers, or booleans.',
+    ),
+});
+
+export type smartsheetUpdateRowParamsType = z.infer<typeof smartsheetUpdateRowParamsSchema>;
+
+export const smartsheetUpdateRowOutputSchema = z.object({
+  success: z.boolean().describe("Whether the row was successfully updated"),
+  error: z.string().describe("Error message if the operation failed").optional(),
+  rowId: z.string().describe("The ID of the updated row").optional(),
+});
+
+export type smartsheetUpdateRowOutputType = z.infer<typeof smartsheetUpdateRowOutputSchema>;
+export type smartsheetUpdateRowFunction = ActionFunction<
+  smartsheetUpdateRowParamsType,
+  AuthParamsType,
+  smartsheetUpdateRowOutputType
 >;

--- a/src/actions/providers/smartsheet/addRowToSheet.ts
+++ b/src/actions/providers/smartsheet/addRowToSheet.ts
@@ -1,0 +1,55 @@
+import type {
+  AuthParamsType,
+  smartsheetAddRowToSheetFunction,
+  smartsheetAddRowToSheetOutputType,
+  smartsheetAddRowToSheetParamsType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getSmartsheetToken, resolveCellsByColumnTitle, smartsheetRequest } from "./utils.js";
+
+type AddRowsResponse = {
+  result: { id: number } | Array<{ id: number }>;
+};
+
+const addRowToSheet: smartsheetAddRowToSheetFunction = async ({
+  params,
+  authParams,
+}: {
+  params: smartsheetAddRowToSheetParamsType;
+  authParams: AuthParamsType;
+}): Promise<smartsheetAddRowToSheetOutputType> => {
+  const token = getSmartsheetToken(authParams);
+  if (!token) throw new Error(MISSING_AUTH_TOKEN);
+
+  const { sheetId, cells, toTop } = params;
+
+  try {
+    const resolvedCells = await resolveCellsByColumnTitle(token, sheetId, cells);
+    if (resolvedCells.length === 0) {
+      return { success: false, error: "cells must contain at least one column title to value mapping" };
+    }
+
+    const response = await smartsheetRequest<AddRowsResponse>(`/sheets/${sheetId}/rows`, token, {
+      method: "POST",
+      body: {
+        ...(toTop ? { toTop: true } : { toBottom: true }),
+        cells: resolvedCells,
+      },
+    });
+
+    const createdRow = Array.isArray(response.result) ? response.result[0] : response.result;
+
+    return {
+      success: true,
+      rowId: createdRow ? String(createdRow.id) : undefined,
+    };
+  } catch (error) {
+    console.error("Error adding row to Smartsheet sheet:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default addRowToSheet;

--- a/src/actions/providers/smartsheet/getSheetRows.ts
+++ b/src/actions/providers/smartsheet/getSheetRows.ts
@@ -1,0 +1,72 @@
+import type {
+  AuthParamsType,
+  smartsheetGetSheetRowsFunction,
+  smartsheetGetSheetRowsOutputType,
+  smartsheetGetSheetRowsParamsType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import type { SmartsheetColumn, SmartsheetRow } from "./utils.js";
+import { getSmartsheetToken, smartsheetRequest } from "./utils.js";
+
+type GetSheetResponse = {
+  id: number;
+  name: string;
+  permalink: string;
+  columns: SmartsheetColumn[];
+  rows: SmartsheetRow[];
+};
+
+const getSheetRows: smartsheetGetSheetRowsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: smartsheetGetSheetRowsParamsType;
+  authParams: AuthParamsType;
+}): Promise<smartsheetGetSheetRowsOutputType> => {
+  const token = getSmartsheetToken(authParams);
+  if (!token) throw new Error(MISSING_AUTH_TOKEN);
+
+  try {
+    const sheet = await smartsheetRequest<GetSheetResponse>(`/sheets/${params.sheetId}`, token);
+
+    const columnTitleById = new Map(sheet.columns.map(column => [column.id, column.title]));
+
+    return {
+      success: true,
+      sheet: {
+        id: String(sheet.id),
+        name: sheet.name,
+        permalink: sheet.permalink,
+        columns: sheet.columns.map(column => ({
+          id: String(column.id),
+          title: column.title,
+          type: column.type,
+          ...(column.options ? { options: column.options } : {}),
+        })),
+        rows: sheet.rows.map(row => {
+          const cells: Record<string, string | number | boolean> = {};
+          for (const cell of row.cells ?? []) {
+            const title = columnTitleById.get(cell.columnId);
+            const value = cell.displayValue ?? cell.value;
+            if (title && value !== undefined) {
+              cells[title] = value;
+            }
+          }
+          return {
+            id: String(row.id),
+            rowNumber: row.rowNumber,
+            cells,
+          };
+        }),
+      },
+    };
+  } catch (error) {
+    console.error("Error getting Smartsheet sheet rows:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default getSheetRows;

--- a/src/actions/providers/smartsheet/listSheets.ts
+++ b/src/actions/providers/smartsheet/listSheets.ts
@@ -1,0 +1,45 @@
+import type {
+  AuthParamsType,
+  smartsheetListSheetsFunction,
+  smartsheetListSheetsOutputType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getSmartsheetToken, smartsheetRequest } from "./utils.js";
+
+type ListSheetsResponse = {
+  data: Array<{
+    id: number;
+    name: string;
+    permalink: string;
+  }>;
+};
+
+const listSheets: smartsheetListSheetsFunction = async ({
+  authParams,
+}: {
+  authParams: AuthParamsType;
+}): Promise<smartsheetListSheetsOutputType> => {
+  const token = getSmartsheetToken(authParams);
+  if (!token) throw new Error(MISSING_AUTH_TOKEN);
+
+  try {
+    const response = await smartsheetRequest<ListSheetsResponse>("/sheets?includeAll=true", token);
+
+    return {
+      success: true,
+      sheets: response.data.map(sheet => ({
+        id: String(sheet.id),
+        name: sheet.name,
+        permalink: sheet.permalink,
+      })),
+    };
+  } catch (error) {
+    console.error("Error listing Smartsheet sheets:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default listSheets;

--- a/src/actions/providers/smartsheet/updateRow.ts
+++ b/src/actions/providers/smartsheet/updateRow.ts
@@ -1,0 +1,55 @@
+import type {
+  AuthParamsType,
+  smartsheetUpdateRowFunction,
+  smartsheetUpdateRowOutputType,
+  smartsheetUpdateRowParamsType,
+} from "../../autogen/types.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { getSmartsheetToken, resolveCellsByColumnTitle, smartsheetRequest } from "./utils.js";
+
+type UpdateRowsResponse = {
+  result: { id: number } | Array<{ id: number }>;
+};
+
+const updateRow: smartsheetUpdateRowFunction = async ({
+  params,
+  authParams,
+}: {
+  params: smartsheetUpdateRowParamsType;
+  authParams: AuthParamsType;
+}): Promise<smartsheetUpdateRowOutputType> => {
+  const token = getSmartsheetToken(authParams);
+  if (!token) throw new Error(MISSING_AUTH_TOKEN);
+
+  const { sheetId, rowId, cells } = params;
+
+  try {
+    const resolvedCells = await resolveCellsByColumnTitle(token, sheetId, cells);
+    if (resolvedCells.length === 0) {
+      return { success: false, error: "cells must contain at least one column title to value mapping" };
+    }
+
+    const response = await smartsheetRequest<UpdateRowsResponse>(`/sheets/${sheetId}/rows`, token, {
+      method: "PUT",
+      body: {
+        id: Number(rowId),
+        cells: resolvedCells,
+      },
+    });
+
+    const updatedRow = Array.isArray(response.result) ? response.result[0] : response.result;
+
+    return {
+      success: true,
+      rowId: updatedRow ? String(updatedRow.id) : String(rowId),
+    };
+  } catch (error) {
+    console.error("Error updating row in Smartsheet sheet:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+export default updateRow;

--- a/src/actions/providers/smartsheet/utils.ts
+++ b/src/actions/providers/smartsheet/utils.ts
@@ -59,18 +59,24 @@ export async function resolveCellsByColumnTitle(
   sheetId: string,
   cellsByTitle: Record<string, unknown>,
 ): Promise<Array<{ columnId: number; value: string | number | boolean; strict: boolean }>> {
-  const { data: columns } = await smartsheetRequest<{ data: SmartsheetColumn[] }>(
+  const columnsResponse = await smartsheetRequest<{ data?: SmartsheetColumn[] }>(
     `/sheets/${sheetId}/columns?includeAll=true`,
     token,
   );
+  const columns = columnsResponse.data;
+  if (!Array.isArray(columns)) {
+    throw new Error(
+      `Could not read columns for sheet "${sheetId}": the Smartsheet API returned an unexpected response shape.`,
+    );
+  }
 
-  const columnIdByTitle = new Map(columns.map(c => [c.title, c.id]));
+  const columnIdByTitle = new Map(columns.map(column => [column.title, column.id]));
 
   return Object.entries(cellsByTitle).map(([title, value]) => {
     const columnId = columnIdByTitle.get(title);
     if (columnId === undefined) {
       throw new Error(
-        `Column "${title}" does not exist in this sheet. Valid column titles are: ${columns.map(c => `"${c.title}"`).join(", ")}`,
+        `Column "${title}" does not exist in this sheet. Valid column titles are: ${columns.map(column => `"${column.title}"`).join(", ")}`,
       );
     }
     if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {

--- a/src/actions/providers/smartsheet/utils.ts
+++ b/src/actions/providers/smartsheet/utils.ts
@@ -1,0 +1,82 @@
+const SMARTSHEET_API_BASE = "https://api.smartsheet.com/2.0";
+
+export type SmartsheetColumn = {
+  id: number;
+  title: string;
+  type: string;
+  options?: string[];
+};
+
+export type SmartsheetCell = {
+  columnId: number;
+  value?: string | number | boolean;
+  displayValue?: string;
+};
+
+export type SmartsheetRow = {
+  id: number;
+  rowNumber: number;
+  cells?: SmartsheetCell[];
+};
+
+export function getSmartsheetToken(authParams: { apiKey?: string; authToken?: string }): string | undefined {
+  return authParams.apiKey ?? authParams.authToken;
+}
+
+export async function smartsheetRequest<T>(
+  path: string,
+  token: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> {
+  const response = await fetch(`${SMARTSHEET_API_BASE}${path}`, {
+    method: init?.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+
+  const data = await response.json().catch(() => undefined);
+
+  if (!response.ok) {
+    const message =
+      data && typeof data === "object" && "message" in data
+        ? (data as { message: string }).message
+        : response.statusText;
+    throw new Error(`Smartsheet API error (status ${response.status}): ${message}`);
+  }
+
+  return data as T;
+}
+
+/**
+ * Resolves a { "Column Title": value } map to the cell objects the Smartsheet API expects,
+ * which address cells by numeric columnId.
+ */
+export async function resolveCellsByColumnTitle(
+  token: string,
+  sheetId: string,
+  cellsByTitle: Record<string, unknown>,
+): Promise<Array<{ columnId: number; value: string | number | boolean; strict: boolean }>> {
+  const { data: columns } = await smartsheetRequest<{ data: SmartsheetColumn[] }>(
+    `/sheets/${sheetId}/columns?includeAll=true`,
+    token,
+  );
+
+  const columnIdByTitle = new Map(columns.map(c => [c.title, c.id]));
+
+  return Object.entries(cellsByTitle).map(([title, value]) => {
+    const columnId = columnIdByTitle.get(title);
+    if (columnId === undefined) {
+      throw new Error(
+        `Column "${title}" does not exist in this sheet. Valid column titles are: ${columns.map(c => `"${c.title}"`).join(", ")}`,
+      );
+    }
+    if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+      throw new Error(`Cell value for column "${title}" must be a string, number, or boolean`);
+    }
+    // strict: false lets Smartsheet coerce values (e.g. numbers into TEXT_NUMBER columns)
+    return { columnId, value, strict: false };
+  });
+}

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9621,4 +9621,170 @@ actions:
               archived:
                 type: boolean
                 description: Whether the ticket is archived
+  smartsheet:
+    listSheets:
+      displayName: List Smartsheet sheets
+      description: List all Smartsheet sheets the authenticated user has access to. Use this first to find a sheet's sheetId by its name before calling other Smartsheet actions.
+      scopes: []
+      parameters:
+        type: object
+        required: []
+        properties: {}
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the sheets were successfully listed
+          error:
+            type: string
+            description: Error message if the operation failed
+          sheets:
+            type: array
+            description: The sheets the user has access to
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: The sheet ID, passed as sheetId to other Smartsheet actions
+                name:
+                  type: string
+                  description: The sheet name
+                permalink:
+                  type: string
+                  description: URL to open the sheet in Smartsheet
+    getSheetRows:
+      displayName: Get rows from a Smartsheet sheet
+      description: Get the columns and rows of a Smartsheet sheet. Each row's cells are returned as a map keyed by column title. Use this to read a sheet's contents and to discover column titles and row IDs before adding or updating rows.
+      scopes: []
+      parameters:
+        type: object
+        required: [sheetId]
+        properties:
+          sheetId:
+            type: string
+            description: The ID of the sheet to read. Obtain this from the listSheets action or from the user; do not guess it.
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the sheet was successfully retrieved
+          error:
+            type: string
+            description: Error message if the operation failed
+          sheet:
+            type: object
+            description: The sheet's columns and rows
+            properties:
+              id:
+                type: string
+                description: The sheet ID
+              name:
+                type: string
+                description: The sheet name
+              permalink:
+                type: string
+                description: URL to open the sheet in Smartsheet
+              columns:
+                type: array
+                description: The sheet's columns, in display order
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The column ID
+                    title:
+                      type: string
+                      description: The column title. Use these exact titles as keys in the cells parameter of addRowToSheet and updateRow.
+                    type:
+                      type: string
+                      description: The column type (e.g. TEXT_NUMBER, PICKLIST, DATE, CHECKBOX, CONTACT_LIST)
+                    options:
+                      type: array
+                      description: The valid values for PICKLIST columns
+                      items:
+                        type: string
+              rows:
+                type: array
+                description: The sheet's rows
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The row ID, passed as rowId to the updateRow action
+                    rowNumber:
+                      type: number
+                      description: The row's position in the sheet, starting at 1
+                    cells:
+                      type: object
+                      description: The row's cell values, keyed by column title
+                      additionalProperties: true
+    addRowToSheet:
+      displayName: Add a row to a Smartsheet sheet
+      description: Add a new row to a Smartsheet sheet. Cell values are provided as a map keyed by column title. Call getSheetRows first to see the sheet's column titles and the valid values for PICKLIST columns.
+      scopes: []
+      parameters:
+        type: object
+        required: [sheetId, cells]
+        properties:
+          sheetId:
+            type: string
+            description: The ID of the sheet to add the row to. Obtain this from the listSheets action or from the user; do not guess it.
+          cells:
+            type: object
+            description: 'The new row''s cell values, keyed by column title exactly as returned by getSheetRows, e.g. {"Task Name": "Review budget", "Status": "In Progress"}. Values may be strings, numbers, or booleans.'
+            additionalProperties: true
+          toTop:
+            type: boolean
+            description: If true, the row is added to the top of the sheet. Defaults to false (added to the bottom).
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the row was successfully added
+          error:
+            type: string
+            description: Error message if the operation failed
+          rowId:
+            type: string
+            description: The ID of the newly created row
+    updateRow:
+      displayName: Update a row in a Smartsheet sheet
+      description: Update cell values of an existing row in a Smartsheet sheet. Only the columns included in the cells parameter are changed. Call getSheetRows first to find the row's rowId and the sheet's column titles.
+      scopes: []
+      parameters:
+        type: object
+        required: [sheetId, rowId, cells]
+        properties:
+          sheetId:
+            type: string
+            description: The ID of the sheet containing the row. Obtain this from the listSheets action or from the user; do not guess it.
+          rowId:
+            type: string
+            description: The ID of the row to update, as returned by the getSheetRows action
+          cells:
+            type: object
+            description: 'The cell values to change, keyed by column title exactly as returned by getSheetRows, e.g. {"Status": "Complete"}. Columns not included are left unchanged. Values may be strings, numbers, or booleans.'
+            additionalProperties: true
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the row was successfully updated
+          error:
+            type: string
+            description: Error message if the operation failed
+          rowId:
+            type: string
+            description: The ID of the updated row
   boxUser: {}

--- a/tests/smartsheet/testSmartsheet.ts
+++ b/tests/smartsheet/testSmartsheet.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert";
+import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+// Full round trip: listSheets → getSheetRows → addRowToSheet → updateRow.
+// Requires SMARTSHEET_API_KEY and SMARTSHEET_TEST_SHEET_NAME (a sheet the token can write to).
+async function runTest() {
+  const authParams = { apiKey: process.env.SMARTSHEET_API_KEY! };
+  const sheetName = process.env.SMARTSHEET_TEST_SHEET_NAME!;
+
+  const listResult = await runAction("listSheets", "smartsheet", authParams, {});
+  assert(listResult.success, listResult.error || "listSheets did not succeed");
+  assert(Array.isArray(listResult.sheets), "sheets should be an array");
+  const sheet = listResult.sheets.find((s: { name: string }) => s.name === sheetName);
+  assert(sheet, `Sheet "${sheetName}" not found among ${listResult.sheets.length} sheets`);
+
+  const getResult = await runAction("getSheetRows", "smartsheet", authParams, { sheetId: sheet.id });
+  assert(getResult.success, getResult.error || "getSheetRows did not succeed");
+  assert(getResult.sheet, "sheet should be present in the response");
+  assert(Array.isArray(getResult.sheet.columns) && getResult.sheet.columns.length > 0, "sheet should have columns");
+  const firstColumnTitle = getResult.sheet.columns[0].title;
+  assert(firstColumnTitle, "first column should have a title");
+
+  const addResult = await runAction("addRowToSheet", "smartsheet", authParams, {
+    sheetId: sheet.id,
+    cells: { [firstColumnTitle]: `Test row ${new Date().toISOString()}` },
+  });
+  assert(addResult.success, addResult.error || "addRowToSheet did not succeed");
+  assert(addResult.rowId, "addRowToSheet should return the new rowId");
+
+  const updateResult = await runAction("updateRow", "smartsheet", authParams, {
+    sheetId: sheet.id,
+    rowId: addResult.rowId,
+    cells: { [firstColumnTitle]: `Updated row ${new Date().toISOString()}` },
+  });
+  assert(updateResult.success, updateResult.error || "updateRow did not succeed");
+  assert(updateResult.rowId === addResult.rowId, "updateRow should return the same rowId");
+
+  const badColumnResult = await runAction("addRowToSheet", "smartsheet", authParams, {
+    sheetId: sheet.id,
+    cells: { "Nonexistent Column": "value" },
+  });
+  assert(!badColumnResult.success, "addRowToSheet with an unknown column title should fail");
+  assert(
+    badColumnResult.error?.includes("Valid column titles"),
+    "Error for an unknown column title should list valid column titles",
+  );
+
+  console.log("All Smartsheet actions succeeded. Created and updated row:", addResult.rowId);
+}
+
+runTest().catch(error => {
+  console.error("Test failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Add Smartsheet provider

Adds a `smartsheet` provider with four actions for a customer demo, to be attached to a Credal first-party MCP server  a minimal but complete read + write loop:

- **`listSheets`** (read) — `GET /sheets`, discover a sheet's ID by name
- **`getSheetRows`** (read) — `GET /sheets/{sheetId}`, cells keyed by column title
- **`addRowToSheet`** (write) — `POST /sheets/{sheetId}/rows`
- **`updateRow`** (write) — `PUT /sheets/{sheetId}/rows`

Write actions accept a `{ "Column Title": value }` map and resolve titles → numeric `columnId`s internally (the raw API addresses cells by ID, which LLMs handle poorly); `getSheetRows` does the inverse. IDs are exposed as strings to avoid precision loss. Token is read as `apiKey ?? authToken`, so it works with either a PAT or per-user OAuth unchanged. Bumps `@credal/actions` to 0.2.221.

Verified with `tsc`, `eslint`, `prettier`, and the existing `jest` suite (all pass). Live API round-trip pending a Business-tier token; integration script included at `tests/smartsheet/testSmartsheet.ts`.
