### PR TITLE
Add transparency setting option to gcal actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.221",
+  "version": "0.2.222",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.221",
+      "version": "0.2.222",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.221",
+  "version": "0.2.222",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -6683,6 +6683,12 @@ export const googleOauthScheduleCalendarMeetingDefinition: ActionTemplate = {
         type: "string",
         description: "The time zone for the meeting, IANA Time Zone identifier (e.g., 'America/New_York')",
       },
+      transparency: {
+        type: "string",
+        enum: ["opaque", "transparent"],
+        description:
+          'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar. This is equivalent to setting "Show me as" to "Available" in the UI.',
+      },
       recurrence: {
         type: "object",
         description: "Recurring meeting configuration. If not provided, creates a one-time meeting.",
@@ -7066,6 +7072,12 @@ export const googleOauthUpdateCalendarEventDefinition: ActionTemplate = {
             type: "string",
             description: "The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')",
           },
+          transparency: {
+            type: "string",
+            enum: ["opaque", "transparent"],
+            description:
+              'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.',
+          },
         },
       },
     },
@@ -7162,6 +7174,12 @@ export const googleOauthEditAGoogleCalendarEventDefinition: ActionTemplate = {
       timeZone: {
         type: "string",
         description: "The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')",
+      },
+      transparency: {
+        type: "string",
+        enum: ["opaque", "transparent"],
+        description:
+          'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.',
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -3628,6 +3628,12 @@ export const googleOauthScheduleCalendarMeetingParamsSchema = z.object({
     .string()
     .describe("The time zone for the meeting, IANA Time Zone identifier (e.g., 'America/New_York')")
     .optional(),
+  transparency: z
+    .enum(["opaque", "transparent"])
+    .describe(
+      'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar. This is equivalent to setting "Show me as" to "Available" in the UI.',
+    )
+    .optional(),
   recurrence: z
     .object({
       frequency: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).describe("How often the meeting repeats").optional(),
@@ -3824,6 +3830,12 @@ export const googleOauthUpdateCalendarEventParamsSchema = z.object({
         .string()
         .describe("The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')")
         .optional(),
+      transparency: z
+        .enum(["opaque", "transparent"])
+        .describe(
+          'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.',
+        )
+        .optional(),
     })
     .describe("The fields to update on the event")
     .optional(),
@@ -3868,6 +3880,12 @@ export const googleOauthEditAGoogleCalendarEventParamsSchema = z.object({
   timeZone: z
     .string()
     .describe("The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')")
+    .optional(),
+  transparency: z
+    .enum(["opaque", "transparent"])
+    .describe(
+      'Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.',
+    )
     .optional(),
 });
 

--- a/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/editAGoogleCalendarEvent.ts
@@ -20,8 +20,20 @@ const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = as
     return { success: false, error: MISSING_AUTH_TOKEN, eventId: "", eventUrl: "", eventDayOfWeek: "" };
   }
 
-  const { calendarId, eventId, title, description, start, end, location, attendees, status, organizer, timeZone } =
-    params;
+  const {
+    calendarId,
+    eventId,
+    title,
+    description,
+    start,
+    end,
+    location,
+    attendees,
+    status,
+    organizer,
+    timeZone,
+    transparency,
+  } = params;
   const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
 
   const body: Record<string, unknown> = {};
@@ -43,6 +55,7 @@ const editAGoogleCalendarEvent: googleOauthEditAGoogleCalendarEventFunction = as
   if (attendees !== undefined) body.attendees = attendees.map(email => ({ email }));
   if (status !== undefined) body.status = status;
   if (organizer !== undefined) body.organizer = organizer;
+  if (transparency !== undefined) body.transparency = transparency;
 
   try {
     const res: AxiosResponse = await axiosClient.patch(url, body, {

--- a/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
+++ b/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
@@ -134,7 +134,7 @@ const scheduleCalendarMeeting: googleOauthScheduleCalendarMeetingFunction = asyn
     }
   }
   // Add transparency if specified
-  if (transparency) {
+  if (transparency !== undefined) {
     data.transparency = transparency;
   }
 

--- a/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
+++ b/src/actions/providers/google-oauth/scheduleCalendarMeeting.ts
@@ -30,10 +30,16 @@ function generateRecurrenceRule(
     const year = date.getUTCFullYear();
     const month = String(date.getUTCMonth() + 1).padStart(2, "0");
     const day = String(date.getUTCDate()).padStart(2, "0");
-    const hour = String(date.getUTCHours()).padStart(2, "0");
-    const minute = String(date.getUTCMinutes()).padStart(2, "0");
-    const second = String(date.getUTCSeconds()).padStart(2, "0");
-    rrule += `;UNTIL=${year}${month}${day}T${hour}${minute}${second}Z`; // trufflehog:ignore
+    // Use date-only format for UNTIL when BYDAY is specified (day-based recurrence)
+    // This is required by Google Calendar API for WEEKLY+BYDAY recurrences
+    if (recurrence.byDay && recurrence.byDay.length > 0) {
+      rrule += `;UNTIL=${year}${month}${day}`;
+    } else {
+      const hour = String(date.getUTCHours()).padStart(2, "0");
+      const minute = String(date.getUTCMinutes()).padStart(2, "0");
+      const second = String(date.getUTCSeconds()).padStart(2, "0");
+      rrule += `;UNTIL=${year}${month}${day}T${hour}${minute}${second}Z`; // trufflehog:ignore
+    }
   }
 
   if (recurrence.byDay && recurrence.byDay.length > 0) {
@@ -61,7 +67,8 @@ const scheduleCalendarMeeting: googleOauthScheduleCalendarMeetingFunction = asyn
   if (!authParams.authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
-  const { calendarId, name, start, end, description, attendees, useGoogleMeet, timeZone, recurrence } = params;
+  const { calendarId, name, start, end, description, attendees, useGoogleMeet, timeZone, recurrence, transparency } =
+    params;
   // https://developers.google.com/calendar/api/v3/reference/events/insert
   let createEventApiUrl = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`;
 
@@ -83,6 +90,7 @@ const scheduleCalendarMeeting: googleOauthScheduleCalendarMeetingFunction = asyn
       };
     };
     recurrence?: string[];
+    transparency?: string;
   } = {
     summary: name,
     start: {
@@ -124,6 +132,10 @@ const scheduleCalendarMeeting: googleOauthScheduleCalendarMeetingFunction = asyn
         error: "Invalid recurrence configuration: " + (error instanceof Error ? error.message : "Unknown error"),
       };
     }
+  }
+  // Add transparency if specified
+  if (transparency) {
+    data.transparency = transparency;
   }
 
   try {

--- a/src/actions/providers/google-oauth/updateCalendarEvent.ts
+++ b/src/actions/providers/google-oauth/updateCalendarEvent.ts
@@ -42,6 +42,7 @@ const updateCalendarEvent: googleOauthUpdateCalendarEventFunction = async ({
     if (updates.attendees != undefined) body.attendees = updates.attendees.map(email => ({ email }));
     if (updates.status != undefined) body.status = updates.status;
     if (updates.organizer != undefined) body.organizer = updates.organizer;
+    if (updates.transparency != undefined) body.transparency = updates.transparency;
   }
 
   try {

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -3522,6 +3522,10 @@ actions:
           timeZone:
             type: string
             description: The time zone for the meeting, IANA Time Zone identifier (e.g., 'America/New_York')
+          transparency:
+            type: string
+            enum: [opaque, transparent]
+            description: Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar. This is equivalent to setting "Show me as" to "Available" in the UI.
           recurrence:
             type: object
             description: Recurring meeting configuration. If not provided, creates a one-time meeting.
@@ -3795,6 +3799,10 @@ actions:
               timeZone:
                 type: string
                 description: The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')
+              transparency:
+                type: string
+                enum: [opaque, transparent]
+                description: Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.
       output:
         type: object
         required: [success]
@@ -3863,6 +3871,10 @@ actions:
           timeZone:
             type: string
             description: The time zone for the event, IANA Time Zone identifier (e.g., 'America/New_York')
+          transparency:
+            type: string
+            enum: [opaque, transparent]
+            description: Opaque is the default value, and it blocks time on the calendar. This is equivalent to setting "Show me as" to "Busy" in the UI. Transparent means the event does not block time on the calendar.
       output:
         type: object
         required: [success]

--- a/tests/google-oauth/testEditAGoogleCalendarEvent.ts
+++ b/tests/google-oauth/testEditAGoogleCalendarEvent.ts
@@ -9,8 +9,8 @@ async function runTest() {
     "googleOauth",
     { authToken: process.env.GOOGLE_OAUTH_EDIT_EVENT_SCOPE },
     {
-      calendarId: "primary",
-      eventId: "19ta0khreli30ib22n2c2717vd", 
+      calendarId: process.env.CALENDAR_ID,
+      eventId: process.env.EVENT_ID,
       title: "Edited Event Title",
       description: "Edited event description",
       start: new Date(Date.now() + 3600 * 1000).toISOString(),
@@ -19,6 +19,7 @@ async function runTest() {
       attendees: ["colleague@example.com", "manager@example.com"],
       status: "confirmed",
       timeZone: "Europe/London",
+      transparency: "opaque",
     },
   );
 

--- a/tests/google-oauth/testGoogleScheduleMeeting.ts
+++ b/tests/google-oauth/testGoogleScheduleMeeting.ts
@@ -4,10 +4,13 @@ import type {
 } from "../../src/actions/autogen/types.js";
 import { runAction } from "../../src/app.js";
 import assert from "node:assert";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 // Test configuration
-const authToken = "insert-access-token";
-const calendarId = "insert-calendar-id";
+const authToken = process.env.GCAL_AUTH_TOKEN;
+const calendarId = process.env.CALENDAR_ID;
 
 /**
  * Test for basic Google OAuth scheduleCalendarMeeting action
@@ -32,6 +35,7 @@ async function runBasicTest() {
       attendees: ["test@test.com", "test2@test.com"],
       useGoogleMeet: true,
       timeZone: "America/New_York",
+      transparency: "opaque",
     } as googleOauthScheduleCalendarMeetingParamsType
   );
 

--- a/tests/google-oauth/testListCalendarEvents.ts
+++ b/tests/google-oauth/testListCalendarEvents.ts
@@ -14,7 +14,7 @@ async function runTest() {
     "googleOauth",
     { authToken: process.env.GOOGLE_CAL_AUTH_TOKEN },
     {
-      calendarId: "jack@credal.ai",
+      calendarId: process.env.CALENDAR_ID,
       query: "",
       maxResults: 50,
       timeMin: weekBeg.toISOString(),

--- a/tests/google-oauth/testListCalendars.ts
+++ b/tests/google-oauth/testListCalendars.ts
@@ -11,7 +11,6 @@ async function runTest() {
     { authToken: process.env.GCAL_AUTH_TOKEN },
     { maxResults: 5 }, // optional
   );
-  console.log(result);
   assert(result, "Response should not be null");
   assert(result.success, "Success should be true");
   assert(Array.isArray(result.calendars), "Calendars should be an array");

--- a/tests/google-oauth/testListCalendars.ts
+++ b/tests/google-oauth/testListCalendars.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 async function runTest() {
   const result = await runAction(
     "listCalendars",
     "googleOauth",
-    { authToken: "auth-token-here" },
-    { maxResults: 1 }, // optional
+    { authToken: process.env.GCAL_AUTH_TOKEN },
+    { maxResults: 5 }, // optional
   );
-
+  console.log(result);
   assert(result, "Response should not be null");
   assert(result.success, "Success should be true");
   assert(Array.isArray(result.calendars), "Calendars should be an array");

--- a/tests/google-oauth/testUpdateCalendarEvent.ts
+++ b/tests/google-oauth/testUpdateCalendarEvent.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert";
 import { runAction } from "../../src/app.js";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 async function runTest() {
   const result = await runAction(
     "updateCalendarEvent",
     "googleOauth",
-    { authToken: "auth-token-with-calendar-scope-here" },
+    { authToken: process.env.GCAL_AUTH_TOKEN },
     {
-      calendarId: "primary",
-      eventId: "event-id-here", 
+      calendarId: process.env.CALENDAR_ID,
+      eventId: process.env.EVENT_ID,
       updates: {
         title: "Updated Event Title",
         description: "Updated event description",
@@ -17,6 +20,7 @@ async function runTest() {
         location: "Virtual",
         attendees: ["test@example.com"],
         timeZone: "America/Los_Angeles",
+        transparency: "transparent",
       },
     },
   );


### PR DESCRIPTION
This was a customer ask and straightforward to implement! Allows users to set transparency in gcal actions