### PR TITLE
Adding ServiceNow Actions

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -37,6 +37,14 @@ import {
   zendeskSearchZendeskByQueryParamsSchema,
   servicenowGetRecordsByQueryOutputSchema,
   servicenowGetRecordsByQueryParamsSchema,
+  servicenowGetIncidentsOutputSchema,
+  servicenowGetIncidentsParamsSchema,
+  servicenowGetChangeRequestsOutputSchema,
+  servicenowGetChangeRequestsParamsSchema,
+  servicenowGetSCTasksOutputSchema,
+  servicenowGetSCTasksParamsSchema,
+  servicenowGetVIPTicketsOutputSchema,
+  servicenowGetVIPTicketsParamsSchema,
   jiraAssignJiraTicketParamsSchema,
   jiraAssignJiraTicketOutputSchema,
   jiraCommentJiraTicketParamsSchema,
@@ -321,6 +329,10 @@ import assignTicket from "./providers/zendesk/assignTicket.js";
 import listZendeskTickets from "./providers/zendesk/listTickets.js";
 import searchZendeskByQuery from "./providers/zendesk/searchZendeskByQuery.js";
 import getServiceNowRecordsByQuery from "./providers/servicenow/getRecordsByQuery.js";
+import getServiceNowIncidents from "./providers/servicenow/getIncidents.js";
+import getServiceNowChangeRequests from "./providers/servicenow/getChangeRequests.js";
+import getServiceNowSCTasks from "./providers/servicenow/getSCTasks.js";
+import getServiceNowVIPTickets from "./providers/servicenow/getVIPTickets.js";
 import assignJiraTicket from "./providers/jira/assignJiraTicket.js";
 import commentJiraTicket from "./providers/jira/commentJiraTicket.js";
 import commentJiraTicketWithMentions from "./providers/jira/commentJiraTicketWithMentions.js";
@@ -762,6 +774,30 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: getServiceNowRecordsByQuery,
       paramsSchema: servicenowGetRecordsByQueryParamsSchema,
       outputSchema: servicenowGetRecordsByQueryOutputSchema,
+      actionType: "read",
+    },
+    getIncidents: {
+      fn: getServiceNowIncidents,
+      paramsSchema: servicenowGetIncidentsParamsSchema,
+      outputSchema: servicenowGetIncidentsOutputSchema,
+      actionType: "read",
+    },
+    getChangeRequests: {
+      fn: getServiceNowChangeRequests,
+      paramsSchema: servicenowGetChangeRequestsParamsSchema,
+      outputSchema: servicenowGetChangeRequestsOutputSchema,
+      actionType: "read",
+    },
+    getSCTasks: {
+      fn: getServiceNowSCTasks,
+      paramsSchema: servicenowGetSCTasksParamsSchema,
+      outputSchema: servicenowGetSCTasksOutputSchema,
+      actionType: "read",
+    },
+    getVIPTickets: {
+      fn: getServiceNowVIPTickets,
+      paramsSchema: servicenowGetVIPTicketsParamsSchema,
+      outputSchema: servicenowGetVIPTicketsOutputSchema,
       actionType: "read",
     },
   },

--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -35,6 +35,8 @@ import {
   zendeskListZendeskTicketsParamsSchema,
   zendeskSearchZendeskByQueryOutputSchema,
   zendeskSearchZendeskByQueryParamsSchema,
+  servicenowGetRecordsByQueryOutputSchema,
+  servicenowGetRecordsByQueryParamsSchema,
   jiraAssignJiraTicketParamsSchema,
   jiraAssignJiraTicketOutputSchema,
   jiraCommentJiraTicketParamsSchema,
@@ -318,6 +320,7 @@ import addCommentToTicket from "./providers/zendesk/addCommentToTicket.js";
 import assignTicket from "./providers/zendesk/assignTicket.js";
 import listZendeskTickets from "./providers/zendesk/listTickets.js";
 import searchZendeskByQuery from "./providers/zendesk/searchZendeskByQuery.js";
+import getServiceNowRecordsByQuery from "./providers/servicenow/getRecordsByQuery.js";
 import assignJiraTicket from "./providers/jira/assignJiraTicket.js";
 import commentJiraTicket from "./providers/jira/commentJiraTicket.js";
 import commentJiraTicketWithMentions from "./providers/jira/commentJiraTicketWithMentions.js";
@@ -751,6 +754,14 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: searchZendeskByQuery,
       paramsSchema: zendeskSearchZendeskByQueryParamsSchema,
       outputSchema: zendeskSearchZendeskByQueryOutputSchema,
+      actionType: "read",
+    },
+  },
+  servicenow: {
+    getRecordsByQuery: {
+      fn: getServiceNowRecordsByQuery,
+      paramsSchema: servicenowGetRecordsByQueryParamsSchema,
+      outputSchema: servicenowGetRecordsByQueryOutputSchema,
       actionType: "read",
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15738,3 +15738,508 @@ export const servicenowGetRecordsByQueryDefinition: ActionTemplate = {
   name: "getRecordsByQuery",
   provider: "servicenow",
 };
+export const servicenowGetIncidentsDefinition: ActionTemplate = {
+  displayName: "Get ServiceNow incidents",
+  description:
+    "Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-resolution.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: [],
+    properties: {
+      query: {
+        type: "string",
+        description:
+          'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base incident lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=7" for open, priority-1 incidents. Leave empty to return all incidents up to the limit.\n',
+      },
+      additionalFields: {
+        type: "array",
+        description:
+          'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+        items: {
+          type: "string",
+        },
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of incidents to return (defaults to 25)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip, for pagination (defaults to 0)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the query was successful",
+      },
+      records: {
+        type: "array",
+        description: "The incident records matching the query",
+        items: {
+          type: "object",
+          properties: {
+            number: {
+              type: "string",
+              description: "The incident ticket number (e.g. INC0010023)",
+            },
+            caller: {
+              type: "string",
+              description: "The name of the person who reported the incident",
+            },
+            assignee: {
+              type: "string",
+              description: "The name of the person assigned to the incident",
+            },
+            assignmentGroup: {
+              type: "string",
+              description: "The name of the group assigned to the incident",
+            },
+            shortDescription: {
+              type: "string",
+              description: "The short description of the incident",
+            },
+            description: {
+              type: "string",
+              description: "The full description of the incident",
+            },
+            state: {
+              type: "string",
+              description: "The current state of the incident",
+            },
+            incidentState: {
+              type: "string",
+              description: "The current incident-specific state (legacy field on some instances; may be absent)",
+            },
+            priority: {
+              type: "string",
+              description: "The priority of the incident",
+            },
+            impact: {
+              type: "string",
+              description: "The impact of the incident",
+            },
+            urgency: {
+              type: "string",
+              description: "The urgency of the incident",
+            },
+            openedAt: {
+              type: "string",
+              description: "The date and time the incident was opened",
+            },
+            updatedAt: {
+              type: "string",
+              description: "The date and time the incident was last updated",
+            },
+            closedAt: {
+              type: "string",
+              description: "The date and time the incident was closed or completed, if applicable",
+            },
+            workNotes: {
+              type: "string",
+              description: "Internal work notes on the incident",
+            },
+            comments: {
+              type: "string",
+              description: "Additional (customer-visible) comments on the incident",
+            },
+            timeToResolutionMinutes: {
+              type: "number",
+              description: "Minutes elapsed between openedAt and closedAt, if the incident is closed",
+            },
+            extraFields: {
+              type: "object",
+              description: "Values for any fields requested via the additionalFields parameter, keyed by field name",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if the query failed",
+      },
+    },
+  },
+  name: "getIncidents",
+  provider: "servicenow",
+};
+export const servicenowGetChangeRequestsDefinition: ActionTemplate = {
+  displayName: "Get ServiceNow change requests",
+  description:
+    "Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-resolution.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: [],
+    properties: {
+      query: {
+        type: "string",
+        description:
+          'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base change request lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open, priority-1 change requests. Leave empty to return all change requests up to the limit.\n',
+      },
+      additionalFields: {
+        type: "array",
+        description:
+          'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+        items: {
+          type: "string",
+        },
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of change requests to return (defaults to 25)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip, for pagination (defaults to 0)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the query was successful",
+      },
+      records: {
+        type: "array",
+        description: "The change request records matching the query",
+        items: {
+          type: "object",
+          properties: {
+            number: {
+              type: "string",
+              description: "The change request number (e.g. CHG0010023)",
+            },
+            requestor: {
+              type: "string",
+              description: "The name of the person who requested the change",
+            },
+            assignee: {
+              type: "string",
+              description: "The name of the person assigned to the change request",
+            },
+            assignmentGroup: {
+              type: "string",
+              description: "The name of the group assigned to the change request",
+            },
+            shortDescription: {
+              type: "string",
+              description: "The short description of the change request",
+            },
+            description: {
+              type: "string",
+              description: "The full description of the change request",
+            },
+            state: {
+              type: "string",
+              description: "The current state of the change request",
+            },
+            priority: {
+              type: "string",
+              description: "The priority of the change request",
+            },
+            impact: {
+              type: "string",
+              description: "The impact of the change request",
+            },
+            urgency: {
+              type: "string",
+              description: "The urgency of the change request",
+            },
+            openedAt: {
+              type: "string",
+              description: "The date and time the change request was opened",
+            },
+            updatedAt: {
+              type: "string",
+              description: "The date and time the change request was last updated",
+            },
+            closedAt: {
+              type: "string",
+              description: "The date and time the change request was closed or completed, if applicable",
+            },
+            workNotes: {
+              type: "string",
+              description: "Internal work notes on the change request",
+            },
+            comments: {
+              type: "string",
+              description: "Additional (customer-visible) comments on the change request",
+            },
+            timeToResolutionMinutes: {
+              type: "number",
+              description: "Minutes elapsed between openedAt and closedAt, if the change request is closed",
+            },
+            extraFields: {
+              type: "object",
+              description: "Values for any fields requested via the additionalFields parameter, keyed by field name",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if the query failed",
+      },
+    },
+  },
+  name: "getChangeRequests",
+  provider: "servicenow",
+};
+export const servicenowGetSCTasksDefinition: ActionTemplate = {
+  displayName: "Get ServiceNow catalog tasks (SCTASKs)",
+  description:
+    "Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-resolution.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: [],
+    properties: {
+      query: {
+        type: "string",
+        description:
+          'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base SCTASK lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open, priority-1 SCTASKs. Leave empty to return all SCTASKs up to the limit.\n',
+      },
+      additionalFields: {
+        type: "array",
+        description:
+          'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+        items: {
+          type: "string",
+        },
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of SCTASKs to return (defaults to 25)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip, for pagination (defaults to 0)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the query was successful",
+      },
+      records: {
+        type: "array",
+        description: "The SCTASK records matching the query",
+        items: {
+          type: "object",
+          properties: {
+            number: {
+              type: "string",
+              description: "The SCTASK ticket number (e.g. SCTASK0010023)",
+            },
+            ritmNumber: {
+              type: "string",
+              description: "The number of the parent Requested Item (RITM) this SCTASK belongs to",
+            },
+            assignee: {
+              type: "string",
+              description: "The name of the person assigned to the SCTASK",
+            },
+            assignmentGroup: {
+              type: "string",
+              description: "The name of the group assigned to the SCTASK",
+            },
+            shortDescription: {
+              type: "string",
+              description: "The short description of the SCTASK",
+            },
+            description: {
+              type: "string",
+              description: "The full description of the SCTASK",
+            },
+            state: {
+              type: "string",
+              description: "The current state of the SCTASK",
+            },
+            priority: {
+              type: "string",
+              description: "The priority of the SCTASK",
+            },
+            openedAt: {
+              type: "string",
+              description: "The date and time the SCTASK was opened",
+            },
+            updatedAt: {
+              type: "string",
+              description: "The date and time the SCTASK was last updated",
+            },
+            closedAt: {
+              type: "string",
+              description: "The date and time the SCTASK was closed or completed, if applicable",
+            },
+            workNotes: {
+              type: "string",
+              description: "Internal work notes on the SCTASK",
+            },
+            comments: {
+              type: "string",
+              description: "Additional (customer-visible) comments on the SCTASK",
+            },
+            timeToResolutionMinutes: {
+              type: "number",
+              description: "Minutes elapsed between openedAt and closedAt, if the SCTASK is closed",
+            },
+            extraFields: {
+              type: "object",
+              description: "Values for any fields requested via the additionalFields parameter, keyed by field name",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if the query failed",
+      },
+    },
+  },
+  name: "getSCTasks",
+  provider: "servicenow",
+};
+export const servicenowGetVIPTicketsDefinition: ActionTemplate = {
+  displayName: "Get ServiceNow VIP tickets",
+  description:
+    "Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-resolution.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["ticketType"],
+    properties: {
+      ticketType: {
+        type: "string",
+        enum: ["incident", "sc_task"],
+        description: "Which kind of ticket to look up VIP records for",
+      },
+      query: {
+        type: "string",
+        description:
+          'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base VIP lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1" to further narrow to priority-1 VIP tickets. Leave empty to return all VIP tickets of the given type up to the limit.\n',
+      },
+      additionalFields: {
+        type: "array",
+        description:
+          'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+        items: {
+          type: "string",
+        },
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of VIP tickets to return (defaults to 25)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip, for pagination (defaults to 0)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the query was successful",
+      },
+      records: {
+        type: "array",
+        description: "The VIP ticket records matching the query",
+        items: {
+          type: "object",
+          properties: {
+            ticketType: {
+              type: "string",
+              description: "Whether this record is an incident or a SCTASK",
+            },
+            number: {
+              type: "string",
+              description: "The ticket number",
+            },
+            ritmNumber: {
+              type: "string",
+              description: "The number of the parent Requested Item (RITM), if this is a SCTASK",
+            },
+            vipUser: {
+              type: "string",
+              description: "The name of the VIP caller or requester associated with this ticket",
+            },
+            assignee: {
+              type: "string",
+              description: "The name of the person assigned to the ticket",
+            },
+            assignmentGroup: {
+              type: "string",
+              description: "The name of the group assigned to the ticket",
+            },
+            shortDescription: {
+              type: "string",
+              description: "The short description of the ticket",
+            },
+            description: {
+              type: "string",
+              description: "The full description of the ticket",
+            },
+            state: {
+              type: "string",
+              description: "The current state of the ticket",
+            },
+            openedAt: {
+              type: "string",
+              description: "The date and time the ticket was opened",
+            },
+            updatedAt: {
+              type: "string",
+              description: "The date and time the ticket was last updated",
+            },
+            closedAt: {
+              type: "string",
+              description: "The date and time the ticket was closed or completed, if applicable",
+            },
+            workNotes: {
+              type: "string",
+              description: "Internal work notes on the ticket",
+            },
+            comments: {
+              type: "string",
+              description: "Additional (customer-visible) comments on the ticket",
+            },
+            timeToResolutionMinutes: {
+              type: "number",
+              description: "Minutes elapsed between openedAt and closedAt, if the ticket is closed",
+            },
+            extraFields: {
+              type: "object",
+              description: "Values for any fields requested via the additionalFields parameter, keyed by field name",
+            },
+          },
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if the query failed",
+      },
+    },
+  },
+  name: "getVIPTickets",
+  provider: "servicenow",
+};

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15672,3 +15672,64 @@ export const smartsheetUpdateRowDefinition: ActionTemplate = {
   name: "updateRow",
   provider: "smartsheet",
 };
+export const servicenowGetRecordsByQueryDefinition: ActionTemplate = {
+  displayName: "Get ServiceNow records by query",
+  description:
+    "Query records from any ServiceNow table (e.g. incident, change_request, sc_request) using an encoded query string via the Table API",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["tableName"],
+    properties: {
+      tableName: {
+        type: "string",
+        description:
+          "The ServiceNow table to query (e.g. incident, change_request, sc_request, sys_user, kb_knowledge)",
+      },
+      query: {
+        type: "string",
+        description:
+          'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.',
+      },
+      fields: {
+        type: "array",
+        description: "Field names to return for each record (sysparm_fields). All fields are returned if omitted.",
+        items: {
+          type: "string",
+        },
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of records to return (defaults to 25)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip, for pagination (defaults to 0)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["success"],
+    properties: {
+      success: {
+        type: "boolean",
+        description: "Whether the query was successful",
+      },
+      records: {
+        type: "array",
+        description: "The records matching the query",
+        items: {
+          type: "object",
+        },
+      },
+      error: {
+        type: "string",
+        description: "Error message if the query failed",
+      },
+    },
+  },
+  name: "getRecordsByQuery",
+  provider: "servicenow",
+};

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15707,6 +15707,11 @@ export const servicenowGetRecordsByQueryDefinition: ActionTemplate = {
         type: "number",
         description: "Number of records to skip, for pagination (defaults to 0)",
       },
+      includeDisplayValues: {
+        type: "boolean",
+        description:
+          'If false (default), each field is returned as a plain scalar value (e.g. active: true, priority: "1"). If true, every field is instead returned as an object {value: "<raw value>", display_value: "<human-readable value>"} — useful for reference fields like assigned_to, where value is a sys_id and display_value is the user\'s name.\n',
+      },
     },
   },
   output: {

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15741,7 +15741,7 @@ export const servicenowGetRecordsByQueryDefinition: ActionTemplate = {
 export const servicenowGetIncidentsDefinition: ActionTemplate = {
   displayName: "Get ServiceNow incidents",
   description:
-    "Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-resolution.",
+    "Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-closure.",
   scopes: [],
   tags: [],
   parameters: {
@@ -15849,9 +15849,9 @@ export const servicenowGetIncidentsDefinition: ActionTemplate = {
               type: "string",
               description: "Additional (customer-visible) comments on the incident",
             },
-            timeToResolutionMinutes: {
+            timeToClosureMinutes: {
               type: "number",
-              description: "Minutes elapsed between openedAt and closedAt, if the incident is closed",
+              description: "Minutes elapsed from opening to final closure, calculated from openedAt and closedAt",
             },
             extraFields: {
               type: "object",
@@ -15872,7 +15872,7 @@ export const servicenowGetIncidentsDefinition: ActionTemplate = {
 export const servicenowGetChangeRequestsDefinition: ActionTemplate = {
   displayName: "Get ServiceNow change requests",
   description:
-    "Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-resolution.",
+    "Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-closure.",
   scopes: [],
   tags: [],
   parameters: {
@@ -15976,9 +15976,9 @@ export const servicenowGetChangeRequestsDefinition: ActionTemplate = {
               type: "string",
               description: "Additional (customer-visible) comments on the change request",
             },
-            timeToResolutionMinutes: {
+            timeToClosureMinutes: {
               type: "number",
-              description: "Minutes elapsed between openedAt and closedAt, if the change request is closed",
+              description: "Minutes elapsed from opening to final closure, calculated from openedAt and closedAt",
             },
             extraFields: {
               type: "object",
@@ -15999,7 +15999,7 @@ export const servicenowGetChangeRequestsDefinition: ActionTemplate = {
 export const servicenowGetSCTasksDefinition: ActionTemplate = {
   displayName: "Get ServiceNow catalog tasks (SCTASKs)",
   description:
-    "Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-resolution.",
+    "Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-closure.",
   scopes: [],
   tags: [],
   parameters: {
@@ -16095,9 +16095,9 @@ export const servicenowGetSCTasksDefinition: ActionTemplate = {
               type: "string",
               description: "Additional (customer-visible) comments on the SCTASK",
             },
-            timeToResolutionMinutes: {
+            timeToClosureMinutes: {
               type: "number",
-              description: "Minutes elapsed between openedAt and closedAt, if the SCTASK is closed",
+              description: "Minutes elapsed from opening to final closure, calculated from openedAt and closedAt",
             },
             extraFields: {
               type: "object",
@@ -16118,7 +16118,7 @@ export const servicenowGetSCTasksDefinition: ActionTemplate = {
 export const servicenowGetVIPTicketsDefinition: ActionTemplate = {
   displayName: "Get ServiceNow VIP tickets",
   description:
-    "Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-resolution.",
+    "Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-closure.",
   scopes: [],
   tags: [],
   parameters: {
@@ -16223,9 +16223,9 @@ export const servicenowGetVIPTicketsDefinition: ActionTemplate = {
               type: "string",
               description: "Additional (customer-visible) comments on the ticket",
             },
-            timeToResolutionMinutes: {
+            timeToClosureMinutes: {
               type: "number",
-              description: "Minutes elapsed between openedAt and closedAt, if the ticket is closed",
+              description: "Minutes elapsed from opening to final closure, calculated from openedAt and closedAt",
             },
             extraFields: {
               type: "object",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -15690,7 +15690,7 @@ export const servicenowGetRecordsByQueryDefinition: ActionTemplate = {
       query: {
         type: "string",
         description:
-          'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.',
+          'ServiceNow encoded query string (sysparm_query) — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Format examples: field=value, field!=value, field>value, fieldLIKEvalue, fieldISEMPTY. Sort with ^ORDERBY<field> (ascending) or ^ORDERBYDESC<field> (descending). Example: "active=true^priority=1^ORDERBYDESCsys_created_on" means active records with priority 1, sorted by most recently created first. If omitted, records are returned unfiltered up to the limit.\n',
       },
       fields: {
         type: "array",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -8024,6 +8024,12 @@ export const servicenowGetRecordsByQueryParamsSchema = z.object({
     .optional(),
   limit: z.coerce.number().describe("Maximum number of records to return (defaults to 25)").optional(),
   offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+  includeDisplayValues: z
+    .boolean()
+    .describe(
+      'If false (default), each field is returned as a plain scalar value (e.g. active: true, priority: "1"). If true, every field is instead returned as an object {value: "<raw value>", display_value: "<human-readable value>"} — useful for reference fields like assigned_to, where value is a sys_id and display_value is the user\'s name.\n',
+    )
+    .optional(),
 });
 
 export type servicenowGetRecordsByQueryParamsType = z.infer<typeof servicenowGetRecordsByQueryParamsSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -185,6 +185,10 @@ export enum ActionName {
   ADDROWTOSHEET = "addRowToSheet",
   UPDATEROW = "updateRow",
   GETRECORDSBYQUERY = "getRecordsByQuery",
+  GETINCIDENTS = "getIncidents",
+  GETCHANGEREQUESTS = "getChangeRequests",
+  GETSCTASKS = "getSCTasks",
+  GETVIPTICKETS = "getVIPTickets",
 }
 
 export type ActionFunction<P, A, O> = (input: { params: P; authParams: A }) => Promise<O>;
@@ -8045,4 +8049,266 @@ export type servicenowGetRecordsByQueryFunction = ActionFunction<
   servicenowGetRecordsByQueryParamsType,
   AuthParamsType,
   servicenowGetRecordsByQueryOutputType
+>;
+
+export const servicenowGetIncidentsParamsSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base incident lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=7" for open, priority-1 incidents. Leave empty to return all incidents up to the limit.\n',
+    )
+    .optional(),
+  additionalFields: z
+    .array(z.string())
+    .describe(
+      'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+    )
+    .optional(),
+  limit: z.coerce.number().describe("Maximum number of incidents to return (defaults to 25)").optional(),
+  offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+});
+
+export type servicenowGetIncidentsParamsType = z.infer<typeof servicenowGetIncidentsParamsSchema>;
+
+export const servicenowGetIncidentsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the query was successful"),
+  records: z
+    .array(
+      z.object({
+        number: z.string().describe("The incident ticket number (e.g. INC0010023)").optional(),
+        caller: z.string().describe("The name of the person who reported the incident").optional(),
+        assignee: z.string().describe("The name of the person assigned to the incident").optional(),
+        assignmentGroup: z.string().describe("The name of the group assigned to the incident").optional(),
+        shortDescription: z.string().describe("The short description of the incident").optional(),
+        description: z.string().describe("The full description of the incident").optional(),
+        state: z.string().describe("The current state of the incident").optional(),
+        incidentState: z
+          .string()
+          .describe("The current incident-specific state (legacy field on some instances; may be absent)")
+          .optional(),
+        priority: z.string().describe("The priority of the incident").optional(),
+        impact: z.string().describe("The impact of the incident").optional(),
+        urgency: z.string().describe("The urgency of the incident").optional(),
+        openedAt: z.string().describe("The date and time the incident was opened").optional(),
+        updatedAt: z.string().describe("The date and time the incident was last updated").optional(),
+        closedAt: z
+          .string()
+          .describe("The date and time the incident was closed or completed, if applicable")
+          .optional(),
+        workNotes: z.string().describe("Internal work notes on the incident").optional(),
+        comments: z.string().describe("Additional (customer-visible) comments on the incident").optional(),
+        timeToResolutionMinutes: z.coerce
+          .number()
+          .describe("Minutes elapsed between openedAt and closedAt, if the incident is closed")
+          .optional(),
+        extraFields: z
+          .object({})
+          .catchall(z.any())
+          .describe("Values for any fields requested via the additionalFields parameter, keyed by field name")
+          .optional(),
+      }),
+    )
+    .describe("The incident records matching the query")
+    .optional(),
+  error: z.string().describe("Error message if the query failed").optional(),
+});
+
+export type servicenowGetIncidentsOutputType = z.infer<typeof servicenowGetIncidentsOutputSchema>;
+export type servicenowGetIncidentsFunction = ActionFunction<
+  servicenowGetIncidentsParamsType,
+  AuthParamsType,
+  servicenowGetIncidentsOutputType
+>;
+
+export const servicenowGetChangeRequestsParamsSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base change request lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open, priority-1 change requests. Leave empty to return all change requests up to the limit.\n',
+    )
+    .optional(),
+  additionalFields: z
+    .array(z.string())
+    .describe(
+      'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+    )
+    .optional(),
+  limit: z.coerce.number().describe("Maximum number of change requests to return (defaults to 25)").optional(),
+  offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+});
+
+export type servicenowGetChangeRequestsParamsType = z.infer<typeof servicenowGetChangeRequestsParamsSchema>;
+
+export const servicenowGetChangeRequestsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the query was successful"),
+  records: z
+    .array(
+      z.object({
+        number: z.string().describe("The change request number (e.g. CHG0010023)").optional(),
+        requestor: z.string().describe("The name of the person who requested the change").optional(),
+        assignee: z.string().describe("The name of the person assigned to the change request").optional(),
+        assignmentGroup: z.string().describe("The name of the group assigned to the change request").optional(),
+        shortDescription: z.string().describe("The short description of the change request").optional(),
+        description: z.string().describe("The full description of the change request").optional(),
+        state: z.string().describe("The current state of the change request").optional(),
+        priority: z.string().describe("The priority of the change request").optional(),
+        impact: z.string().describe("The impact of the change request").optional(),
+        urgency: z.string().describe("The urgency of the change request").optional(),
+        openedAt: z.string().describe("The date and time the change request was opened").optional(),
+        updatedAt: z.string().describe("The date and time the change request was last updated").optional(),
+        closedAt: z
+          .string()
+          .describe("The date and time the change request was closed or completed, if applicable")
+          .optional(),
+        workNotes: z.string().describe("Internal work notes on the change request").optional(),
+        comments: z.string().describe("Additional (customer-visible) comments on the change request").optional(),
+        timeToResolutionMinutes: z.coerce
+          .number()
+          .describe("Minutes elapsed between openedAt and closedAt, if the change request is closed")
+          .optional(),
+        extraFields: z
+          .object({})
+          .catchall(z.any())
+          .describe("Values for any fields requested via the additionalFields parameter, keyed by field name")
+          .optional(),
+      }),
+    )
+    .describe("The change request records matching the query")
+    .optional(),
+  error: z.string().describe("Error message if the query failed").optional(),
+});
+
+export type servicenowGetChangeRequestsOutputType = z.infer<typeof servicenowGetChangeRequestsOutputSchema>;
+export type servicenowGetChangeRequestsFunction = ActionFunction<
+  servicenowGetChangeRequestsParamsType,
+  AuthParamsType,
+  servicenowGetChangeRequestsOutputType
+>;
+
+export const servicenowGetSCTasksParamsSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base SCTASK lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open, priority-1 SCTASKs. Leave empty to return all SCTASKs up to the limit.\n',
+    )
+    .optional(),
+  additionalFields: z
+    .array(z.string())
+    .describe(
+      'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+    )
+    .optional(),
+  limit: z.coerce.number().describe("Maximum number of SCTASKs to return (defaults to 25)").optional(),
+  offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+});
+
+export type servicenowGetSCTasksParamsType = z.infer<typeof servicenowGetSCTasksParamsSchema>;
+
+export const servicenowGetSCTasksOutputSchema = z.object({
+  success: z.boolean().describe("Whether the query was successful"),
+  records: z
+    .array(
+      z.object({
+        number: z.string().describe("The SCTASK ticket number (e.g. SCTASK0010023)").optional(),
+        ritmNumber: z
+          .string()
+          .describe("The number of the parent Requested Item (RITM) this SCTASK belongs to")
+          .optional(),
+        assignee: z.string().describe("The name of the person assigned to the SCTASK").optional(),
+        assignmentGroup: z.string().describe("The name of the group assigned to the SCTASK").optional(),
+        shortDescription: z.string().describe("The short description of the SCTASK").optional(),
+        description: z.string().describe("The full description of the SCTASK").optional(),
+        state: z.string().describe("The current state of the SCTASK").optional(),
+        priority: z.string().describe("The priority of the SCTASK").optional(),
+        openedAt: z.string().describe("The date and time the SCTASK was opened").optional(),
+        updatedAt: z.string().describe("The date and time the SCTASK was last updated").optional(),
+        closedAt: z.string().describe("The date and time the SCTASK was closed or completed, if applicable").optional(),
+        workNotes: z.string().describe("Internal work notes on the SCTASK").optional(),
+        comments: z.string().describe("Additional (customer-visible) comments on the SCTASK").optional(),
+        timeToResolutionMinutes: z.coerce
+          .number()
+          .describe("Minutes elapsed between openedAt and closedAt, if the SCTASK is closed")
+          .optional(),
+        extraFields: z
+          .object({})
+          .catchall(z.any())
+          .describe("Values for any fields requested via the additionalFields parameter, keyed by field name")
+          .optional(),
+      }),
+    )
+    .describe("The SCTASK records matching the query")
+    .optional(),
+  error: z.string().describe("Error message if the query failed").optional(),
+});
+
+export type servicenowGetSCTasksOutputType = z.infer<typeof servicenowGetSCTasksOutputSchema>;
+export type servicenowGetSCTasksFunction = ActionFunction<
+  servicenowGetSCTasksParamsType,
+  AuthParamsType,
+  servicenowGetSCTasksOutputType
+>;
+
+export const servicenowGetVIPTicketsParamsSchema = z.object({
+  ticketType: z.enum(["incident", "sc_task"]).describe("Which kind of ticket to look up VIP records for"),
+  query: z
+    .string()
+    .describe(
+      'Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base VIP lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Example: "priority=1" to further narrow to priority-1 VIP tickets. Leave empty to return all VIP tickets of the given type up to the limit.\n',
+    )
+    .optional(),
+  additionalFields: z
+    .array(z.string())
+    .describe(
+      'Extra ServiceNow field technical names to fetch for instance-specific/custom fields not covered by the standard output (e.g. a custom "Program Office" field). Values are returned per record under extraFields, keyed by the field name given here.\n',
+    )
+    .optional(),
+  limit: z.coerce.number().describe("Maximum number of VIP tickets to return (defaults to 25)").optional(),
+  offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+});
+
+export type servicenowGetVIPTicketsParamsType = z.infer<typeof servicenowGetVIPTicketsParamsSchema>;
+
+export const servicenowGetVIPTicketsOutputSchema = z.object({
+  success: z.boolean().describe("Whether the query was successful"),
+  records: z
+    .array(
+      z.object({
+        ticketType: z.string().describe("Whether this record is an incident or a SCTASK").optional(),
+        number: z.string().describe("The ticket number").optional(),
+        ritmNumber: z
+          .string()
+          .describe("The number of the parent Requested Item (RITM), if this is a SCTASK")
+          .optional(),
+        vipUser: z.string().describe("The name of the VIP caller or requester associated with this ticket").optional(),
+        assignee: z.string().describe("The name of the person assigned to the ticket").optional(),
+        assignmentGroup: z.string().describe("The name of the group assigned to the ticket").optional(),
+        shortDescription: z.string().describe("The short description of the ticket").optional(),
+        description: z.string().describe("The full description of the ticket").optional(),
+        state: z.string().describe("The current state of the ticket").optional(),
+        openedAt: z.string().describe("The date and time the ticket was opened").optional(),
+        updatedAt: z.string().describe("The date and time the ticket was last updated").optional(),
+        closedAt: z.string().describe("The date and time the ticket was closed or completed, if applicable").optional(),
+        workNotes: z.string().describe("Internal work notes on the ticket").optional(),
+        comments: z.string().describe("Additional (customer-visible) comments on the ticket").optional(),
+        timeToResolutionMinutes: z.coerce
+          .number()
+          .describe("Minutes elapsed between openedAt and closedAt, if the ticket is closed")
+          .optional(),
+        extraFields: z
+          .object({})
+          .catchall(z.any())
+          .describe("Values for any fields requested via the additionalFields parameter, keyed by field name")
+          .optional(),
+      }),
+    )
+    .describe("The VIP ticket records matching the query")
+    .optional(),
+  error: z.string().describe("Error message if the query failed").optional(),
+});
+
+export type servicenowGetVIPTicketsOutputType = z.infer<typeof servicenowGetVIPTicketsOutputSchema>;
+export type servicenowGetVIPTicketsFunction = ActionFunction<
+  servicenowGetVIPTicketsParamsType,
+  AuthParamsType,
+  servicenowGetVIPTicketsOutputType
 >;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -8015,7 +8015,7 @@ export const servicenowGetRecordsByQueryParamsSchema = z.object({
   query: z
     .string()
     .describe(
-      'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.',
+      'ServiceNow encoded query string (sysparm_query) — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^. Format examples: field=value, field!=value, field>value, fieldLIKEvalue, fieldISEMPTY. Sort with ^ORDERBY<field> (ascending) or ^ORDERBYDESC<field> (descending). Example: "active=true^priority=1^ORDERBYDESCsys_created_on" means active records with priority 1, sorted by most recently created first. If omitted, records are returned unfiltered up to the limit.\n',
     )
     .optional(),
   fields: z

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -37,6 +37,7 @@ export enum ProviderName {
   LINEAR = "linear",
   HUBSPOT = "hubspot",
   SMARTSHEET = "smartsheet",
+  SERVICENOW = "servicenow",
   BOXUSER = "boxUser",
 }
 
@@ -183,6 +184,7 @@ export enum ActionName {
   GETSHEETROWS = "getSheetRows",
   ADDROWTOSHEET = "addRowToSheet",
   UPDATEROW = "updateRow",
+  GETRECORDSBYQUERY = "getRecordsByQuery",
 }
 
 export type ActionFunction<P, A, O> = (input: { params: P; authParams: A }) => Promise<O>;
@@ -8004,4 +8006,37 @@ export type smartsheetUpdateRowFunction = ActionFunction<
   smartsheetUpdateRowParamsType,
   AuthParamsType,
   smartsheetUpdateRowOutputType
+>;
+
+export const servicenowGetRecordsByQueryParamsSchema = z.object({
+  tableName: z
+    .string()
+    .describe("The ServiceNow table to query (e.g. incident, change_request, sc_request, sys_user, kb_knowledge)"),
+  query: z
+    .string()
+    .describe(
+      'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.',
+    )
+    .optional(),
+  fields: z
+    .array(z.string())
+    .describe("Field names to return for each record (sysparm_fields). All fields are returned if omitted.")
+    .optional(),
+  limit: z.coerce.number().describe("Maximum number of records to return (defaults to 25)").optional(),
+  offset: z.coerce.number().describe("Number of records to skip, for pagination (defaults to 0)").optional(),
+});
+
+export type servicenowGetRecordsByQueryParamsType = z.infer<typeof servicenowGetRecordsByQueryParamsSchema>;
+
+export const servicenowGetRecordsByQueryOutputSchema = z.object({
+  success: z.boolean().describe("Whether the query was successful"),
+  records: z.array(z.object({}).catchall(z.any())).describe("The records matching the query").optional(),
+  error: z.string().describe("Error message if the query failed").optional(),
+});
+
+export type servicenowGetRecordsByQueryOutputType = z.infer<typeof servicenowGetRecordsByQueryOutputSchema>;
+export type servicenowGetRecordsByQueryFunction = ActionFunction<
+  servicenowGetRecordsByQueryParamsType,
+  AuthParamsType,
+  servicenowGetRecordsByQueryOutputType
 >;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -8097,9 +8097,9 @@ export const servicenowGetIncidentsOutputSchema = z.object({
           .optional(),
         workNotes: z.string().describe("Internal work notes on the incident").optional(),
         comments: z.string().describe("Additional (customer-visible) comments on the incident").optional(),
-        timeToResolutionMinutes: z.coerce
+        timeToClosureMinutes: z.coerce
           .number()
-          .describe("Minutes elapsed between openedAt and closedAt, if the incident is closed")
+          .describe("Minutes elapsed from opening to final closure, calculated from openedAt and closedAt")
           .optional(),
         extraFields: z
           .object({})
@@ -8162,9 +8162,9 @@ export const servicenowGetChangeRequestsOutputSchema = z.object({
           .optional(),
         workNotes: z.string().describe("Internal work notes on the change request").optional(),
         comments: z.string().describe("Additional (customer-visible) comments on the change request").optional(),
-        timeToResolutionMinutes: z.coerce
+        timeToClosureMinutes: z.coerce
           .number()
-          .describe("Minutes elapsed between openedAt and closedAt, if the change request is closed")
+          .describe("Minutes elapsed from opening to final closure, calculated from openedAt and closedAt")
           .optional(),
         extraFields: z
           .object({})
@@ -8225,9 +8225,9 @@ export const servicenowGetSCTasksOutputSchema = z.object({
         closedAt: z.string().describe("The date and time the SCTASK was closed or completed, if applicable").optional(),
         workNotes: z.string().describe("Internal work notes on the SCTASK").optional(),
         comments: z.string().describe("Additional (customer-visible) comments on the SCTASK").optional(),
-        timeToResolutionMinutes: z.coerce
+        timeToClosureMinutes: z.coerce
           .number()
-          .describe("Minutes elapsed between openedAt and closedAt, if the SCTASK is closed")
+          .describe("Minutes elapsed from opening to final closure, calculated from openedAt and closedAt")
           .optional(),
         extraFields: z
           .object({})
@@ -8290,9 +8290,9 @@ export const servicenowGetVIPTicketsOutputSchema = z.object({
         closedAt: z.string().describe("The date and time the ticket was closed or completed, if applicable").optional(),
         workNotes: z.string().describe("Internal work notes on the ticket").optional(),
         comments: z.string().describe("Additional (customer-visible) comments on the ticket").optional(),
-        timeToResolutionMinutes: z.coerce
+        timeToClosureMinutes: z.coerce
           .number()
-          .describe("Minutes elapsed between openedAt and closedAt, if the ticket is closed")
+          .describe("Minutes elapsed from opening to final closure, calculated from openedAt and closedAt")
           .optional(),
         extraFields: z
           .object({})

--- a/src/actions/providers/servicenow/getChangeRequests.ts
+++ b/src/actions/providers/servicenow/getChangeRequests.ts
@@ -1,0 +1,74 @@
+import type {
+  AuthParamsType,
+  servicenowGetChangeRequestsFunction,
+  servicenowGetChangeRequestsOutputType,
+  servicenowGetChangeRequestsParamsType,
+} from "../../autogen/types.js";
+import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+
+const CHANGE_REQUEST_FIELDS = [
+  "number",
+  "short_description",
+  "description",
+  "state",
+  "priority",
+  "impact",
+  "urgency",
+  "requested_by",
+  "assigned_to",
+  "assignment_group",
+  "opened_at",
+  "sys_updated_on",
+  "closed_at",
+  "work_notes",
+  "comments",
+];
+
+const getChangeRequests: servicenowGetChangeRequestsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: servicenowGetChangeRequestsParamsType;
+  authParams: AuthParamsType;
+}): Promise<servicenowGetChangeRequestsOutputType> => {
+  const { query, additionalFields, limit, offset } = params;
+
+  const result = await queryServiceNowTable({
+    authParams,
+    tableName: "change_request",
+    fields: CHANGE_REQUEST_FIELDS,
+    filter: query,
+    additionalFields,
+    limit,
+    offset,
+  });
+
+  if ("error" in result) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    records: result.records.map(record => ({
+      number: record.number,
+      requestor: record.requested_by,
+      assignee: record.assigned_to,
+      assignmentGroup: record.assignment_group,
+      shortDescription: record.short_description,
+      description: record.description,
+      state: record.state,
+      priority: record.priority,
+      impact: record.impact,
+      urgency: record.urgency,
+      openedAt: record.opened_at,
+      updatedAt: record.sys_updated_on,
+      closedAt: record.closed_at,
+      workNotes: record.work_notes,
+      comments: record.comments,
+      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      extraFields: extractAdditionalFields(record, additionalFields),
+    })),
+  };
+};
+
+export default getChangeRequests;

--- a/src/actions/providers/servicenow/getChangeRequests.ts
+++ b/src/actions/providers/servicenow/getChangeRequests.ts
@@ -4,7 +4,7 @@ import type {
   servicenowGetChangeRequestsOutputType,
   servicenowGetChangeRequestsParamsType,
 } from "../../autogen/types.js";
-import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+import { computeTimeToClosureMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
 
 const CHANGE_REQUEST_FIELDS = [
   "number",
@@ -65,7 +65,7 @@ const getChangeRequests: servicenowGetChangeRequestsFunction = async ({
       closedAt: record.closed_at,
       workNotes: record.work_notes,
       comments: record.comments,
-      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      timeToClosureMinutes: computeTimeToClosureMinutes(record.opened_at, record.closed_at),
       extraFields: extractAdditionalFields(record, additionalFields),
     })),
   };

--- a/src/actions/providers/servicenow/getIncidents.ts
+++ b/src/actions/providers/servicenow/getIncidents.ts
@@ -4,7 +4,7 @@ import type {
   servicenowGetIncidentsOutputType,
   servicenowGetIncidentsParamsType,
 } from "../../autogen/types.js";
-import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+import { computeTimeToClosureMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
 
 const INCIDENT_FIELDS = [
   "number",
@@ -67,7 +67,7 @@ const getIncidents: servicenowGetIncidentsFunction = async ({
       closedAt: record.closed_at,
       workNotes: record.work_notes,
       comments: record.comments,
-      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      timeToClosureMinutes: computeTimeToClosureMinutes(record.opened_at, record.closed_at),
       extraFields: extractAdditionalFields(record, additionalFields),
     })),
   };

--- a/src/actions/providers/servicenow/getIncidents.ts
+++ b/src/actions/providers/servicenow/getIncidents.ts
@@ -1,0 +1,76 @@
+import type {
+  AuthParamsType,
+  servicenowGetIncidentsFunction,
+  servicenowGetIncidentsOutputType,
+  servicenowGetIncidentsParamsType,
+} from "../../autogen/types.js";
+import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+
+const INCIDENT_FIELDS = [
+  "number",
+  "short_description",
+  "description",
+  "state",
+  "incident_state",
+  "priority",
+  "impact",
+  "urgency",
+  "caller_id",
+  "assigned_to",
+  "assignment_group",
+  "opened_at",
+  "sys_updated_on",
+  "closed_at",
+  "work_notes",
+  "comments",
+];
+
+const getIncidents: servicenowGetIncidentsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: servicenowGetIncidentsParamsType;
+  authParams: AuthParamsType;
+}): Promise<servicenowGetIncidentsOutputType> => {
+  const { query, additionalFields, limit, offset } = params;
+
+  const result = await queryServiceNowTable({
+    authParams,
+    tableName: "incident",
+    fields: INCIDENT_FIELDS,
+    filter: query,
+    additionalFields,
+    limit,
+    offset,
+  });
+
+  if ("error" in result) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    records: result.records.map(record => ({
+      number: record.number,
+      caller: record.caller_id,
+      assignee: record.assigned_to,
+      assignmentGroup: record.assignment_group,
+      shortDescription: record.short_description,
+      description: record.description,
+      state: record.state,
+      incidentState: record.incident_state,
+      priority: record.priority,
+      impact: record.impact,
+      urgency: record.urgency,
+      openedAt: record.opened_at,
+      updatedAt: record.sys_updated_on,
+      closedAt: record.closed_at,
+      workNotes: record.work_notes,
+      comments: record.comments,
+      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      extraFields: extractAdditionalFields(record, additionalFields),
+    })),
+  };
+};
+
+export default getIncidents;

--- a/src/actions/providers/servicenow/getRecordsByQuery.ts
+++ b/src/actions/providers/servicenow/getRecordsByQuery.ts
@@ -7,6 +7,7 @@ import type {
 import { ApiError, axiosClient } from "../../util/axiosClient.js";
 
 const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 10000;
 
 const getRecordsByQuery: servicenowGetRecordsByQueryFunction = async ({
   params,
@@ -16,17 +17,19 @@ const getRecordsByQuery: servicenowGetRecordsByQueryFunction = async ({
   authParams: AuthParamsType;
 }): Promise<servicenowGetRecordsByQueryOutputType> => {
   const { authToken, baseUrl } = authParams;
-  const { tableName, query, fields, limit = DEFAULT_LIMIT, offset = 0 } = params;
+  const { tableName, query, fields, limit = DEFAULT_LIMIT, offset = 0, includeDisplayValues = false } = params;
 
   if (!authToken || !baseUrl) {
     return { success: false, error: "authToken and baseUrl are required for the ServiceNow API" };
   }
 
+  const cappedLimit = Math.min(limit, MAX_LIMIT);
+
   const queryParams = new URLSearchParams();
-  queryParams.append("sysparm_limit", limit.toString());
+  queryParams.append("sysparm_limit", cappedLimit.toString());
   queryParams.append("sysparm_offset", offset.toString());
-  // Return human-readable values alongside raw sys_ids for reference fields
-  queryParams.append("sysparm_display_value", "all");
+  // "all" nests each field as {value, display_value}; "false" keeps fields as plain scalars
+  queryParams.append("sysparm_display_value", includeDisplayValues ? "all" : "false");
   queryParams.append("sysparm_exclude_reference_link", "true");
   if (query) {
     queryParams.append("sysparm_query", query);

--- a/src/actions/providers/servicenow/getRecordsByQuery.ts
+++ b/src/actions/providers/servicenow/getRecordsByQuery.ts
@@ -47,7 +47,8 @@ const getRecordsByQuery: servicenowGetRecordsByQueryFunction = async ({
         Authorization: `Bearer ${authToken}`,
       },
     });
-    return { success: true, records: response.data.result };
+    const result = response.data.result;
+    return { success: true, records: Array.isArray(result) ? result : [] };
   } catch (error) {
     console.error("Error querying ServiceNow records:", error);
     return {

--- a/src/actions/providers/servicenow/getRecordsByQuery.ts
+++ b/src/actions/providers/servicenow/getRecordsByQuery.ts
@@ -1,0 +1,57 @@
+import type {
+  AuthParamsType,
+  servicenowGetRecordsByQueryFunction,
+  servicenowGetRecordsByQueryOutputType,
+  servicenowGetRecordsByQueryParamsType,
+} from "../../autogen/types.js";
+import { ApiError, axiosClient } from "../../util/axiosClient.js";
+
+const DEFAULT_LIMIT = 25;
+
+const getRecordsByQuery: servicenowGetRecordsByQueryFunction = async ({
+  params,
+  authParams,
+}: {
+  params: servicenowGetRecordsByQueryParamsType;
+  authParams: AuthParamsType;
+}): Promise<servicenowGetRecordsByQueryOutputType> => {
+  const { authToken, baseUrl } = authParams;
+  const { tableName, query, fields, limit = DEFAULT_LIMIT, offset = 0 } = params;
+
+  if (!authToken || !baseUrl) {
+    return { success: false, error: "authToken and baseUrl are required for the ServiceNow API" };
+  }
+
+  const queryParams = new URLSearchParams();
+  queryParams.append("sysparm_limit", limit.toString());
+  queryParams.append("sysparm_offset", offset.toString());
+  // Return human-readable values alongside raw sys_ids for reference fields
+  queryParams.append("sysparm_display_value", "all");
+  queryParams.append("sysparm_exclude_reference_link", "true");
+  if (query) {
+    queryParams.append("sysparm_query", query);
+  }
+  if (fields && fields.length > 0) {
+    queryParams.append("sysparm_fields", fields.join(","));
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/now/table/${encodeURIComponent(tableName)}?${queryParams.toString()}`;
+
+  try {
+    const response = await axiosClient.get(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+    return { success: true, records: response.data.result };
+  } catch (error) {
+    console.error("Error querying ServiceNow records:", error);
+    return {
+      success: false,
+      error: error instanceof ApiError ? error.message : "An unknown error occurred",
+    };
+  }
+};
+
+export default getRecordsByQuery;

--- a/src/actions/providers/servicenow/getSCTasks.ts
+++ b/src/actions/providers/servicenow/getSCTasks.ts
@@ -4,7 +4,7 @@ import type {
   servicenowGetSCTasksOutputType,
   servicenowGetSCTasksParamsType,
 } from "../../autogen/types.js";
-import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+import { computeTimeToClosureMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
 
 const SC_TASK_FIELDS = [
   "number",
@@ -62,7 +62,7 @@ const getSCTasks: servicenowGetSCTasksFunction = async ({
       closedAt: record.closed_at,
       workNotes: record.work_notes,
       comments: record.comments,
-      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      timeToClosureMinutes: computeTimeToClosureMinutes(record.opened_at, record.closed_at),
       extraFields: extractAdditionalFields(record, additionalFields),
     })),
   };

--- a/src/actions/providers/servicenow/getSCTasks.ts
+++ b/src/actions/providers/servicenow/getSCTasks.ts
@@ -1,0 +1,71 @@
+import type {
+  AuthParamsType,
+  servicenowGetSCTasksFunction,
+  servicenowGetSCTasksOutputType,
+  servicenowGetSCTasksParamsType,
+} from "../../autogen/types.js";
+import { computeTimeToResolutionMinutes, extractAdditionalFields, queryServiceNowTable } from "./utils/tableQuery.js";
+
+const SC_TASK_FIELDS = [
+  "number",
+  "request_item",
+  "short_description",
+  "description",
+  "state",
+  "priority",
+  "assigned_to",
+  "assignment_group",
+  "opened_at",
+  "sys_updated_on",
+  "closed_at",
+  "work_notes",
+  "comments",
+];
+
+const getSCTasks: servicenowGetSCTasksFunction = async ({
+  params,
+  authParams,
+}: {
+  params: servicenowGetSCTasksParamsType;
+  authParams: AuthParamsType;
+}): Promise<servicenowGetSCTasksOutputType> => {
+  const { query, additionalFields, limit, offset } = params;
+
+  const result = await queryServiceNowTable({
+    authParams,
+    tableName: "sc_task",
+    fields: SC_TASK_FIELDS,
+    filter: query,
+    additionalFields,
+    limit,
+    offset,
+  });
+
+  if ("error" in result) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    records: result.records.map(record => ({
+      number: record.number,
+      // request_item's display value is the parent Requested Item's number (e.g. RITM0010023)
+      ritmNumber: record.request_item,
+      assignee: record.assigned_to,
+      assignmentGroup: record.assignment_group,
+      shortDescription: record.short_description,
+      description: record.description,
+      state: record.state,
+      priority: record.priority,
+      openedAt: record.opened_at,
+      updatedAt: record.sys_updated_on,
+      closedAt: record.closed_at,
+      workNotes: record.work_notes,
+      comments: record.comments,
+      timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+      extraFields: extractAdditionalFields(record, additionalFields),
+    })),
+  };
+};
+
+export default getSCTasks;

--- a/src/actions/providers/servicenow/getVIPTickets.ts
+++ b/src/actions/providers/servicenow/getVIPTickets.ts
@@ -5,7 +5,7 @@ import type {
   servicenowGetVIPTicketsParamsType,
 } from "../../autogen/types.js";
 import {
-  computeTimeToResolutionMinutes,
+  computeTimeToClosureMinutes,
   extractAdditionalFields,
   queryServiceNowTable,
   type ServiceNowRecord,
@@ -48,7 +48,7 @@ function mapRecord(record: ServiceNowRecord, ticketType: "incident" | "sc_task",
     closedAt: record.closed_at,
     workNotes: record.work_notes,
     comments: record.comments,
-    timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+    timeToClosureMinutes: computeTimeToClosureMinutes(record.opened_at, record.closed_at),
     extraFields: extractAdditionalFields(record, additionalFields),
   };
 }

--- a/src/actions/providers/servicenow/getVIPTickets.ts
+++ b/src/actions/providers/servicenow/getVIPTickets.ts
@@ -1,0 +1,88 @@
+import type {
+  AuthParamsType,
+  servicenowGetVIPTicketsFunction,
+  servicenowGetVIPTicketsOutputType,
+  servicenowGetVIPTicketsParamsType,
+} from "../../autogen/types.js";
+import {
+  computeTimeToResolutionMinutes,
+  extractAdditionalFields,
+  queryServiceNowTable,
+  type ServiceNowRecord,
+} from "./utils/tableQuery.js";
+
+const SHARED_FIELDS = [
+  "number",
+  "assigned_to",
+  "assignment_group",
+  "short_description",
+  "description",
+  "state",
+  "opened_at",
+  "sys_updated_on",
+  "closed_at",
+  "work_notes",
+  "comments",
+];
+
+// vip is a standard (non-custom) boolean field on sys_user used to flag VIP users.
+const INCIDENT_VIP_FIELDS = [...SHARED_FIELDS, "caller_id"];
+const INCIDENT_VIP_BASE_FILTER = "caller_id.vip=true";
+
+const SC_TASK_VIP_FIELDS = [...SHARED_FIELDS, "request_item", "request_item.requested_for"];
+const SC_TASK_VIP_BASE_FILTER = "request_item.requested_for.vip=true";
+
+function mapRecord(record: ServiceNowRecord, ticketType: "incident" | "sc_task", additionalFields?: string[]) {
+  return {
+    ticketType,
+    number: record.number,
+    ritmNumber: ticketType === "sc_task" ? record.request_item : undefined,
+    vipUser: ticketType === "incident" ? record.caller_id : record["request_item.requested_for"],
+    assignee: record.assigned_to,
+    assignmentGroup: record.assignment_group,
+    shortDescription: record.short_description,
+    description: record.description,
+    state: record.state,
+    openedAt: record.opened_at,
+    updatedAt: record.sys_updated_on,
+    closedAt: record.closed_at,
+    workNotes: record.work_notes,
+    comments: record.comments,
+    timeToResolutionMinutes: computeTimeToResolutionMinutes(record.opened_at, record.closed_at),
+    extraFields: extractAdditionalFields(record, additionalFields),
+  };
+}
+
+const getVIPTickets: servicenowGetVIPTicketsFunction = async ({
+  params,
+  authParams,
+}: {
+  params: servicenowGetVIPTicketsParamsType;
+  authParams: AuthParamsType;
+}): Promise<servicenowGetVIPTicketsOutputType> => {
+  const { ticketType, query, additionalFields, limit, offset } = params;
+
+  const isIncident = ticketType === "incident";
+
+  const result = await queryServiceNowTable({
+    authParams,
+    tableName: isIncident ? "incident" : "sc_task",
+    fields: isIncident ? INCIDENT_VIP_FIELDS : SC_TASK_VIP_FIELDS,
+    baseFilter: isIncident ? INCIDENT_VIP_BASE_FILTER : SC_TASK_VIP_BASE_FILTER,
+    filter: query,
+    additionalFields,
+    limit,
+    offset,
+  });
+
+  if ("error" in result) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    records: result.records.map(record => mapRecord(record, ticketType, additionalFields)),
+  };
+};
+
+export default getVIPTickets;

--- a/src/actions/providers/servicenow/utils/tableQuery.ts
+++ b/src/actions/providers/servicenow/utils/tableQuery.ts
@@ -1,0 +1,95 @@
+import type { AuthParamsType } from "../../../autogen/types.js";
+import { ApiError, axiosClient } from "../../../util/axiosClient.js";
+
+export const DEFAULT_LIMIT = 25;
+export const MAX_LIMIT = 10000;
+
+export type ServiceNowRecord = Record<string, string>;
+
+export interface QueryServiceNowTableArgs {
+  authParams: AuthParamsType;
+  tableName: string;
+  fields: string[];
+  filter?: string;
+  baseFilter?: string;
+  additionalFields?: string[];
+  limit?: number;
+  offset?: number;
+}
+
+export type QueryServiceNowTableResult = { records: ServiceNowRecord[] } | { error: string };
+
+// Uses sysparm_display_value=true so choice fields (e.g. state, priority) and reference fields
+// (e.g. assigned_to, request_item) come back as plain human-readable strings rather than nested
+// {value, display_value} objects.
+export async function queryServiceNowTable({
+  authParams,
+  tableName,
+  fields,
+  filter,
+  baseFilter,
+  additionalFields,
+  limit = DEFAULT_LIMIT,
+  offset = 0,
+}: QueryServiceNowTableArgs): Promise<QueryServiceNowTableResult> {
+  const { authToken, baseUrl } = authParams;
+  if (!authToken || !baseUrl) {
+    return { error: "authToken and baseUrl are required for the ServiceNow API" };
+  }
+
+  const cappedLimit = Math.min(limit, MAX_LIMIT);
+  const allFields = additionalFields && additionalFields.length > 0 ? [...fields, ...additionalFields] : fields;
+  const combinedFilter = [baseFilter, filter].filter(part => !!part).join("^");
+
+  const queryParams = new URLSearchParams();
+  queryParams.append("sysparm_limit", cappedLimit.toString());
+  queryParams.append("sysparm_offset", offset.toString());
+  queryParams.append("sysparm_display_value", "true");
+  queryParams.append("sysparm_fields", allFields.join(","));
+  if (combinedFilter) {
+    queryParams.append("sysparm_query", combinedFilter);
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/now/table/${encodeURIComponent(tableName)}?${queryParams.toString()}`;
+
+  try {
+    const response = await axiosClient.get(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+    return { records: response.data.result };
+  } catch (error) {
+    console.error(`Error querying ServiceNow table ${tableName}:`, error);
+    return { error: error instanceof ApiError ? error.message : "An unknown error occurred" };
+  }
+}
+
+export function computeTimeToResolutionMinutes(openedAt?: string, closedAt?: string): number | undefined {
+  if (!openedAt || !closedAt) {
+    return undefined;
+  }
+  const openedMs = new Date(openedAt).getTime();
+  const closedMs = new Date(closedAt).getTime();
+  if (Number.isNaN(openedMs) || Number.isNaN(closedMs) || closedMs < openedMs) {
+    return undefined;
+  }
+  return Math.round((closedMs - openedMs) / 60000);
+}
+
+export function extractAdditionalFields(
+  record: ServiceNowRecord,
+  additionalFields?: string[],
+): Record<string, string> | undefined {
+  if (!additionalFields || additionalFields.length === 0) {
+    return undefined;
+  }
+  const extra: Record<string, string> = {};
+  for (const field of additionalFields) {
+    if (record[field] !== undefined) {
+      extra[field] = record[field];
+    }
+  }
+  return extra;
+}

--- a/src/actions/providers/servicenow/utils/tableQuery.ts
+++ b/src/actions/providers/servicenow/utils/tableQuery.ts
@@ -59,7 +59,8 @@ export async function queryServiceNowTable({
         Authorization: `Bearer ${authToken}`,
       },
     });
-    return { records: response.data.result };
+    const result = response.data.result;
+    return { records: Array.isArray(result) ? result : [] };
   } catch (error) {
     console.error(`Error querying ServiceNow table ${tableName}:`, error);
     return { error: error instanceof ApiError ? error.message : "An unknown error occurred" };

--- a/src/actions/providers/servicenow/utils/tableQuery.ts
+++ b/src/actions/providers/servicenow/utils/tableQuery.ts
@@ -45,6 +45,7 @@ export async function queryServiceNowTable({
   queryParams.append("sysparm_limit", cappedLimit.toString());
   queryParams.append("sysparm_offset", offset.toString());
   queryParams.append("sysparm_display_value", "true");
+  queryParams.append("sysparm_exclude_reference_link", "true");
   queryParams.append("sysparm_fields", allFields.join(","));
   if (combinedFilter) {
     queryParams.append("sysparm_query", combinedFilter);
@@ -67,7 +68,7 @@ export async function queryServiceNowTable({
   }
 }
 
-export function computeTimeToResolutionMinutes(openedAt?: string, closedAt?: string): number | undefined {
+export function computeTimeToClosureMinutes(openedAt?: string, closedAt?: string): number | undefined {
   if (!openedAt || !closedAt) {
     return undefined;
   }

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9856,7 +9856,7 @@ actions:
             description: Error message if the query failed
     getIncidents:
       displayName: Get ServiceNow incidents
-      description: Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-resolution.
+      description: Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-closure.
       scopes: []
       parameters:
         type: object
@@ -9944,9 +9944,9 @@ actions:
                 comments:
                   type: string
                   description: Additional (customer-visible) comments on the incident
-                timeToResolutionMinutes:
+                timeToClosureMinutes:
                   type: number
-                  description: Minutes elapsed between openedAt and closedAt, if the incident is closed
+                  description: Minutes elapsed from opening to final closure, calculated from openedAt and closedAt
                 extraFields:
                   type: object
                   description: Values for any fields requested via the additionalFields parameter, keyed by field name
@@ -9955,7 +9955,7 @@ actions:
             description: Error message if the query failed
     getChangeRequests:
       displayName: Get ServiceNow change requests
-      description: Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-resolution.
+      description: Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-closure.
       scopes: []
       parameters:
         type: object
@@ -10040,9 +10040,9 @@ actions:
                 comments:
                   type: string
                   description: Additional (customer-visible) comments on the change request
-                timeToResolutionMinutes:
+                timeToClosureMinutes:
                   type: number
-                  description: Minutes elapsed between openedAt and closedAt, if the change request is closed
+                  description: Minutes elapsed from opening to final closure, calculated from openedAt and closedAt
                 extraFields:
                   type: object
                   description: Values for any fields requested via the additionalFields parameter, keyed by field name
@@ -10051,7 +10051,7 @@ actions:
             description: Error message if the query failed
     getSCTasks:
       displayName: Get ServiceNow catalog tasks (SCTASKs)
-      description: Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-resolution.
+      description: Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-closure.
       scopes: []
       parameters:
         type: object
@@ -10130,9 +10130,9 @@ actions:
                 comments:
                   type: string
                   description: Additional (customer-visible) comments on the SCTASK
-                timeToResolutionMinutes:
+                timeToClosureMinutes:
                   type: number
-                  description: Minutes elapsed between openedAt and closedAt, if the SCTASK is closed
+                  description: Minutes elapsed from opening to final closure, calculated from openedAt and closedAt
                 extraFields:
                   type: object
                   description: Values for any fields requested via the additionalFields parameter, keyed by field name
@@ -10141,7 +10141,7 @@ actions:
             description: Error message if the query failed
     getVIPTickets:
       displayName: Get ServiceNow VIP tickets
-      description: Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-resolution.
+      description: Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-closure.
       scopes: []
       parameters:
         type: object
@@ -10227,9 +10227,9 @@ actions:
                 comments:
                   type: string
                   description: Additional (customer-visible) comments on the ticket
-                timeToResolutionMinutes:
+                timeToClosureMinutes:
                   type: number
-                  description: Minutes elapsed between openedAt and closedAt, if the ticket is closed
+                  description: Minutes elapsed from opening to final closure, calculated from openedAt and closedAt
                 extraFields:
                   type: object
                   description: Values for any fields requested via the additionalFields parameter, keyed by field name

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9854,4 +9854,386 @@ actions:
           error:
             type: string
             description: Error message if the query failed
+    getIncidents:
+      displayName: Get ServiceNow incidents
+      description: Read incident records from ServiceNow, optionally filtered by an additional encoded query. Returns standard incident fields plus a computed time-to-resolution.
+      scopes: []
+      parameters:
+        type: object
+        required: []
+        properties:
+          query:
+            type: string
+            description: >
+              Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base incident
+              lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR
+              for OR, with no spaces around the ^. Example: "priority=1^state!=7" for open, priority-1
+              incidents. Leave empty to return all incidents up to the limit.
+          additionalFields:
+            type: array
+            description: >
+              Extra ServiceNow field technical names to fetch for instance-specific/custom fields not
+              covered by the standard output (e.g. a custom "Program Office" field). Values are returned
+              per record under extraFields, keyed by the field name given here.
+            items:
+              type: string
+          limit:
+            type: number
+            description: Maximum number of incidents to return (defaults to 25)
+          offset:
+            type: number
+            description: Number of records to skip, for pagination (defaults to 0)
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the query was successful
+          records:
+            type: array
+            description: The incident records matching the query
+            items:
+              type: object
+              properties:
+                number:
+                  type: string
+                  description: The incident ticket number (e.g. INC0010023)
+                caller:
+                  type: string
+                  description: The name of the person who reported the incident
+                assignee:
+                  type: string
+                  description: The name of the person assigned to the incident
+                assignmentGroup:
+                  type: string
+                  description: The name of the group assigned to the incident
+                shortDescription:
+                  type: string
+                  description: The short description of the incident
+                description:
+                  type: string
+                  description: The full description of the incident
+                state:
+                  type: string
+                  description: The current state of the incident
+                incidentState:
+                  type: string
+                  description: The current incident-specific state (legacy field on some instances; may be absent)
+                priority:
+                  type: string
+                  description: The priority of the incident
+                impact:
+                  type: string
+                  description: The impact of the incident
+                urgency:
+                  type: string
+                  description: The urgency of the incident
+                openedAt:
+                  type: string
+                  description: The date and time the incident was opened
+                updatedAt:
+                  type: string
+                  description: The date and time the incident was last updated
+                closedAt:
+                  type: string
+                  description: The date and time the incident was closed or completed, if applicable
+                workNotes:
+                  type: string
+                  description: Internal work notes on the incident
+                comments:
+                  type: string
+                  description: Additional (customer-visible) comments on the incident
+                timeToResolutionMinutes:
+                  type: number
+                  description: Minutes elapsed between openedAt and closedAt, if the incident is closed
+                extraFields:
+                  type: object
+                  description: Values for any fields requested via the additionalFields parameter, keyed by field name
+          error:
+            type: string
+            description: Error message if the query failed
+    getChangeRequests:
+      displayName: Get ServiceNow change requests
+      description: Read change request records from ServiceNow, optionally filtered by an additional encoded query. Returns standard change request fields plus a computed time-to-resolution.
+      scopes: []
+      parameters:
+        type: object
+        required: []
+        properties:
+          query:
+            type: string
+            description: >
+              Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base change
+              request lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND
+              and ^OR for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open,
+              priority-1 change requests. Leave empty to return all change requests up to the limit.
+          additionalFields:
+            type: array
+            description: >
+              Extra ServiceNow field technical names to fetch for instance-specific/custom fields not
+              covered by the standard output (e.g. a custom "Program Office" field). Values are returned
+              per record under extraFields, keyed by the field name given here.
+            items:
+              type: string
+          limit:
+            type: number
+            description: Maximum number of change requests to return (defaults to 25)
+          offset:
+            type: number
+            description: Number of records to skip, for pagination (defaults to 0)
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the query was successful
+          records:
+            type: array
+            description: The change request records matching the query
+            items:
+              type: object
+              properties:
+                number:
+                  type: string
+                  description: The change request number (e.g. CHG0010023)
+                requestor:
+                  type: string
+                  description: The name of the person who requested the change
+                assignee:
+                  type: string
+                  description: The name of the person assigned to the change request
+                assignmentGroup:
+                  type: string
+                  description: The name of the group assigned to the change request
+                shortDescription:
+                  type: string
+                  description: The short description of the change request
+                description:
+                  type: string
+                  description: The full description of the change request
+                state:
+                  type: string
+                  description: The current state of the change request
+                priority:
+                  type: string
+                  description: The priority of the change request
+                impact:
+                  type: string
+                  description: The impact of the change request
+                urgency:
+                  type: string
+                  description: The urgency of the change request
+                openedAt:
+                  type: string
+                  description: The date and time the change request was opened
+                updatedAt:
+                  type: string
+                  description: The date and time the change request was last updated
+                closedAt:
+                  type: string
+                  description: The date and time the change request was closed or completed, if applicable
+                workNotes:
+                  type: string
+                  description: Internal work notes on the change request
+                comments:
+                  type: string
+                  description: Additional (customer-visible) comments on the change request
+                timeToResolutionMinutes:
+                  type: number
+                  description: Minutes elapsed between openedAt and closedAt, if the change request is closed
+                extraFields:
+                  type: object
+                  description: Values for any fields requested via the additionalFields parameter, keyed by field name
+          error:
+            type: string
+            description: Error message if the query failed
+    getSCTasks:
+      displayName: Get ServiceNow catalog tasks (SCTASKs)
+      description: Read service catalog task (sc_task) records from ServiceNow, optionally filtered by an additional encoded query. Returns standard SCTASK fields, the parent RITM number, and a computed time-to-resolution.
+      scopes: []
+      parameters:
+        type: object
+        required: []
+        properties:
+          query:
+            type: string
+            description: >
+              Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base SCTASK
+              lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR
+              for OR, with no spaces around the ^. Example: "priority=1^state!=3" for open, priority-1
+              SCTASKs. Leave empty to return all SCTASKs up to the limit.
+          additionalFields:
+            type: array
+            description: >
+              Extra ServiceNow field technical names to fetch for instance-specific/custom fields not
+              covered by the standard output (e.g. a custom "Program Office" field). Values are returned
+              per record under extraFields, keyed by the field name given here.
+            items:
+              type: string
+          limit:
+            type: number
+            description: Maximum number of SCTASKs to return (defaults to 25)
+          offset:
+            type: number
+            description: Number of records to skip, for pagination (defaults to 0)
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the query was successful
+          records:
+            type: array
+            description: The SCTASK records matching the query
+            items:
+              type: object
+              properties:
+                number:
+                  type: string
+                  description: The SCTASK ticket number (e.g. SCTASK0010023)
+                ritmNumber:
+                  type: string
+                  description: The number of the parent Requested Item (RITM) this SCTASK belongs to
+                assignee:
+                  type: string
+                  description: The name of the person assigned to the SCTASK
+                assignmentGroup:
+                  type: string
+                  description: The name of the group assigned to the SCTASK
+                shortDescription:
+                  type: string
+                  description: The short description of the SCTASK
+                description:
+                  type: string
+                  description: The full description of the SCTASK
+                state:
+                  type: string
+                  description: The current state of the SCTASK
+                priority:
+                  type: string
+                  description: The priority of the SCTASK
+                openedAt:
+                  type: string
+                  description: The date and time the SCTASK was opened
+                updatedAt:
+                  type: string
+                  description: The date and time the SCTASK was last updated
+                closedAt:
+                  type: string
+                  description: The date and time the SCTASK was closed or completed, if applicable
+                workNotes:
+                  type: string
+                  description: Internal work notes on the SCTASK
+                comments:
+                  type: string
+                  description: Additional (customer-visible) comments on the SCTASK
+                timeToResolutionMinutes:
+                  type: number
+                  description: Minutes elapsed between openedAt and closedAt, if the SCTASK is closed
+                extraFields:
+                  type: object
+                  description: Values for any fields requested via the additionalFields parameter, keyed by field name
+          error:
+            type: string
+            description: Error message if the query failed
+    getVIPTickets:
+      displayName: Get ServiceNow VIP tickets
+      description: Read incident or SCTASK records in ServiceNow whose caller/requester is flagged as a VIP user (sys_user.vip), optionally filtered by an additional encoded query. Returns standard ticket fields and a computed time-to-resolution.
+      scopes: []
+      parameters:
+        type: object
+        required: [ticketType]
+        properties:
+          ticketType:
+            type: string
+            enum: [incident, sc_task]
+            description: Which kind of ticket to look up VIP records for
+          query:
+            type: string
+            description: >
+              Optional additional ServiceNow encoded query (sysparm_query) ANDed onto the base VIP
+              lookup — NOT SQL, JQL, or natural language. Conditions are joined with ^ for AND and ^OR
+              for OR, with no spaces around the ^. Example: "priority=1" to further narrow to
+              priority-1 VIP tickets. Leave empty to return all VIP tickets of the given type up to the limit.
+          additionalFields:
+            type: array
+            description: >
+              Extra ServiceNow field technical names to fetch for instance-specific/custom fields not
+              covered by the standard output (e.g. a custom "Program Office" field). Values are returned
+              per record under extraFields, keyed by the field name given here.
+            items:
+              type: string
+          limit:
+            type: number
+            description: Maximum number of VIP tickets to return (defaults to 25)
+          offset:
+            type: number
+            description: Number of records to skip, for pagination (defaults to 0)
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the query was successful
+          records:
+            type: array
+            description: The VIP ticket records matching the query
+            items:
+              type: object
+              properties:
+                ticketType:
+                  type: string
+                  description: Whether this record is an incident or a SCTASK
+                number:
+                  type: string
+                  description: The ticket number
+                ritmNumber:
+                  type: string
+                  description: The number of the parent Requested Item (RITM), if this is a SCTASK
+                vipUser:
+                  type: string
+                  description: The name of the VIP caller or requester associated with this ticket
+                assignee:
+                  type: string
+                  description: The name of the person assigned to the ticket
+                assignmentGroup:
+                  type: string
+                  description: The name of the group assigned to the ticket
+                shortDescription:
+                  type: string
+                  description: The short description of the ticket
+                description:
+                  type: string
+                  description: The full description of the ticket
+                state:
+                  type: string
+                  description: The current state of the ticket
+                openedAt:
+                  type: string
+                  description: The date and time the ticket was opened
+                updatedAt:
+                  type: string
+                  description: The date and time the ticket was last updated
+                closedAt:
+                  type: string
+                  description: The date and time the ticket was closed or completed, if applicable
+                workNotes:
+                  type: string
+                  description: Internal work notes on the ticket
+                comments:
+                  type: string
+                  description: Additional (customer-visible) comments on the ticket
+                timeToResolutionMinutes:
+                  type: number
+                  description: Minutes elapsed between openedAt and closedAt, if the ticket is closed
+                extraFields:
+                  type: object
+                  description: Values for any fields requested via the additionalFields parameter, keyed by field name
+          error:
+            type: string
+            description: Error message if the query failed
   boxUser: {}

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9832,6 +9832,13 @@ actions:
           offset:
             type: number
             description: Number of records to skip, for pagination (defaults to 0)
+          includeDisplayValues:
+            type: boolean
+            description: >
+              If false (default), each field is returned as a plain scalar value (e.g. active: true,
+              priority: "1"). If true, every field is instead returned as an object
+              {value: "<raw value>", display_value: "<human-readable value>"} — useful for reference
+              fields like assigned_to, where value is a sys_id and display_value is the user's name.
       output:
         type: object
         required: [success]

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9799,4 +9799,45 @@ actions:
           rowId:
             type: string
             description: The ID of the updated row
+  servicenow:
+    getRecordsByQuery:
+      displayName: Get ServiceNow records by query
+      description: Query records from any ServiceNow table (e.g. incident, change_request, sc_request) using an encoded query string via the Table API
+      scopes: []
+      parameters:
+        type: object
+        required: [tableName]
+        properties:
+          tableName:
+            type: string
+            description: The ServiceNow table to query (e.g. incident, change_request, sc_request, sys_user, kb_knowledge)
+          query:
+            type: string
+            description: 'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.'
+          fields:
+            type: array
+            description: Field names to return for each record (sysparm_fields). All fields are returned if omitted.
+            items:
+              type: string
+          limit:
+            type: number
+            description: Maximum number of records to return (defaults to 25)
+          offset:
+            type: number
+            description: Number of records to skip, for pagination (defaults to 0)
+      output:
+        type: object
+        required: [success]
+        properties:
+          success:
+            type: boolean
+            description: Whether the query was successful
+          records:
+            type: array
+            description: The records matching the query
+            items:
+              type: object
+          error:
+            type: string
+            description: Error message if the query failed
   boxUser: {}

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -9813,7 +9813,14 @@ actions:
             description: The ServiceNow table to query (e.g. incident, change_request, sc_request, sys_user, kb_knowledge)
           query:
             type: string
-            description: 'ServiceNow encoded query string (sysparm_query), e.g. "active=true^priority=1^ORDERBYDESCsys_created_on". If omitted, records are returned unfiltered up to the limit.'
+            description: >
+              ServiceNow encoded query string (sysparm_query) — NOT SQL, JQL, or natural language.
+              Conditions are joined with ^ for AND and ^OR for OR, with no spaces around the ^.
+              Format examples: field=value, field!=value, field>value, fieldLIKEvalue, fieldISEMPTY.
+              Sort with ^ORDERBY<field> (ascending) or ^ORDERBYDESC<field> (descending).
+              Example: "active=true^priority=1^ORDERBYDESCsys_created_on" means active records
+              with priority 1, sorted by most recently created first.
+              If omitted, records are returned unfiltered up to the limit.
           fields:
             type: array
             description: Field names to return for each record (sysparm_fields). All fields are returned if omitted.

--- a/tests/servicenow/testServiceNowActions.test.ts
+++ b/tests/servicenow/testServiceNowActions.test.ts
@@ -141,6 +141,17 @@ describe("ServiceNow actions", () => {
     expect(url.searchParams.get("sysparm_exclude_reference_link")).toBe("true");
   });
 
+  it("returns an empty records array when a generic query receives a non-array result", async () => {
+    mockGet.mockResolvedValueOnce({ data: { result: null } });
+
+    const result = await getRecordsByQuery({
+      authParams: AUTH,
+      params: { tableName: "incident" },
+    });
+
+    expect(result).toEqual({ success: true, records: [] });
+  });
+
   it("maps incident fields and custom fields", async () => {
     mockRecords([
       {

--- a/tests/servicenow/testServiceNowActions.test.ts
+++ b/tests/servicenow/testServiceNowActions.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import getChangeRequests from "../../src/actions/providers/servicenow/getChangeRequests";
+import getIncidents from "../../src/actions/providers/servicenow/getIncidents";
+import getRecordsByQuery from "../../src/actions/providers/servicenow/getRecordsByQuery";
+import getSCTasks from "../../src/actions/providers/servicenow/getSCTasks";
+import getVIPTickets from "../../src/actions/providers/servicenow/getVIPTickets";
+import {
+  computeTimeToClosureMinutes,
+  queryServiceNowTable,
+} from "../../src/actions/providers/servicenow/utils/tableQuery";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
+
+jest.mock("../../src/actions/util/axiosClient", () => ({
+  axiosClient: { get: (...args: any[]) => mockGet(...args) },
+  ApiError: class ApiError extends Error {},
+}));
+
+const AUTH = {
+  authToken: "test-token",
+  baseUrl: "https://example.service-now.com/",
+};
+
+function mockRecords(records: Record<string, string>[]) {
+  mockGet.mockResolvedValueOnce({ data: { result: records } });
+}
+
+function requestedUrl(): URL {
+  return new URL(mockGet.mock.calls[0][0] as string);
+}
+
+describe("ServiceNow table query helper", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds a safe Table API request and caps the limit", async () => {
+    mockRecords([]);
+
+    const result = await queryServiceNowTable({
+      authParams: AUTH,
+      tableName: "incident",
+      fields: ["number"],
+      additionalFields: ["u_program_office"],
+      baseFilter: "active=true",
+      filter: "priority=1",
+      limit: 100000,
+      offset: 5,
+    });
+
+    expect(result).toEqual({ records: [] });
+    const url = requestedUrl();
+    expect(url.pathname).toBe("/api/now/table/incident");
+    expect(url.searchParams.get("sysparm_limit")).toBe("10000");
+    expect(url.searchParams.get("sysparm_offset")).toBe("5");
+    expect(url.searchParams.get("sysparm_query")).toBe(
+      "active=true^priority=1",
+    );
+    expect(url.searchParams.get("sysparm_fields")).toBe(
+      "number,u_program_office",
+    );
+    expect(url.searchParams.get("sysparm_display_value")).toBe("true");
+    expect(url.searchParams.get("sysparm_exclude_reference_link")).toBe("true");
+    expect(mockGet.mock.calls[0][1]).toEqual({
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer test-token",
+      },
+    });
+  });
+
+  it("returns an empty array when ServiceNow returns a non-array result", async () => {
+    mockGet.mockResolvedValueOnce({ data: { result: null } });
+
+    const result = await queryServiceNowTable({
+      authParams: AUTH,
+      tableName: "incident",
+      fields: ["number"],
+    });
+
+    expect(result).toEqual({ records: [] });
+  });
+
+  it("rejects missing authentication before making a request", async () => {
+    const result = await queryServiceNowTable({
+      authParams: {},
+      tableName: "incident",
+      fields: ["number"],
+    });
+
+    expect(result).toEqual({
+      error: "authToken and baseUrl are required for the ServiceNow API",
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("calculates time to closure and ignores invalid date ranges", () => {
+    expect(
+      computeTimeToClosureMinutes(
+        "2026-01-01T10:00:00Z",
+        "2026-01-01T11:30:00Z",
+      ),
+    ).toBe(90);
+    expect(
+      computeTimeToClosureMinutes(
+        "2026-01-01T11:30:00Z",
+        "2026-01-01T10:00:00Z",
+      ),
+    ).toBeUndefined();
+    expect(
+      computeTimeToClosureMinutes("invalid", "2026-01-01T10:00:00Z"),
+    ).toBeUndefined();
+    expect(computeTimeToClosureMinutes("2026-01-01T10:00:00Z")).toBeUndefined();
+  });
+});
+
+describe("ServiceNow actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("queries arbitrary records with plain scalar values by default", async () => {
+    mockRecords([{ number: "INC001", active: "true" }]);
+
+    const result = await getRecordsByQuery({
+      authParams: AUTH,
+      params: {
+        tableName: "incident",
+        query: "active=true",
+        fields: ["number", "active"],
+      },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      records: [{ number: "INC001", active: "true" }],
+    });
+    const url = requestedUrl();
+    expect(url.searchParams.get("sysparm_display_value")).toBe("false");
+    expect(url.searchParams.get("sysparm_exclude_reference_link")).toBe("true");
+  });
+
+  it("maps incident fields and custom fields", async () => {
+    mockRecords([
+      {
+        number: "INC001",
+        caller_id: "VIP User",
+        assigned_to: "Agent One",
+        assignment_group: "Service Desk",
+        short_description: "Cannot connect",
+        description: "VPN is unavailable",
+        state: "Resolved",
+        incident_state: "Resolved",
+        priority: "1 - Critical",
+        impact: "1 - High",
+        urgency: "1 - High",
+        opened_at: "2026-01-01T10:00:00Z",
+        sys_updated_on: "2026-01-01T11:00:00Z",
+        closed_at: "2026-01-01T11:30:00Z",
+        work_notes: "Restarted gateway",
+        comments: "Service restored",
+        u_program_office: "Technology",
+      },
+    ]);
+
+    const result = await getIncidents({
+      authParams: AUTH,
+      params: { additionalFields: ["u_program_office"] },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.records?.[0]).toMatchObject({
+      number: "INC001",
+      caller: "VIP User",
+      assignee: "Agent One",
+      state: "Resolved",
+      timeToClosureMinutes: 90,
+      extraFields: { u_program_office: "Technology" },
+    });
+    expect(requestedUrl().pathname).toBe("/api/now/table/incident");
+  });
+
+  it("maps change request fields", async () => {
+    mockRecords([
+      {
+        number: "CHG001",
+        requested_by: "Requestor One",
+        assigned_to: "Agent One",
+        assignment_group: "Change Team",
+        short_description: "Upgrade database",
+        description: "Apply database upgrade",
+        state: "Closed",
+        priority: "2 - High",
+        impact: "2 - Medium",
+        urgency: "2 - Medium",
+        opened_at: "2026-01-01T10:00:00Z",
+        sys_updated_on: "2026-01-01T12:00:00Z",
+        closed_at: "2026-01-01T12:00:00Z",
+        work_notes: "Upgrade completed",
+        comments: "Validated",
+      },
+    ]);
+
+    const result = await getChangeRequests({ authParams: AUTH, params: {} });
+
+    expect(result.success).toBe(true);
+    expect(result.records?.[0]).toMatchObject({
+      number: "CHG001",
+      requestor: "Requestor One",
+      assignmentGroup: "Change Team",
+      timeToClosureMinutes: 120,
+    });
+    expect(requestedUrl().pathname).toBe("/api/now/table/change_request");
+  });
+
+  it("maps SCTASK fields and its parent RITM number", async () => {
+    mockRecords([
+      {
+        number: "SCTASK001",
+        request_item: "RITM001",
+        assigned_to: "Agent One",
+        assignment_group: "Fulfillment",
+        short_description: "Provision laptop",
+        description: "Prepare standard laptop",
+        state: "Closed Complete",
+        priority: "3 - Moderate",
+        opened_at: "2026-01-01T10:00:00Z",
+        sys_updated_on: "2026-01-01T10:45:00Z",
+        closed_at: "2026-01-01T10:45:00Z",
+        work_notes: "Laptop provisioned",
+        comments: "Ready for pickup",
+      },
+    ]);
+
+    const result = await getSCTasks({ authParams: AUTH, params: {} });
+
+    expect(result.success).toBe(true);
+    expect(result.records?.[0]).toMatchObject({
+      number: "SCTASK001",
+      ritmNumber: "RITM001",
+      assignmentGroup: "Fulfillment",
+      timeToClosureMinutes: 45,
+    });
+    expect(requestedUrl().pathname).toBe("/api/now/table/sc_task");
+  });
+
+  it.each([
+    {
+      ticketType: "incident" as const,
+      sourceUserField: "caller_id",
+      vipUser: "VIP Caller",
+      expectedFilter: "caller_id.vip=true^state=7",
+    },
+    {
+      ticketType: "sc_task" as const,
+      sourceUserField: "request_item.requested_for",
+      vipUser: "VIP Requester",
+      expectedFilter: "request_item.requested_for.vip=true^state=7",
+    },
+  ])(
+    "queries and maps VIP $ticketType tickets",
+    async ({ ticketType, sourceUserField, vipUser, expectedFilter }) => {
+      mockRecords([
+        {
+          number: ticketType === "incident" ? "INC001" : "SCTASK001",
+          request_item: "RITM001",
+          [sourceUserField]: vipUser,
+          opened_at: "2026-01-01T10:00:00Z",
+          closed_at: "2026-01-01T11:00:00Z",
+        },
+      ]);
+
+      const result = await getVIPTickets({
+        authParams: AUTH,
+        params: { ticketType, query: "state=7" },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.records?.[0]).toMatchObject({
+        ticketType,
+        vipUser,
+        timeToClosureMinutes: 60,
+      });
+      expect(requestedUrl().searchParams.get("sysparm_query")).toBe(
+        expectedFilter,
+      );
+    },
+  );
+});


### PR DESCRIPTION
**Context**
We're integrating ServiceNow support into the SDK. ACF want to be able to read only for now, using the specific actions created here.

**Summary**
- Added a new servicenow provider with a getRecordsByQuery action, defined in src/actions/schema.yaml and implemented in src/actions/providers/servicenow/getRecordsByQuery.ts
- The action queries any ServiceNow table via the Table API, supporting an encoded query string, field selection, and limit/offset pagination
Auth follows the existing baseUrl + authToken convention (same pattern as Salesforce), pointing at the ServiceNow instance URL with a Bearer token
- Regenerated src/actions/autogen/types.ts and src/actions/autogen/templates.ts via npm run generate:types, and registered the action in src/actions/actionMapper.ts as a read action

Tested locally with real ServiceNow instance:
Loom: https://www.loom.com/share/2a02c9ffab69470bb1076dd8bb086126