### PR TITLE
fix(microsoft): support targeting a specific drive via driveId in document actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.224",
+  "version": "0.2.225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.224",
+      "version": "0.2.225",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.224",
+  "version": "0.2.225",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11658,7 +11658,13 @@ export const microsoftUpdateDocumentDefinition: ActionTemplate = {
     properties: {
       siteId: {
         type: "string",
-        description: "The ID of the site where the document is located",
+        description:
+          "The ID of the site where the document is located (targets the site's default document library; ignored if driveId is provided)",
+      },
+      driveId: {
+        type: "string",
+        description:
+          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
       },
       documentId: {
         type: "string",
@@ -11720,7 +11726,13 @@ export const microsoftUpdateSpreadsheetDefinition: ActionTemplate = {
       },
       siteId: {
         type: "string",
-        description: "The ID of the site where the spreadsheet is located",
+        description:
+          "The ID of the site where the spreadsheet is located (targets the site's default document library; ignored if driveId is provided)",
+      },
+      driveId: {
+        type: "string",
+        description:
+          "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId",
       },
     },
   },
@@ -11840,7 +11852,13 @@ export const microsoftGetDocumentDefinition: ActionTemplate = {
     properties: {
       siteId: {
         type: "string",
-        description: "The ID of the site where the document is located (optional for OneDrive)",
+        description:
+          "The ID of the site where the document is located (optional for OneDrive; targets the site's default document library; ignored if driveId is provided)",
+      },
+      driveId: {
+        type: "string",
+        description:
+          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
       },
       documentId: {
         type: "string",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11596,7 +11596,13 @@ export const microsoftCreateDocumentDefinition: ActionTemplate = {
     properties: {
       siteId: {
         type: "string",
-        description: "The ID of the site where the document will be created",
+        description:
+          "The ID of the site where the document will be created (targets the site's default document library; ignored if driveId is provided)",
+      },
+      driveId: {
+        type: "string",
+        description:
+          "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId",
       },
       name: {
         type: "string",

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11602,7 +11602,7 @@ export const microsoftCreateDocumentDefinition: ActionTemplate = {
       driveId: {
         type: "string",
         description:
-          "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId",
+          "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
       },
       name: {
         type: "string",
@@ -11664,7 +11664,7 @@ export const microsoftUpdateDocumentDefinition: ActionTemplate = {
       driveId: {
         type: "string",
         description:
-          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
       },
       documentId: {
         type: "string",
@@ -11732,7 +11732,7 @@ export const microsoftUpdateSpreadsheetDefinition: ActionTemplate = {
       driveId: {
         type: "string",
         description:
-          "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId",
+          "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
       },
     },
   },
@@ -11858,7 +11858,7 @@ export const microsoftGetDocumentDefinition: ActionTemplate = {
       driveId: {
         type: "string",
         description:
-          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+          "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
       },
       documentId: {
         type: "string",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6178,7 +6178,18 @@ export type salesforceGetReportMetadataFunction = ActionFunction<
 >;
 
 export const microsoftCreateDocumentParamsSchema = z.object({
-  siteId: z.string().describe("The ID of the site where the document will be created").optional(),
+  siteId: z
+    .string()
+    .describe(
+      "The ID of the site where the document will be created (targets the site's default document library; ignored if driveId is provided)",
+    )
+    .optional(),
+  driveId: z
+    .string()
+    .describe(
+      "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId",
+    )
+    .optional(),
   name: z.string().describe("The name of the new document (include extension like .docx or .xlsx)"),
   content: z.string().describe("The content to add to the new document"),
   folderId: z.string().describe("The ID of the folder to create the document in (optional)").optional(),

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6213,7 +6213,18 @@ export type microsoftCreateDocumentFunction = ActionFunction<
 >;
 
 export const microsoftUpdateDocumentParamsSchema = z.object({
-  siteId: z.string().describe("The ID of the site where the document is located").optional(),
+  siteId: z
+    .string()
+    .describe(
+      "The ID of the site where the document is located (targets the site's default document library; ignored if driveId is provided)",
+    )
+    .optional(),
+  driveId: z
+    .string()
+    .describe(
+      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+    )
+    .optional(),
   documentId: z.string().describe("The ID of the document"),
   content: z.string().describe("The new content to update in the document"),
 });
@@ -6237,7 +6248,18 @@ export const microsoftUpdateSpreadsheetParamsSchema = z.object({
   spreadsheetId: z.string().describe("The ID of the spreadsheet to update"),
   range: z.string().describe('The range of cells to update (e.g., "Sheet1!A1:B2")'),
   values: z.array(z.array(z.string())).describe("The values to update in the specified range"),
-  siteId: z.string().describe("The ID of the site where the spreadsheet is located").optional(),
+  siteId: z
+    .string()
+    .describe(
+      "The ID of the site where the spreadsheet is located (targets the site's default document library; ignored if driveId is provided)",
+    )
+    .optional(),
+  driveId: z
+    .string()
+    .describe(
+      "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId",
+    )
+    .optional(),
 });
 
 export type microsoftUpdateSpreadsheetParamsType = z.infer<typeof microsoftUpdateSpreadsheetParamsSchema>;
@@ -6297,7 +6319,18 @@ export type microsoftMessageTeamsChannelFunction = ActionFunction<
 >;
 
 export const microsoftGetDocumentParamsSchema = z.object({
-  siteId: z.string().describe("The ID of the site where the document is located (optional for OneDrive)").optional(),
+  siteId: z
+    .string()
+    .describe(
+      "The ID of the site where the document is located (optional for OneDrive; targets the site's default document library; ignored if driveId is provided)",
+    )
+    .optional(),
+  driveId: z
+    .string()
+    .describe(
+      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+    )
+    .optional(),
   documentId: z.string().describe("The ID of the document to retrieve"),
 });
 

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6187,7 +6187,7 @@ export const microsoftCreateDocumentParamsSchema = z.object({
   driveId: z
     .string()
     .describe(
-      "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId",
+      "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
   name: z.string().describe("The name of the new document (include extension like .docx or .xlsx)"),
@@ -6222,7 +6222,7 @@ export const microsoftUpdateDocumentParamsSchema = z.object({
   driveId: z
     .string()
     .describe(
-      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
   documentId: z.string().describe("The ID of the document"),
@@ -6257,7 +6257,7 @@ export const microsoftUpdateSpreadsheetParamsSchema = z.object({
   driveId: z
     .string()
     .describe(
-      "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId",
+      "The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
 });
@@ -6328,7 +6328,7 @@ export const microsoftGetDocumentParamsSchema = z.object({
   driveId: z
     .string()
     .describe(
-      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId",
+      "The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
   documentId: z.string().describe("The ID of the document to retrieve"),

--- a/src/actions/providers/microsoft/createDocument.ts
+++ b/src/actions/providers/microsoft/createDocument.ts
@@ -13,7 +13,7 @@ const createDocument: microsoftCreateDocumentFunction = async ({
   params: microsoftCreateDocumentParamsType;
   authParams: AuthParamsType;
 }): Promise<microsoftCreateDocumentOutputType> => {
-  const { folderId, name, content, siteId } = params;
+  const { folderId, name, content, siteId, driveId } = params;
 
   let client = undefined;
   try {
@@ -25,9 +25,11 @@ const createDocument: microsoftCreateDocumentFunction = async ({
     };
   }
 
-  const apiEndpointPrefix = siteId ? `/sites/${siteId}` : "/me";
+  // Item IDs are scoped to a drive, so a driveId (when known) addresses the exact document
+  // library; /sites/{siteId}/drive only ever reaches the site's default library
+  const drivePath = driveId ? `/drives/${driveId}` : siteId ? `/sites/${siteId}/drive` : "/me/drive";
   const sanitizedFileName = validateAndSanitizeFileName(name);
-  const endpoint = `${apiEndpointPrefix}/drive/items/${folderId || "root"}:/${sanitizedFileName}:/content`;
+  const endpoint = `${drivePath}/items/${folderId || "root"}:/${sanitizedFileName}:/content`;
   try {
     // Create or update the document
     const response = await client.api(endpoint).put(content);

--- a/src/actions/providers/microsoft/createDocument.ts
+++ b/src/actions/providers/microsoft/createDocument.ts
@@ -4,7 +4,7 @@ import type {
   microsoftCreateDocumentOutputType,
   microsoftCreateDocumentParamsType,
 } from "../../autogen/types.js";
-import { getGraphClient, validateAndSanitizeFileName } from "./utils.js";
+import { getDrivePath, getGraphClient, validateAndSanitizeFileName } from "./utils.js";
 
 const createDocument: microsoftCreateDocumentFunction = async ({
   params,
@@ -25,11 +25,8 @@ const createDocument: microsoftCreateDocumentFunction = async ({
     };
   }
 
-  // Item IDs are scoped to a drive, so a driveId (when known) addresses the exact document
-  // library; /sites/{siteId}/drive only ever reaches the site's default library
-  const drivePath = driveId ? `/drives/${driveId}` : siteId ? `/sites/${siteId}/drive` : "/me/drive";
   const sanitizedFileName = validateAndSanitizeFileName(name);
-  const endpoint = `${drivePath}/items/${folderId || "root"}:/${sanitizedFileName}:/content`;
+  const endpoint = `${getDrivePath({ driveId, siteId })}/items/${folderId || "root"}:/${sanitizedFileName}:/content`;
   try {
     // Create or update the document
     const response = await client.api(endpoint).put(content);

--- a/src/actions/providers/microsoft/getDocument.ts
+++ b/src/actions/providers/microsoft/getDocument.ts
@@ -4,7 +4,7 @@ import type {
   microsoftGetDocumentOutputType,
   microsoftGetDocumentParamsType,
 } from "../../autogen/types.js";
-import { getGraphClient } from "./utils.js";
+import { getDrivePath, getGraphClient } from "./utils.js";
 
 const getDocument: microsoftGetDocumentFunction = async ({
   params,
@@ -13,7 +13,7 @@ const getDocument: microsoftGetDocumentFunction = async ({
   params: microsoftGetDocumentParamsType;
   authParams: AuthParamsType;
 }): Promise<microsoftGetDocumentOutputType> => {
-  const { siteId, documentId } = params;
+  const { siteId, driveId, documentId } = params;
 
   let client;
   try {
@@ -26,10 +26,7 @@ const getDocument: microsoftGetDocumentFunction = async ({
   }
 
   try {
-    // Construct the API endpoint
-    const endpoint = siteId
-      ? `/sites/${siteId}/drive/items/${documentId}/content`
-      : `/me/drive/items/${documentId}/content`;
+    const endpoint = `${getDrivePath({ driveId, siteId })}/items/${documentId}/content`;
 
     // Fetch the document content
     const response = await client.api(endpoint).get();

--- a/src/actions/providers/microsoft/updateDocument.ts
+++ b/src/actions/providers/microsoft/updateDocument.ts
@@ -4,7 +4,7 @@ import type {
   microsoftUpdateDocumentOutputType,
   microsoftUpdateDocumentParamsType,
 } from "../../autogen/types.js";
-import { getGraphClient } from "./utils.js";
+import { getDrivePath, getGraphClient } from "./utils.js";
 
 const updateDocument: microsoftUpdateDocumentFunction = async ({
   params,
@@ -13,7 +13,7 @@ const updateDocument: microsoftUpdateDocumentFunction = async ({
   params: microsoftUpdateDocumentParamsType;
   authParams: AuthParamsType;
 }): Promise<microsoftUpdateDocumentOutputType> => {
-  const { documentId, content, siteId } = params;
+  const { documentId, content, siteId, driveId } = params;
 
   let client = undefined;
   try {
@@ -26,10 +26,7 @@ const updateDocument: microsoftUpdateDocumentFunction = async ({
   }
 
   try {
-    // Determine the endpoint based on whether siteId is provided
-    const endpoint = siteId
-      ? `/sites/${siteId}/drive/items/${documentId}/content`
-      : `/me/drive/items/${documentId}/content`;
+    const endpoint = `${getDrivePath({ driveId, siteId })}/items/${documentId}/content`;
 
     const response = await client.api(endpoint).put(content);
 

--- a/src/actions/providers/microsoft/updateSpreadsheet.ts
+++ b/src/actions/providers/microsoft/updateSpreadsheet.ts
@@ -4,7 +4,7 @@ import type {
   microsoftUpdateSpreadsheetOutputType,
   microsoftUpdateSpreadsheetParamsType,
 } from "../../autogen/types.js";
-import { getGraphClient } from "./utils.js";
+import { getDrivePath, getGraphClient } from "./utils.js";
 
 const updateSpreadsheet: microsoftUpdateSpreadsheetFunction = async ({
   params,
@@ -13,7 +13,7 @@ const updateSpreadsheet: microsoftUpdateSpreadsheetFunction = async ({
   params: microsoftUpdateSpreadsheetParamsType;
   authParams: AuthParamsType;
 }): Promise<microsoftUpdateSpreadsheetOutputType> => {
-  const { spreadsheetId, range, values, siteId } = params; // Added siteId to destructured params
+  const { spreadsheetId, range, values, siteId, driveId } = params;
 
   let client = undefined;
   try {
@@ -25,7 +25,6 @@ const updateSpreadsheet: microsoftUpdateSpreadsheetFunction = async ({
     };
   }
 
-  const apiEndpointPrefix = siteId ? `/sites/${siteId}` : "/me";
   if (!range.includes("!")) {
     return {
       success: false,
@@ -41,7 +40,7 @@ const updateSpreadsheet: microsoftUpdateSpreadsheetFunction = async ({
     };
   }
 
-  const apiEndpoint = `${apiEndpointPrefix}/drive/items/${spreadsheetId}/workbook/worksheets/${sheetName}/range(address='${cellRange}')`;
+  const apiEndpoint = `${getDrivePath({ driveId, siteId })}/items/${spreadsheetId}/workbook/worksheets/${sheetName}/range(address='${cellRange}')`;
 
   try {
     const response = await client.api(apiEndpoint).patch({ values });

--- a/src/actions/providers/microsoft/utils.ts
+++ b/src/actions/providers/microsoft/utils.ts
@@ -14,6 +14,15 @@ export async function getGraphClient(authParams: AuthParamsType): Promise<Client
 }
 
 /**
+ * Builds the Graph API path prefix addressing a drive. Item IDs are scoped to a drive, so a
+ * driveId (when known) addresses the exact document library; /sites/{siteId}/drive only ever
+ * reaches the site's default library, and /me/drive the user's personal OneDrive.
+ */
+export function getDrivePath({ driveId, siteId }: { driveId?: string; siteId?: string }): string {
+  return driveId ? `/drives/${driveId}` : siteId ? `/sites/${siteId}/drive` : "/me/drive";
+}
+
+/**
  * Validates and sanitizes a filename for SharePoint or OneDrive.
  * @param fileName The original filename to validate and sanitize.
  * @returns A sanitized filename that is safe to use.

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6966,7 +6966,10 @@ actions:
         properties:
           siteId:
             type: string
-            description: The ID of the site where the document is located
+            description: The ID of the site where the document is located (targets the site's default document library; ignored if driveId is provided)
+          driveId:
+            type: string
+            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId
           documentId:
             type: string
             description: The ID of the document
@@ -7009,7 +7012,10 @@ actions:
                 type: string
           siteId:
             type: string
-            description: The ID of the site where the spreadsheet is located
+            description: The ID of the site where the spreadsheet is located (targets the site's default document library; ignored if driveId is provided)
+          driveId:
+            type: string
+            description: The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId
       output:
         type: object
         required: [success]
@@ -7090,7 +7096,10 @@ actions:
         properties:
           siteId:
             type: string
-            description: The ID of the site where the document is located (optional for OneDrive)
+            description: The ID of the site where the document is located (optional for OneDrive; targets the site's default document library; ignored if driveId is provided)
+          driveId:
+            type: string
+            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId
           documentId:
             type: string
             description: The ID of the document to retrieve

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6927,7 +6927,7 @@ actions:
             description: The ID of the site where the document will be created (targets the site's default document library; ignored if driveId is provided)
           driveId:
             type: string
-            description: The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId
+            description: The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action
           name:
             type: string
             description: The name of the new document (include extension like .docx or .xlsx)
@@ -6969,7 +6969,7 @@ actions:
             description: The ID of the site where the document is located (targets the site's default document library; ignored if driveId is provided)
           driveId:
             type: string
-            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId
+            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action
           documentId:
             type: string
             description: The ID of the document
@@ -7015,7 +7015,7 @@ actions:
             description: The ID of the site where the spreadsheet is located (targets the site's default document library; ignored if driveId is provided)
           driveId:
             type: string
-            description: The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId
+            description: The ID of the drive (document library) containing the spreadsheet. Required when the spreadsheet is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action
       output:
         type: object
         required: [success]
@@ -7099,7 +7099,7 @@ actions:
             description: The ID of the site where the document is located (optional for OneDrive; targets the site's default document library; ignored if driveId is provided)
           driveId:
             type: string
-            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId
+            description: The ID of the drive (document library) containing the document. Required when the document is in a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action
           documentId:
             type: string
             description: The ID of the document to retrieve

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6924,7 +6924,10 @@ actions:
         properties:
           siteId:
             type: string
-            description: The ID of the site where the document will be created
+            description: The ID of the site where the document will be created (targets the site's default document library; ignored if driveId is provided)
+          driveId:
+            type: string
+            description: The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId
           name:
             type: string
             description: The name of the new document (include extension like .docx or .xlsx)

--- a/tests/microsoft/testCreateDocument.ts
+++ b/tests/microsoft/testCreateDocument.ts
@@ -17,6 +17,7 @@ async function runTest() {
     }, // authParams
     {
       siteId: process.env.MICROSOFT_SITE_ID!,
+      driveId: process.env.MICROSOFT_DRIVE_ID,
       name: `TestDocument-${new Date()}.docx`,
       content: "",
       folderId: process.env.MICROSOFT_FOLDER_ID!,


### PR DESCRIPTION
/sites/{siteId}/drive only ever resolves to the site's default document library, so createDocument 404'd whenever the target folder lived in any other library (item IDs are drive-scoped). Add an optional driveId param that addresses the drive directly via /drives/{driveId}.