### PR TITLE
Microsoft createDocument/updateDocument: generate real .docx from text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.225",
+  "version": "0.2.226",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.225",
+      "version": "0.2.226",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.225",
+  "version": "0.2.226",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11606,11 +11606,11 @@ export const microsoftCreateDocumentDefinition: ActionTemplate = {
       },
       name: {
         type: "string",
-        description: "The name of the new document (include extension like .docx or .xlsx)",
+        description: "The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected",
       },
       content: {
         type: "string",
-        description: "The content to add to the new document",
+        description: "The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is",
       },
       folderId: {
         type: "string",
@@ -11672,7 +11672,7 @@ export const microsoftUpdateDocumentDefinition: ActionTemplate = {
       },
       content: {
         type: "string",
-        description: "The new content to update in the document",
+        description: "The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated",
       },
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -11606,11 +11606,13 @@ export const microsoftCreateDocumentDefinition: ActionTemplate = {
       },
       name: {
         type: "string",
-        description: "The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected",
+        description:
+          "The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected",
       },
       content: {
         type: "string",
-        description: "The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is",
+        description:
+          "The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is",
       },
       folderId: {
         type: "string",
@@ -11672,7 +11674,8 @@ export const microsoftUpdateDocumentDefinition: ActionTemplate = {
       },
       content: {
         type: "string",
-        description: "The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated",
+        description:
+          "The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6190,8 +6190,8 @@ export const microsoftCreateDocumentParamsSchema = z.object({
       "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
-  name: z.string().describe("The name of the new document (include extension like .docx or .xlsx)"),
-  content: z.string().describe("The content to add to the new document"),
+  name: z.string().describe("The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected"),
+  content: z.string().describe("The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is"),
   folderId: z.string().describe("The ID of the folder to create the document in (optional)").optional(),
 });
 
@@ -6226,7 +6226,7 @@ export const microsoftUpdateDocumentParamsSchema = z.object({
     )
     .optional(),
   documentId: z.string().describe("The ID of the document"),
-  content: z.string().describe("The new content to update in the document"),
+  content: z.string().describe("The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated"),
 });
 
 export type microsoftUpdateDocumentParamsType = z.infer<typeof microsoftUpdateDocumentParamsSchema>;

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -6190,8 +6190,16 @@ export const microsoftCreateDocumentParamsSchema = z.object({
       "The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action",
     )
     .optional(),
-  name: z.string().describe("The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected"),
-  content: z.string().describe("The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is"),
+  name: z
+    .string()
+    .describe(
+      "The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected",
+    ),
+  content: z
+    .string()
+    .describe(
+      "The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is",
+    ),
   folderId: z.string().describe("The ID of the folder to create the document in (optional)").optional(),
 });
 
@@ -6226,7 +6234,11 @@ export const microsoftUpdateDocumentParamsSchema = z.object({
     )
     .optional(),
   documentId: z.string().describe("The ID of the document"),
-  content: z.string().describe("The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated"),
+  content: z
+    .string()
+    .describe(
+      "The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated",
+    ),
 });
 
 export type microsoftUpdateDocumentParamsType = z.infer<typeof microsoftUpdateDocumentParamsSchema>;

--- a/src/actions/providers/microsoft/createDocument.ts
+++ b/src/actions/providers/microsoft/createDocument.ts
@@ -4,7 +4,14 @@ import type {
   microsoftCreateDocumentOutputType,
   microsoftCreateDocumentParamsType,
 } from "../../autogen/types.js";
-import { getDrivePath, getGraphClient, validateAndSanitizeFileName } from "./utils.js";
+import {
+  fileNameHasDocxExtension,
+  generateDocxFromPlainText,
+  getDrivePath,
+  getGraphClient,
+  getUnsupportedOfficeExtension,
+  validateAndSanitizeFileName,
+} from "./utils.js";
 
 const createDocument: microsoftCreateDocumentFunction = async ({
   params,
@@ -26,10 +33,22 @@ const createDocument: microsoftCreateDocumentFunction = async ({
   }
 
   const sanitizedFileName = validateAndSanitizeFileName(name);
+
+  const unsupportedOfficeExtension = getUnsupportedOfficeExtension(sanitizedFileName);
+  if (unsupportedOfficeExtension) {
+    return {
+      success: false,
+      error: `Cannot create "${unsupportedOfficeExtension}" files: this action writes the provided text and can only generate Word documents. Use a .docx extension for a Word document, or a plain-text extension like .txt.`,
+    };
+  }
+
   const endpoint = `${getDrivePath({ driveId, siteId })}/items/${folderId || "root"}:/${sanitizedFileName}:/content`;
   try {
+    // .docx is a ZIP-of-XML container, so the text must be converted into real OOXML
+    // bytes; writing it directly would produce a file Word cannot open.
+    const body = fileNameHasDocxExtension(sanitizedFileName) ? await generateDocxFromPlainText(content) : content;
     // Create or update the document
-    const response = await client.api(endpoint).put(content);
+    const response = await client.api(endpoint).put(body);
     return {
       success: true,
       documentId: response.id,

--- a/src/actions/providers/microsoft/updateDocument.ts
+++ b/src/actions/providers/microsoft/updateDocument.ts
@@ -4,7 +4,13 @@ import type {
   microsoftUpdateDocumentOutputType,
   microsoftUpdateDocumentParamsType,
 } from "../../autogen/types.js";
-import { getDrivePath, getGraphClient } from "./utils.js";
+import {
+  fileNameHasDocxExtension,
+  generateDocxFromPlainText,
+  getDrivePath,
+  getGraphClient,
+  getUnsupportedOfficeExtension,
+} from "./utils.js";
 
 const updateDocument: microsoftUpdateDocumentFunction = async ({
   params,
@@ -26,9 +32,26 @@ const updateDocument: microsoftUpdateDocumentFunction = async ({
   }
 
   try {
-    const endpoint = `${getDrivePath({ driveId, siteId })}/items/${documentId}/content`;
+    const drivePath = getDrivePath({ driveId, siteId });
 
-    const response = await client.api(endpoint).put(content);
+    // The target's filename decides how the content must be written: .docx is a
+    // ZIP-of-XML container, so overwriting it with raw text would corrupt it.
+    const itemMetadata = await client.api(`${drivePath}/items/${documentId}?$select=name`).get();
+    const fileName: string = itemMetadata?.name ?? "";
+
+    const unsupportedOfficeExtension = getUnsupportedOfficeExtension(fileName);
+    if (unsupportedOfficeExtension) {
+      return {
+        success: false,
+        error: `Cannot update "${unsupportedOfficeExtension}" files: this action writes the provided text and can only generate Word documents. Only .docx and plain-text files can be updated.`,
+      };
+    }
+
+    const body = fileNameHasDocxExtension(fileName) ? await generateDocxFromPlainText(content) : content;
+
+    const endpoint = `${drivePath}/items/${documentId}/content`;
+
+    const response = await client.api(endpoint).put(body);
 
     return {
       success: true,

--- a/src/actions/providers/microsoft/utils.ts
+++ b/src/actions/providers/microsoft/utils.ts
@@ -1,4 +1,5 @@
 import { Client } from "@microsoft/microsoft-graph-client";
+import { Document, Packer, Paragraph, TextRun } from "docx";
 import type { AuthParamsType } from "../../autogen/types.js";
 
 export async function getGraphClient(authParams: AuthParamsType): Promise<Client> {
@@ -49,6 +50,30 @@ export function validateAndSanitizeFileName(fileName: string): string {
   }
 
   return sanitizedFileName;
+}
+
+// Office formats that are binary/ZIP containers. Writing plain text bytes under these
+// extensions produces a file the corresponding Office app cannot open.
+const UNSUPPORTED_OFFICE_EXTENSIONS = [".doc", ".xlsx", ".xls", ".pptx", ".ppt"];
+
+export function fileNameHasDocxExtension(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".docx");
+}
+
+export function getUnsupportedOfficeExtension(fileName: string): string | undefined {
+  const lowerCaseFileName = fileName.toLowerCase();
+  return UNSUPPORTED_OFFICE_EXTENSIONS.find(extension => lowerCaseFileName.endsWith(extension));
+}
+
+/**
+ * Builds a valid .docx file from plain text, one paragraph per line. A .docx is a ZIP
+ * archive of XML parts, so text bytes written directly under a .docx name produce a
+ * corrupted document — the bytes must be generated with an OOXML writer.
+ */
+export async function generateDocxFromPlainText(text: string): Promise<Buffer> {
+  const paragraphs = text.split(/\r?\n/).map(line => new Paragraph({ children: [new TextRun({ text: line })] }));
+  const document = new Document({ sections: [{ properties: {}, children: paragraphs }] });
+  return Packer.toBuffer(document);
 }
 
 export const MICROSOFT_GRAPH_API_URL = "https://graph.microsoft.com/v1.0";

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -6930,10 +6930,10 @@ actions:
             description: The ID of the drive (document library) to create the document in. Required to target a non-default document library; takes precedence over siteId. Can be resolved from a SharePoint URL with the getSharepointItem action
           name:
             type: string
-            description: The name of the new document (include extension like .docx or .xlsx)
+            description: The name of the new document, including the extension. Use .docx for a Word document (the content is converted into a real Word file) or a plain-text extension like .txt or .md. Other Office extensions (.doc, .xlsx, .xls, .pptx, .ppt) are not supported and will be rejected
           content:
             type: string
-            description: The content to add to the new document
+            description: The plain-text content of the document. When the name ends in .docx it is converted into a Word document with one paragraph per line; otherwise it is written as-is
           folderId:
             type: string
             description: The ID of the folder to create the document in (optional)
@@ -6975,7 +6975,7 @@ actions:
             description: The ID of the document
           content:
             type: string
-            description: The new content to update in the document
+            description: The new plain-text content for the document (replaces the existing content entirely). If the target file is a .docx it is converted into a Word document with one paragraph per line; other Office formats (.doc, .xlsx, .xls, .pptx, .ppt) cannot be updated
       output:
         type: object
         required: [success]


### PR DESCRIPTION
Comcast (Arjun and Fady) use the Microsoft write actions to have agents produce Word master documents. **createDocument** wrote the agent's text as raw file bytes, while its schema told agents to name files .docx or .xlsx. Any Office-named file it produced was corrupted: Word Online refused to open it, and pasting it into Credal ingestion failed with a 400 from the docx parser.

Changes

- **createDocument**: when the name ends in .docx, the text content is converted into a
  valid Word document (one paragraph per line) using the `docx` library, which was
  already a dependency, and uploaded as real OOXML bytes.
  
- **updateDocument**: looks up the target file's name first and converts the same way for
  .docx targets, so updating a Word document no longer corrupts it.
  
- Both actions reject .doc, .xlsx, .xls, .pptx and .ppt with a clear error the agent
  can act on, instead of silently writing corrupt bytes.
  
- Schema descriptions updated so agents are no longer instructed to use unsupported
  Office extensions.

Testing

- E2E test in local dev: 

  Test Master Document.docx via createDocument, the file opens and edits normally in
  Word Online, then updateDocument replaced the content with multi-line text and the
  document stayed valid. Uploaded bytes were fetched via Graph and confirmed to be a
  real docx (ZIP magic), not text.
