### PR TITLE
Add Query Zendesk tickets action

### DIFF
--- a/src/actions/actionMapper.ts
+++ b/src/actions/actionMapper.ts
@@ -35,6 +35,8 @@ import {
   zendeskListZendeskTicketsParamsSchema,
   zendeskSearchZendeskByQueryOutputSchema,
   zendeskSearchZendeskByQueryParamsSchema,
+  zendeskSearchZendeskTicketsByQueryOutputSchema,
+  zendeskSearchZendeskTicketsByQueryParamsSchema,
   servicenowGetRecordsByQueryOutputSchema,
   servicenowGetRecordsByQueryParamsSchema,
   servicenowGetIncidentsOutputSchema,
@@ -336,6 +338,7 @@ import addCommentToTicket from "./providers/zendesk/addCommentToTicket.js";
 import assignTicket from "./providers/zendesk/assignTicket.js";
 import listZendeskTickets from "./providers/zendesk/listTickets.js";
 import searchZendeskByQuery from "./providers/zendesk/searchZendeskByQuery.js";
+import searchZendeskTicketsByQuery from "./providers/zendesk/searchZendeskTicketsByQuery.js";
 import getServiceNowRecordsByQuery from "./providers/servicenow/getRecordsByQuery.js";
 import getServiceNowIncidents from "./providers/servicenow/getIncidents.js";
 import getServiceNowChangeRequests from "./providers/servicenow/getChangeRequests.js";
@@ -778,6 +781,12 @@ export const ActionMapper: Record<ProviderName, Record<string, ActionFunctionCom
       fn: searchZendeskByQuery,
       paramsSchema: zendeskSearchZendeskByQueryParamsSchema,
       outputSchema: zendeskSearchZendeskByQueryOutputSchema,
+      actionType: "read",
+    },
+    searchZendeskTicketsByQuery: {
+      fn: searchZendeskTicketsByQuery,
+      paramsSchema: zendeskSearchZendeskTicketsByQueryParamsSchema,
+      outputSchema: zendeskSearchZendeskTicketsByQueryOutputSchema,
       actionType: "read",
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4727,6 +4727,54 @@ export const zendeskSearchZendeskByQueryDefinition: ActionTemplate = {
   name: "searchZendeskByQuery",
   provider: "zendesk",
 };
+export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
+  displayName: "Search Zendesk tickets with a query",
+  description:
+    "Search Zendesk tickets by query with flexible filtering options. Only returns tickets, never any other type of Zendesk resource.",
+  scopes: [],
+  tags: [],
+  parameters: {
+    type: "object",
+    required: ["subdomain", "query"],
+    properties: {
+      subdomain: {
+        type: "string",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
+        tags: ["recommend-predefined"],
+      },
+      query: {
+        type: "string",
+        description:
+          'Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.',
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of tickets to return (optional, defaults to 100)",
+      },
+    },
+  },
+  output: {
+    type: "object",
+    required: ["results", "count"],
+    properties: {
+      results: {
+        type: "array",
+        description: "List of tickets matching the query",
+        items: {
+          type: "object",
+        },
+      },
+      count: {
+        type: "number",
+        description: "Number of tickets found",
+      },
+    },
+  },
+  name: "searchZendeskTicketsByQuery",
+  provider: "zendesk",
+};
 export const linkedinCreateShareLinkedinPostUrlDefinition: ActionTemplate = {
   displayName: "Create a share LinkedIn post URL",
   description: "Create a share LinkedIn post link",

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -85,6 +85,7 @@ export enum ActionName {
   ADDCOMMENTTOTICKET = "addCommentToTicket",
   ASSIGNTICKET = "assignTicket",
   SEARCHZENDESKBYQUERY = "searchZendeskByQuery",
+  SEARCHZENDESKTICKETSBYQUERY = "searchZendeskTicketsByQuery",
   CREATESHARELINKEDINPOSTURL = "createShareLinkedinPostUrl",
   CREATESHAREXPOSTURL = "createShareXPostUrl",
   INSERTMONGODOC = "insertMongoDoc",
@@ -2643,6 +2644,37 @@ export type zendeskSearchZendeskByQueryFunction = ActionFunction<
   zendeskSearchZendeskByQueryParamsType,
   AuthParamsType,
   zendeskSearchZendeskByQueryOutputType
+>;
+
+export const zendeskSearchZendeskTicketsByQueryParamsSchema = z.object({
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
+  query: z
+    .string()
+    .describe(
+      'Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.',
+    ),
+  limit: z.coerce.number().describe("Maximum number of tickets to return (optional, defaults to 100)").optional(),
+});
+
+export type zendeskSearchZendeskTicketsByQueryParamsType = z.infer<
+  typeof zendeskSearchZendeskTicketsByQueryParamsSchema
+>;
+
+export const zendeskSearchZendeskTicketsByQueryOutputSchema = z.object({
+  results: z.array(z.object({}).catchall(z.any())).describe("List of tickets matching the query"),
+  count: z.coerce.number().describe("Number of tickets found"),
+});
+
+export type zendeskSearchZendeskTicketsByQueryOutputType = z.infer<
+  typeof zendeskSearchZendeskTicketsByQueryOutputSchema
+>;
+export type zendeskSearchZendeskTicketsByQueryFunction = ActionFunction<
+  zendeskSearchZendeskTicketsByQueryParamsType,
+  AuthParamsType,
+  zendeskSearchZendeskTicketsByQueryOutputType
 >;
 
 export const linkedinCreateShareLinkedinPostUrlParamsSchema = z.object({

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -7,6 +7,8 @@ import type {
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
 
+const ZENDESK_SUBDOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+
 const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
   params,
   authParams,
@@ -17,12 +19,15 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
   const { authToken } = authParams;
   const { subdomain, query, limit = 100 } = params;
 
-  // Endpoint for searching Zendesk objects
-  const url = `https://${subdomain}.zendesk.com/api/v2/search.json`;
-
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  if (!ZENDESK_SUBDOMAIN_PATTERN.test(subdomain)) {
+    throw new Error("Invalid Zendesk subdomain");
+  }
+
+  const url = new URL(`https://${subdomain}.zendesk.com/api/v2/search.json`);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Strip any type: filters from the incoming query so it can't target other resource types,
@@ -32,11 +37,10 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
     .replace(/\s+/g, " ")
     .trim();
 
-  const queryParams = new URLSearchParams();
-  queryParams.append("query", `type:ticket ${sanitizedQuery}`.trim());
-  queryParams.append("per_page", limit.toString());
+  url.searchParams.set("query", `type:ticket ${sanitizedQuery}`.trim());
+  url.searchParams.set("per_page", limit.toString());
 
-  const response = await axiosClient.get(`${url}?${queryParams.toString()}`, {
+  const response = await axiosClient.get(url.toString(), {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,
@@ -47,10 +51,11 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
   const results = Array.isArray(response.data.results)
     ? response.data.results.filter((result: { result_type?: string }) => result.result_type === "ticket")
     : [];
+  const count = typeof response.data.count === "number" ? response.data.count : results.length;
 
   return {
     results,
-    count: results.length,
+    count,
   };
 };
 

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -1,0 +1,57 @@
+import type {
+  AuthParamsType,
+  zendeskSearchZendeskTicketsByQueryFunction,
+  zendeskSearchZendeskTicketsByQueryOutputType,
+  zendeskSearchZendeskTicketsByQueryParamsType,
+} from "../../autogen/types.js";
+import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
+import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+
+const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
+  params,
+  authParams,
+}: {
+  params: zendeskSearchZendeskTicketsByQueryParamsType;
+  authParams: AuthParamsType;
+}): Promise<zendeskSearchZendeskTicketsByQueryOutputType> => {
+  const { authToken } = authParams;
+  const { subdomain, query, limit = 100 } = params;
+
+  // Endpoint for searching Zendesk objects
+  const url = `https://${subdomain}.zendesk.com/api/v2/search.json`;
+
+  if (!authToken) {
+    throw new Error(MISSING_AUTH_TOKEN);
+  }
+  const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
+
+  // Strip any type: filters from the incoming query so it can't target other resource types,
+  // then force the search to tickets only
+  const sanitizedQuery = query
+    .replace(/\btype:\S+/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const queryParams = new URLSearchParams();
+  queryParams.append("query", `type:ticket ${sanitizedQuery}`.trim());
+  queryParams.append("per_page", limit.toString());
+
+  const response = await axiosClient.get(`${url}?${queryParams.toString()}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+
+  // Defense in depth: only return results Zendesk marks as tickets
+  const results = Array.isArray(response.data.results)
+    ? response.data.results.filter((result: { result_type?: string }) => result.result_type === "ticket")
+    : [];
+
+  return {
+    results,
+    count: results.length,
+  };
+};
+
+export default searchZendeskTicketsByQuery;

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2154,7 +2154,8 @@ actions:
         properties:
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           query:
             type: string

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2144,6 +2144,36 @@ actions:
           count:
             type: number
             description: Number of objects found
+    searchZendeskTicketsByQuery:
+      displayName: Search Zendesk tickets with a query
+      description: Search Zendesk tickets by query with flexible filtering options. Only returns tickets, never any other type of Zendesk resource.
+      scopes: []
+      parameters:
+        type: object
+        required: [subdomain, query]
+        properties:
+          subdomain:
+            type: string
+            description: The subdomain of the Zendesk account
+            tags: [recommend-predefined]
+          query:
+            type: string
+            description: Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.
+          limit:
+            type: number
+            description: Maximum number of tickets to return (optional, defaults to 100)
+      output:
+        type: object
+        required: [results, count]
+        properties:
+          results:
+            type: array
+            description: List of tickets matching the query
+            items:
+              type: object
+          count:
+            type: number
+            description: Number of tickets found
   linkedin:
     createShareLinkedinPostUrl:
       displayName: Create a share LinkedIn post URL

--- a/tests/zendesk/searchZendeskTicketsByQuery.test.ts
+++ b/tests/zendesk/searchZendeskTicketsByQuery.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
+
+jest.mock("../../src/actions/util/axiosClient", () => ({
+  createAxiosClientWithRetries: () => ({
+    get: (...args: any[]) => mockGet(...args),
+  }),
+}));
+
+import { zendeskSearchZendeskTicketsByQueryParamsSchema } from "../../src/actions/autogen/types";
+import searchZendeskTicketsByQuery from "../../src/actions/providers/zendesk/searchZendeskTicketsByQuery";
+
+const AUTH = { authToken: "test-token" };
+
+describe("zendesk searchZendeskTicketsByQuery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects a subdomain that could redirect credentials to another host", async () => {
+    await expect(
+      searchZendeskTicketsByQuery({
+        params: {
+          subdomain: "attacker.example/",
+          query: "status:open",
+        },
+        authParams: AUTH,
+      }),
+    ).rejects.toThrow("Invalid Zendesk subdomain");
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("forces ticket searches, filters non-ticket results, and preserves the total count", async () => {
+    const ticket = { id: 1, result_type: "ticket" };
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [ticket, { id: 2, result_type: "user" }],
+        count: 275,
+      },
+    });
+
+    const result = await searchZendeskTicketsByQuery({
+      params: {
+        subdomain: "example-account",
+        query: "type:user status:open",
+        limit: 10,
+      },
+      authParams: AUTH,
+    });
+
+    const [requestUrl] = mockGet.mock.calls[0] as [string];
+    const parsedUrl = new URL(requestUrl);
+    expect(parsedUrl.hostname).toBe("example-account.zendesk.com");
+    expect(parsedUrl.searchParams.get("query")).toBe("type:ticket status:open");
+    expect(parsedUrl.searchParams.get("per_page")).toBe("10");
+    expect(result.results).toEqual([ticket]);
+    expect(result.count).toBe(275);
+  });
+
+  it("validates the subdomain in the generated parameter schema", () => {
+    expect(
+      zendeskSearchZendeskTicketsByQueryParamsSchema.safeParse({
+        subdomain: "example-account",
+        query: "status:open",
+      }).success,
+    ).toBe(true);
+    expect(
+      zendeskSearchZendeskTicketsByQueryParamsSchema.safeParse({
+        subdomain: "attacker.example/",
+        query: "status:open",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/tests/zendesk/testSearchZendeskTicketsByQuery.ts
+++ b/tests/zendesk/testSearchZendeskTicketsByQuery.ts
@@ -1,0 +1,21 @@
+import { runAction } from "../../src/app.js";
+
+async function runTest() {
+  const output = await runAction(
+    "searchZendeskTicketsByQuery",
+    "zendesk",
+    {
+      authToken: "insert-auth-token",
+    }, // authParams
+    {
+      subdomain: "insert-subdomain",
+      // The type:user filter should be stripped and only tickets returned
+      query: "type:user status:closed priority:high",
+      limit: 5,
+    }
+  );
+
+  console.log("Output:", output);
+}
+
+runTest().catch(console.error);


### PR DESCRIPTION
**Context:**
So we had a query Zendesk action but it wasn't unique to tickets. The Zendesk Admin wants to disable that action and only enable an action that can query only Zendesk tickets. He also wants safeguards within the action to make sure that a nefarious actor could not tell the agent to query for another resource.

**Summary:**

- Add `searchZendeskTicketsByQuery`, a Zendesk action for flexible ticket searches
- Remove user-supplied `type:` filters and always enforce `type:ticket`
- Filter API responses to ensure only ticket resources are returned
- Register the action and generate its schemas and templates

**Testing:**
Ran it locally and tested it in an agent with a trial Zendesk account.
Loom: https://www.loom.com/share/ed2c9fd1f94f4cd0b998fcdee6ff57ff

**Documentation and rollout:**
No standalone documentation update is required. The public action contract, parameter guidance, and ticket-only behavior are defined in `src/actions/schema.yaml` and published through the generated action template and TypeScript schemas. Zendesk authentication and setup are unchanged. Consumers can roll this out by enabling the new ticket-only action while disabling the existing general Zendesk query action where broader resource searches are not desired.