### PR TITLE
Add Zendesk subdomain validation + Actions bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.228",
+  "version": "0.2.229",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.228",
+      "version": "0.2.229",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.228",
+  "version": "0.2.229",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4478,7 +4478,9 @@ export const zendeskCreateZendeskTicketDefinition: ActionTemplate = {
       },
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       groupId: {
@@ -4515,7 +4517,9 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
     properties: {
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       status: {
@@ -4559,7 +4563,9 @@ export const zendeskGetTicketDetailsDefinition: ActionTemplate = {
       },
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
     },
@@ -4592,7 +4598,9 @@ export const zendeskUpdateTicketStatusDefinition: ActionTemplate = {
       },
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       status: {
@@ -4620,7 +4628,9 @@ export const zendeskAddCommentToTicketDefinition: ActionTemplate = {
       },
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       body: {
@@ -4665,7 +4675,9 @@ export const zendeskAssignTicketDefinition: ActionTemplate = {
       },
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       assigneeEmail: {
@@ -4688,7 +4700,9 @@ export const zendeskSearchZendeskByQueryDefinition: ActionTemplate = {
     properties: {
       subdomain: {
         type: "string",
-        description: "The subdomain of the Zendesk account",
+        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+        description:
+          "The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix",
         tags: ["recommend-predefined"],
       },
       query: {

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2504,7 +2504,10 @@ export type bingGetTopNSearchResultUrlsFunction = ActionFunction<
 export const zendeskCreateZendeskTicketParamsSchema = z.object({
   subject: z.string().describe("The subject of the ticket"),
   body: z.string().describe("The body of the ticket").optional(),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   groupId: z.coerce.number().describe("The ID of the group to assign the ticket to").optional(),
 });
 
@@ -2523,7 +2526,10 @@ export type zendeskCreateZendeskTicketFunction = ActionFunction<
 >;
 
 export const zendeskListZendeskTicketsParamsSchema = z.object({
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   status: z.string().describe("Filter tickets by status (new, open, pending, hold, solved, closed)").optional(),
 });
 
@@ -2543,7 +2549,10 @@ export type zendeskListZendeskTicketsFunction = ActionFunction<
 
 export const zendeskGetTicketDetailsParamsSchema = z.object({
   ticketId: z.string().describe("The ID of the ticket"),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
 });
 
 export type zendeskGetTicketDetailsParamsType = z.infer<typeof zendeskGetTicketDetailsParamsSchema>;
@@ -2561,7 +2570,10 @@ export type zendeskGetTicketDetailsFunction = ActionFunction<
 
 export const zendeskUpdateTicketStatusParamsSchema = z.object({
   ticketId: z.string().describe("The ID of the ticket to update"),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   status: z
     .string()
     .describe(
@@ -2582,7 +2594,10 @@ export type zendeskUpdateTicketStatusFunction = ActionFunction<
 
 export const zendeskAddCommentToTicketParamsSchema = z.object({
   ticketId: z.string().describe("The ID of the ticket to update"),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   body: z.string().describe("The body of the comment"),
   public: z.boolean().describe("Whether the comment should be public (defaults to true)").optional(),
 });
@@ -2603,7 +2618,10 @@ export type zendeskAddCommentToTicketFunction = ActionFunction<
 
 export const zendeskAssignTicketParamsSchema = z.object({
   ticketId: z.string().describe("The ID of the ticket to update"),
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   assigneeEmail: z.string().describe("The email address of the agent to assign the ticket to"),
 });
 
@@ -2619,7 +2637,10 @@ export type zendeskAssignTicketFunction = ActionFunction<
 >;
 
 export const zendeskSearchZendeskByQueryParamsSchema = z.object({
-  subdomain: z.string().describe("The subdomain of the Zendesk account"),
+  subdomain: z
+    .string()
+    .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
+    .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
   query: z
     .string()
     .describe(

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
   params,
@@ -16,11 +17,14 @@ const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
 }): Promise<zendeskAddCommentToTicketOutputType> => {
   const { authToken } = authParams;
   const { subdomain, ticketId, body, public: isPublic } = params;
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  validateZendeskSubdomain(subdomain);
+
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
   const axiosClient = createAxiosClientWithRetries({ timeout: 20000, retryCount: 5 });
 
   try {

--- a/src/actions/providers/zendesk/addCommentToTicket.ts
+++ b/src/actions/providers/zendesk/addCommentToTicket.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
   params,
@@ -22,14 +22,13 @@ const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL(`/api/v2/tickets/${ticketId}.json`, zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 20000, retryCount: 5 });
 
   try {
     await axiosClient.request({
-      url: url,
+      url: apiEndpoint.toString(),
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -47,7 +46,7 @@ const addCommentToTicket: zendeskAddCommentToTicketFunction = async ({
 
     return {
       success: true,
-      ticketUrl: `https://${subdomain}.zendesk.com/agent/tickets/${ticketId}`,
+      ticketUrl: new URL(`/agent/tickets/${ticketId}`, zendeskBaseUrl).toString(),
     };
   } catch (error) {
     console.error("Failed to add comment to Zendesk ticket:", error);

--- a/src/actions/providers/zendesk/assignTicket.ts
+++ b/src/actions/providers/zendesk/assignTicket.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const updateTicketStatus: zendeskAssignTicketFunction = async ({
   params,
@@ -16,11 +17,14 @@ const updateTicketStatus: zendeskAssignTicketFunction = async ({
 }): Promise<zendeskAssignTicketOutputType> => {
   const { authToken } = authParams;
   const { subdomain, ticketId, assigneeEmail } = params;
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  validateZendeskSubdomain(subdomain);
+
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   await axiosClient.request({

--- a/src/actions/providers/zendesk/assignTicket.ts
+++ b/src/actions/providers/zendesk/assignTicket.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const updateTicketStatus: zendeskAssignTicketFunction = async ({
   params,
@@ -22,13 +22,12 @@ const updateTicketStatus: zendeskAssignTicketFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL(`/api/v2/tickets/${ticketId}.json`, zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   await axiosClient.request({
-    url: url,
+    url: apiEndpoint.toString(),
     method: "PUT",
     headers: {
       "Content-Type": "application/json",

--- a/src/actions/providers/zendesk/createZendeskTicket.ts
+++ b/src/actions/providers/zendesk/createZendeskTicket.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
   params,
@@ -22,9 +22,8 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL("/api/v2/tickets.json", zendeskBaseUrl);
   const payload = {
     ticket: {
       subject,
@@ -37,7 +36,7 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
 
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
-  const response = await axiosClient.post(url, payload, {
+  const response = await axiosClient.post(apiEndpoint.toString(), payload, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,
@@ -45,7 +44,7 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
   });
   return {
     ticketId: response.data.ticket.id,
-    ticketUrl: `https://${subdomain}.zendesk.com/requests/${response.data.ticket.id}`,
+    ticketUrl: new URL(`/requests/${response.data.ticket.id}`, zendeskBaseUrl).toString(),
   };
 };
 

--- a/src/actions/providers/zendesk/createZendeskTicket.ts
+++ b/src/actions/providers/zendesk/createZendeskTicket.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
   params,
@@ -16,6 +17,13 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
 }): Promise<zendeskCreateZendeskTicketOutputType> => {
   const { authToken } = authParams;
   const { subdomain, subject, body, groupId } = params;
+
+  if (!authToken) {
+    throw new Error(MISSING_AUTH_TOKEN);
+  }
+
+  validateZendeskSubdomain(subdomain);
+
   const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
   const payload = {
     ticket: {
@@ -27,9 +35,6 @@ const createZendeskTicket: zendeskCreateZendeskTicketFunction = async ({
     },
   };
 
-  if (!authToken) {
-    throw new Error(MISSING_AUTH_TOKEN);
-  }
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   const response = await axiosClient.post(url, payload, {

--- a/src/actions/providers/zendesk/getTicketDetails.ts
+++ b/src/actions/providers/zendesk/getTicketDetails.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
   params,
@@ -16,12 +17,14 @@ const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
 }): Promise<zendeskGetTicketDetailsOutputType> => {
   const { authToken } = authParams;
   const { subdomain, ticketId } = params;
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
+  validateZendeskSubdomain(subdomain);
+
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   const response = await axiosClient.request({

--- a/src/actions/providers/zendesk/getTicketDetails.ts
+++ b/src/actions/providers/zendesk/getTicketDetails.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
   params,
@@ -22,13 +22,12 @@ const getZendeskTicketDetails: zendeskGetTicketDetailsFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL(`/api/v2/tickets/${ticketId}.json`, zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   const response = await axiosClient.request({
-    url: url,
+    url: apiEndpoint.toString(),
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   params,
@@ -27,22 +27,18 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  // Endpoint for getting tickets
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
-
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL("/api/v2/tickets.json", zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Add query parameters for filtering
-  const queryParams = new URLSearchParams();
-  queryParams.append("created_after", formattedDate);
+  apiEndpoint.searchParams.set("created_after", formattedDate);
 
   if (status) {
-    queryParams.append("status", status);
+    apiEndpoint.searchParams.set("status", status);
   }
 
-  const response = await axiosClient.get(`${url}?${queryParams.toString()}`, {
+  const response = await axiosClient.get(apiEndpoint.toString(), {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   params,
@@ -22,12 +23,15 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
   const formattedDate = threeMonthsAgo.toISOString().split("T")[0];
 
-  // Endpoint for getting tickets
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
-
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  validateZendeskSubdomain(subdomain);
+
+  // Endpoint for getting tickets
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets.json`;
+
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Add query parameters for filtering

--- a/src/actions/providers/zendesk/searchZendeskByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskByQuery.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
   params,
@@ -17,12 +18,15 @@ const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
   const { authToken } = authParams;
   const { subdomain, query, objectType = "ticket", limit = 100 } = params;
 
-  // Endpoint for searching Zendesk objects
-  const url = `https://${subdomain}.zendesk.com/api/v2/search.json`;
-
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  validateZendeskSubdomain(subdomain);
+
+  // Endpoint for searching Zendesk objects
+  const url = `https://${subdomain}.zendesk.com/api/v2/search.json`;
+
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Build search query parameters

--- a/src/actions/providers/zendesk/searchZendeskByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskByQuery.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
   params,
@@ -22,19 +22,15 @@ const searchZendeskByQuery: zendeskSearchZendeskByQueryFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  // Endpoint for searching Zendesk objects
-  const url = `https://${subdomain}.zendesk.com/api/v2/search.json`;
-
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL("/api/v2/search.json", zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Build search query parameters
-  const queryParams = new URLSearchParams();
-  queryParams.append("query", `type:${objectType} ${query}`);
-  queryParams.append("per_page", limit.toString());
+  apiEndpoint.searchParams.set("query", `type:${objectType} ${query}`);
+  apiEndpoint.searchParams.set("per_page", limit.toString());
 
-  const response = await axiosClient.get(`${url}?${queryParams.toString()}`, {
+  const response = await axiosClient.get(apiEndpoint.toString(), {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -6,8 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-
-const ZENDESK_SUBDOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
   params,
@@ -23,9 +22,7 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  if (!ZENDESK_SUBDOMAIN_PATTERN.test(subdomain)) {
-    throw new Error("Invalid Zendesk subdomain");
-  }
+  validateZendeskSubdomain(subdomain);
 
   const url = new URL(`https://${subdomain}.zendesk.com/api/v2/search.json`);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
   params,
@@ -22,9 +22,8 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = new URL(`https://${subdomain}.zendesk.com/api/v2/search.json`);
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL("/api/v2/search.json", zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   // Strip any type: filters from the incoming query so it can't target other resource types,
@@ -34,10 +33,10 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
     .replace(/\s+/g, " ")
     .trim();
 
-  url.searchParams.set("query", `type:ticket ${sanitizedQuery}`.trim());
-  url.searchParams.set("per_page", limit.toString());
+  apiEndpoint.searchParams.set("query", `type:ticket ${sanitizedQuery}`.trim());
+  apiEndpoint.searchParams.set("per_page", limit.toString());
 
-  const response = await axiosClient.get(url.toString(), {
+  const response = await axiosClient.get(apiEndpoint.toString(), {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,

--- a/src/actions/providers/zendesk/updateTicketStatus.ts
+++ b/src/actions/providers/zendesk/updateTicketStatus.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
+import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
   params,
@@ -22,13 +22,12 @@ const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
     throw new Error(MISSING_AUTH_TOKEN);
   }
 
-  validateZendeskSubdomain(subdomain);
-
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
+  const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
+  const apiEndpoint = new URL(`/api/v2/tickets/${ticketId}.json`, zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   await axiosClient.request({
-    url: url,
+    url: apiEndpoint.toString(),
     method: "PUT",
     headers: {
       "Content-Type": "application/json",

--- a/src/actions/providers/zendesk/updateTicketStatus.ts
+++ b/src/actions/providers/zendesk/updateTicketStatus.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { validateZendeskSubdomain } from "./utils/validateSubdomain.js";
 
 const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
   params,
@@ -16,11 +17,14 @@ const updateTicketStatus: zendeskUpdateTicketStatusFunction = async ({
 }): Promise<zendeskUpdateTicketStatusOutputType> => {
   const { authToken } = authParams;
   const { subdomain, ticketId, status } = params;
-  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
   }
+
+  validateZendeskSubdomain(subdomain);
+
+  const url = `https://${subdomain}.zendesk.com/api/v2/tickets/${ticketId}.json`;
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
   await axiosClient.request({

--- a/src/actions/providers/zendesk/utils/getZendeskBaseUrl.ts
+++ b/src/actions/providers/zendesk/utils/getZendeskBaseUrl.ts
@@ -1,7 +1,9 @@
 const ZENDESK_SUBDOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
 
-export const validateZendeskSubdomain = (subdomain: string): void => {
+export const getZendeskBaseUrl = ({ subdomain }: { subdomain: string }): URL => {
   if (!ZENDESK_SUBDOMAIN_PATTERN.test(subdomain)) {
     throw new Error("Invalid Zendesk subdomain");
   }
+
+  return new URL(`https://${subdomain}.zendesk.com/`);
 };

--- a/src/actions/providers/zendesk/utils/validateSubdomain.ts
+++ b/src/actions/providers/zendesk/utils/validateSubdomain.ts
@@ -1,0 +1,7 @@
+const ZENDESK_SUBDOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+export const validateZendeskSubdomain = (subdomain: string): void => {
+  if (!ZENDESK_SUBDOMAIN_PATTERN.test(subdomain)) {
+    throw new Error("Invalid Zendesk subdomain");
+  }
+};

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1978,7 +1978,8 @@ actions:
             description: The body of the ticket
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           groupId:
             type: number
@@ -2003,7 +2004,8 @@ actions:
         properties:
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           status:
             type: string
@@ -2033,7 +2035,8 @@ actions:
             description: The ID of the ticket
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
       output:
         type: object
@@ -2056,7 +2059,8 @@ actions:
             description: The ID of the ticket to update
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           status:
             type: string
@@ -2074,7 +2078,8 @@ actions:
             description: The ID of the ticket to update
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           body:
             type: string
@@ -2105,7 +2110,8 @@ actions:
             description: The ID of the ticket to update
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           assigneeEmail:
             type: string
@@ -2120,7 +2126,8 @@ actions:
         properties:
           subdomain:
             type: string
-            description: The subdomain of the Zendesk account
+            pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+            description: The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix
             tags: [recommend-predefined]
           query:
             type: string

--- a/tests/zendesk/searchZendeskTicketsByQuery.test.ts
+++ b/tests/zendesk/searchZendeskTicketsByQuery.test.ts
@@ -2,15 +2,35 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGet = jest.fn<(...args: any[]) => Promise<any>>();
+const mockPost = jest.fn<(...args: any[]) => Promise<any>>();
+const mockRequest = jest.fn<(...args: any[]) => Promise<any>>();
 
 jest.mock("../../src/actions/util/axiosClient", () => ({
   createAxiosClientWithRetries: () => ({
     get: (...args: any[]) => mockGet(...args),
+    post: (...args: any[]) => mockPost(...args),
+    request: (...args: any[]) => mockRequest(...args),
   }),
 }));
 
-import { zendeskSearchZendeskTicketsByQueryParamsSchema } from "../../src/actions/autogen/types";
+import {
+  zendeskAddCommentToTicketParamsSchema,
+  zendeskAssignTicketParamsSchema,
+  zendeskCreateZendeskTicketParamsSchema,
+  zendeskGetTicketDetailsParamsSchema,
+  zendeskListZendeskTicketsParamsSchema,
+  zendeskSearchZendeskByQueryParamsSchema,
+  zendeskSearchZendeskTicketsByQueryParamsSchema,
+  zendeskUpdateTicketStatusParamsSchema,
+} from "../../src/actions/autogen/types";
+import addCommentToTicket from "../../src/actions/providers/zendesk/addCommentToTicket";
+import assignTicket from "../../src/actions/providers/zendesk/assignTicket";
+import createZendeskTicket from "../../src/actions/providers/zendesk/createZendeskTicket";
+import getTicketDetails from "../../src/actions/providers/zendesk/getTicketDetails";
+import listZendeskTickets from "../../src/actions/providers/zendesk/listTickets";
+import searchZendeskByQuery from "../../src/actions/providers/zendesk/searchZendeskByQuery";
 import searchZendeskTicketsByQuery from "../../src/actions/providers/zendesk/searchZendeskTicketsByQuery";
+import updateTicketStatus from "../../src/actions/providers/zendesk/updateTicketStatus";
 
 const AUTH = { authToken: "test-token" };
 
@@ -31,6 +51,54 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
     ).rejects.toThrow("Invalid Zendesk subdomain");
 
     expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe subdomains in every Zendesk action that constructs a tenant URL", async () => {
+    const subdomain = "attacker.example/";
+    const requests = [
+      createZendeskTicket({
+        params: { subdomain, subject: "Subject" },
+        authParams: AUTH,
+      }),
+      listZendeskTickets({
+        params: { subdomain },
+        authParams: AUTH,
+      }),
+      getTicketDetails({
+        params: { subdomain, ticketId: "1" },
+        authParams: AUTH,
+      }),
+      updateTicketStatus({
+        params: { subdomain, ticketId: "1", status: "open" },
+        authParams: AUTH,
+      }),
+      addCommentToTicket({
+        params: { subdomain, ticketId: "1", body: "Comment" },
+        authParams: AUTH,
+      }),
+      assignTicket({
+        params: {
+          subdomain,
+          ticketId: "1",
+          assigneeEmail: "agent@example.com",
+        },
+        authParams: AUTH,
+      }),
+      searchZendeskByQuery({
+        params: { subdomain, query: "status:open" },
+        authParams: AUTH,
+      }),
+    ];
+
+    await Promise.all(
+      requests.map((request) =>
+        expect(request).rejects.toThrow("Invalid Zendesk subdomain"),
+      ),
+    );
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 
   it("forces ticket searches, filters non-ticket results, and preserves the total count", async () => {
@@ -60,18 +128,49 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
     expect(result.count).toBe(275);
   });
 
-  it("validates the subdomain in the generated parameter schema", () => {
-    expect(
-      zendeskSearchZendeskTicketsByQueryParamsSchema.safeParse({
-        subdomain: "example-account",
-        query: "status:open",
-      }).success,
-    ).toBe(true);
-    expect(
-      zendeskSearchZendeskTicketsByQueryParamsSchema.safeParse({
-        subdomain: "attacker.example/",
-        query: "status:open",
-      }).success,
-    ).toBe(false);
+  it("validates the subdomain in every generated Zendesk parameter schema", () => {
+    const schemaCases: Array<{
+      schema: { safeParse: (input: unknown) => { success: boolean } };
+      params: Record<string, unknown>;
+    }> = [
+      {
+        schema: zendeskCreateZendeskTicketParamsSchema,
+        params: { subject: "Subject" },
+      },
+      { schema: zendeskListZendeskTicketsParamsSchema, params: {} },
+      {
+        schema: zendeskGetTicketDetailsParamsSchema,
+        params: { ticketId: "1" },
+      },
+      {
+        schema: zendeskUpdateTicketStatusParamsSchema,
+        params: { ticketId: "1", status: "open" },
+      },
+      {
+        schema: zendeskAddCommentToTicketParamsSchema,
+        params: { ticketId: "1", body: "Comment" },
+      },
+      {
+        schema: zendeskAssignTicketParamsSchema,
+        params: { ticketId: "1", assigneeEmail: "agent@example.com" },
+      },
+      {
+        schema: zendeskSearchZendeskByQueryParamsSchema,
+        params: { query: "status:open" },
+      },
+      {
+        schema: zendeskSearchZendeskTicketsByQueryParamsSchema,
+        params: { query: "status:open" },
+      },
+    ];
+
+    for (const { schema, params } of schemaCases) {
+      expect(
+        schema.safeParse({ ...params, subdomain: "example-account" }).success,
+      ).toBe(true);
+      expect(
+        schema.safeParse({ ...params, subdomain: "attacker.example/" }).success,
+      ).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
**Context:**
After creating a new action for ACF, Betsy recommended I use the same subdomain validation logic I used in the new action, in the rest of the zendesk actions.

**Summary:**
- Add shared Zendesk subdomain validation to all actions constructing tenant URLs
- Add schema-level validation and regenerate action types/templates
- Add regression tests preventing credential redirection through malicious subdomains
- Actions bump

**Testing:**
Tested locally for regressions
Loom: https://www.loom.com/share/73f1ba14563d493e809d18266f2a2266