### PR TITLE
Optimize Zendesk Ticket search action

### DIFF
--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4540,24 +4540,18 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
         description:
           "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
       },
-      includeCustomFieldNames: {
-        type: "boolean",
-        description:
-          "Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)",
-      },
     },
   },
   output: {
     type: "object",
-    required: ["tickets", "count", "returned_count", "has_more", "response_truncated"],
+    required: ["tickets", "count", "returned_count", "has_more"],
     properties: {
       tickets: {
         type: "array",
-        description:
-          "Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.",
+        description: "Small ticket records for choosing which IDs to fetch with getTicketDetails",
         items: {
           type: "object",
-          required: ["id", "description_excerpt", "description_truncated", "custom_fields_truncated", "tags_truncated"],
+          required: ["id", "description_excerpt", "description_truncated"],
           properties: {
             id: {
               type: "integer",
@@ -4572,11 +4566,6 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
               type: "string",
               nullable: true,
               description: "Ticket status category",
-            },
-            custom_status_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk custom status ID",
             },
             type: {
               type: "string",
@@ -4598,77 +4587,13 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
               nullable: true,
               description: "Ticket update timestamp",
             },
-            requester_id: {
-              type: "integer",
-              nullable: true,
-              description: "Requester user ID",
-            },
-            assignee_id: {
-              type: "integer",
-              nullable: true,
-              description: "Assigned agent ID",
-            },
-            group_id: {
-              type: "integer",
-              nullable: true,
-              description: "Assigned group ID",
-            },
-            organization_id: {
-              type: "integer",
-              nullable: true,
-              description: "Requester organization ID",
-            },
-            brand_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk brand ID",
-            },
-            ticket_form_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk ticket form ID",
-            },
-            tags: {
-              type: "array",
-              description: "Ticket tags, omitted when empty",
-              items: {
-                type: "string",
-              },
-            },
-            tags_truncated: {
-              type: "boolean",
-              description: "Whether some tags were omitted to keep the discovery response bounded",
-            },
-            via: {
-              type: "object",
-              description: "Compact ticket creation channel information",
-              properties: {
-                channel: {
-                  type: "string",
-                  description: "Channel through which the ticket was created",
-                },
-              },
-            },
             description_excerpt: {
               type: "string",
-              description: "Up to the first 1,500 characters of the ticket description",
+              description: "Up to the first 1,000 characters of the ticket description",
             },
             description_truncated: {
               type: "boolean",
               description: "Whether the full ticket description is longer than description_excerpt",
-            },
-            custom_fields: {
-              type: "array",
-              description:
-                "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
-              items: {
-                type: "object",
-              },
-            },
-            custom_fields_truncated: {
-              type: "boolean",
-              description:
-                "Whether populated custom fields or their values were truncated to keep the response bounded",
             },
           },
         },
@@ -4688,10 +4613,6 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
       next_page: {
         type: "integer",
         description: "Page number to pass on the next call when has_more is true",
-      },
-      response_truncated: {
-        type: "boolean",
-        description: "Whether any large discovery fields were truncated to enforce the response-size budget",
       },
     },
   },
@@ -4925,24 +4846,18 @@ export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
         description:
           "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
       },
-      includeCustomFieldNames: {
-        type: "boolean",
-        description:
-          "Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)",
-      },
     },
   },
   output: {
     type: "object",
-    required: ["results", "count", "returned_count", "has_more", "response_truncated"],
+    required: ["results", "count", "returned_count", "has_more"],
     properties: {
       results: {
         type: "array",
-        description:
-          "Compact ticket records matching the query. Full ticket details and comments are deliberately omitted.",
+        description: "Small ticket records for choosing which IDs to fetch with getTicketDetails",
         items: {
           type: "object",
-          required: ["id", "description_excerpt", "description_truncated", "custom_fields_truncated", "tags_truncated"],
+          required: ["id", "description_excerpt", "description_truncated"],
           properties: {
             id: {
               type: "integer",
@@ -4957,11 +4872,6 @@ export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
               type: "string",
               nullable: true,
               description: "Ticket status category",
-            },
-            custom_status_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk custom status ID",
             },
             type: {
               type: "string",
@@ -4983,77 +4893,13 @@ export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
               nullable: true,
               description: "Ticket update timestamp",
             },
-            requester_id: {
-              type: "integer",
-              nullable: true,
-              description: "Requester user ID",
-            },
-            assignee_id: {
-              type: "integer",
-              nullable: true,
-              description: "Assigned agent ID",
-            },
-            group_id: {
-              type: "integer",
-              nullable: true,
-              description: "Assigned group ID",
-            },
-            organization_id: {
-              type: "integer",
-              nullable: true,
-              description: "Requester organization ID",
-            },
-            brand_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk brand ID",
-            },
-            ticket_form_id: {
-              type: "integer",
-              nullable: true,
-              description: "Zendesk ticket form ID",
-            },
-            tags: {
-              type: "array",
-              description: "Ticket tags, omitted when empty",
-              items: {
-                type: "string",
-              },
-            },
-            tags_truncated: {
-              type: "boolean",
-              description: "Whether some tags were omitted to keep the discovery response bounded",
-            },
-            via: {
-              type: "object",
-              description: "Compact ticket creation channel information",
-              properties: {
-                channel: {
-                  type: "string",
-                  description: "Channel through which the ticket was created",
-                },
-              },
-            },
             description_excerpt: {
               type: "string",
-              description: "Up to the first 1,500 characters of the ticket description",
+              description: "Up to the first 1,000 characters of the ticket description",
             },
             description_truncated: {
               type: "boolean",
               description: "Whether the full ticket description is longer than description_excerpt",
-            },
-            custom_fields: {
-              type: "array",
-              description:
-                "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
-              items: {
-                type: "object",
-              },
-            },
-            custom_fields_truncated: {
-              type: "boolean",
-              description:
-                "Whether populated custom fields or their values were truncated to keep the response bounded",
             },
           },
         },
@@ -5073,10 +4919,6 @@ export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
       next_page: {
         type: "integer",
         description: "Page number to pass on the next call when has_more is true",
-      },
-      response_truncated: {
-        type: "boolean",
-        description: "Whether any large discovery fields were truncated to enforce the response-size budget",
       },
     },
   },

--- a/src/actions/autogen/templates.ts
+++ b/src/actions/autogen/templates.ts
@@ -4508,7 +4508,8 @@ export const zendeskCreateZendeskTicketDefinition: ActionTemplate = {
 };
 export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
   displayName: "List Zendesk tickets",
-  description: "List tickets in Zendesk from the past 3 months",
+  description:
+    "List compact ticket discovery records from Zendesk from the past 3 months. Use getTicketDetails to investigate selected tickets.",
   scopes: [],
   tags: [],
   parameters: {
@@ -4524,24 +4525,173 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
       },
       status: {
         type: "string",
+        enum: ["new", "open", "pending", "hold", "solved", "closed"],
         description: "Filter tickets by status (new, open, pending, hold, solved, closed)",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        description: "Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)",
+      },
+      page: {
+        type: "integer",
+        minimum: 1,
+        description:
+          "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
+      },
+      includeCustomFieldNames: {
+        type: "boolean",
+        description:
+          "Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)",
       },
     },
   },
   output: {
     type: "object",
-    required: ["tickets", "count"],
+    required: ["tickets", "count", "returned_count", "has_more", "response_truncated"],
     properties: {
       tickets: {
         type: "array",
-        description: "List of tickets",
+        description:
+          "Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.",
         items: {
           type: "object",
+          required: ["id", "description_excerpt", "description_truncated", "custom_fields_truncated", "tags_truncated"],
+          properties: {
+            id: {
+              type: "integer",
+              description: "Zendesk ticket ID",
+            },
+            subject: {
+              type: "string",
+              nullable: true,
+              description: "Ticket subject",
+            },
+            status: {
+              type: "string",
+              nullable: true,
+              description: "Ticket status category",
+            },
+            custom_status_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk custom status ID",
+            },
+            type: {
+              type: "string",
+              nullable: true,
+              description: "Ticket type such as question, incident, problem, or task",
+            },
+            priority: {
+              type: "string",
+              nullable: true,
+              description: "Ticket priority",
+            },
+            created_at: {
+              type: "string",
+              nullable: true,
+              description: "Ticket creation timestamp",
+            },
+            updated_at: {
+              type: "string",
+              nullable: true,
+              description: "Ticket update timestamp",
+            },
+            requester_id: {
+              type: "integer",
+              nullable: true,
+              description: "Requester user ID",
+            },
+            assignee_id: {
+              type: "integer",
+              nullable: true,
+              description: "Assigned agent ID",
+            },
+            group_id: {
+              type: "integer",
+              nullable: true,
+              description: "Assigned group ID",
+            },
+            organization_id: {
+              type: "integer",
+              nullable: true,
+              description: "Requester organization ID",
+            },
+            brand_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk brand ID",
+            },
+            ticket_form_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk ticket form ID",
+            },
+            tags: {
+              type: "array",
+              description: "Ticket tags, omitted when empty",
+              items: {
+                type: "string",
+              },
+            },
+            tags_truncated: {
+              type: "boolean",
+              description: "Whether some tags were omitted to keep the discovery response bounded",
+            },
+            via: {
+              type: "object",
+              description: "Compact ticket creation channel information",
+              properties: {
+                channel: {
+                  type: "string",
+                  description: "Channel through which the ticket was created",
+                },
+              },
+            },
+            description_excerpt: {
+              type: "string",
+              description: "Up to the first 1,500 characters of the ticket description",
+            },
+            description_truncated: {
+              type: "boolean",
+              description: "Whether the full ticket description is longer than description_excerpt",
+            },
+            custom_fields: {
+              type: "array",
+              description:
+                "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
+              items: {
+                type: "object",
+              },
+            },
+            custom_fields_truncated: {
+              type: "boolean",
+              description:
+                "Whether populated custom fields or their values were truncated to keep the response bounded",
+            },
+          },
         },
       },
       count: {
         type: "number",
-        description: "Number of tickets found",
+        description: "Total number of tickets reported by Zendesk for the list query",
+      },
+      returned_count: {
+        type: "number",
+        description: "Number of compact ticket records returned in this response",
+      },
+      has_more: {
+        type: "boolean",
+        description: "Whether another page of tickets is available",
+      },
+      next_page: {
+        type: "integer",
+        description: "Page number to pass on the next call when has_more is true",
+      },
+      response_truncated: {
+        type: "boolean",
+        description: "Whether any large discovery fields were truncated to enforce the response-size budget",
       },
     },
   },
@@ -4550,7 +4700,7 @@ export const zendeskListZendeskTicketsDefinition: ActionTemplate = {
 };
 export const zendeskGetTicketDetailsDefinition: ActionTemplate = {
   displayName: "Get ticket details",
-  description: "Get details of a ticket in Zendesk",
+  description: "Get the full ticket object for a selected Zendesk ticket.",
   scopes: [],
   tags: [],
   parameters: {
@@ -4744,7 +4894,7 @@ export const zendeskSearchZendeskByQueryDefinition: ActionTemplate = {
 export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
   displayName: "Search Zendesk tickets with a query",
   description:
-    "Search Zendesk tickets by query with flexible filtering options. Only returns tickets, never any other type of Zendesk resource.",
+    "Search compact Zendesk ticket discovery records with flexible filtering options. Only returns tickets. Use getTicketDetails to investigate selected tickets.",
   scopes: [],
   tags: [],
   parameters: {
@@ -4764,25 +4914,169 @@ export const zendeskSearchZendeskTicketsByQueryDefinition: ActionTemplate = {
           'Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.',
       },
       limit: {
-        type: "number",
-        description: "Maximum number of tickets to return (optional, defaults to 100)",
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        description: "Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)",
+      },
+      page: {
+        type: "integer",
+        minimum: 1,
+        description:
+          "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
+      },
+      includeCustomFieldNames: {
+        type: "boolean",
+        description:
+          "Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)",
       },
     },
   },
   output: {
     type: "object",
-    required: ["results", "count"],
+    required: ["results", "count", "returned_count", "has_more", "response_truncated"],
     properties: {
       results: {
         type: "array",
-        description: "List of tickets matching the query",
+        description:
+          "Compact ticket records matching the query. Full ticket details and comments are deliberately omitted.",
         items: {
           type: "object",
+          required: ["id", "description_excerpt", "description_truncated", "custom_fields_truncated", "tags_truncated"],
+          properties: {
+            id: {
+              type: "integer",
+              description: "Zendesk ticket ID",
+            },
+            subject: {
+              type: "string",
+              nullable: true,
+              description: "Ticket subject",
+            },
+            status: {
+              type: "string",
+              nullable: true,
+              description: "Ticket status category",
+            },
+            custom_status_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk custom status ID",
+            },
+            type: {
+              type: "string",
+              nullable: true,
+              description: "Ticket type such as question, incident, problem, or task",
+            },
+            priority: {
+              type: "string",
+              nullable: true,
+              description: "Ticket priority",
+            },
+            created_at: {
+              type: "string",
+              nullable: true,
+              description: "Ticket creation timestamp",
+            },
+            updated_at: {
+              type: "string",
+              nullable: true,
+              description: "Ticket update timestamp",
+            },
+            requester_id: {
+              type: "integer",
+              nullable: true,
+              description: "Requester user ID",
+            },
+            assignee_id: {
+              type: "integer",
+              nullable: true,
+              description: "Assigned agent ID",
+            },
+            group_id: {
+              type: "integer",
+              nullable: true,
+              description: "Assigned group ID",
+            },
+            organization_id: {
+              type: "integer",
+              nullable: true,
+              description: "Requester organization ID",
+            },
+            brand_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk brand ID",
+            },
+            ticket_form_id: {
+              type: "integer",
+              nullable: true,
+              description: "Zendesk ticket form ID",
+            },
+            tags: {
+              type: "array",
+              description: "Ticket tags, omitted when empty",
+              items: {
+                type: "string",
+              },
+            },
+            tags_truncated: {
+              type: "boolean",
+              description: "Whether some tags were omitted to keep the discovery response bounded",
+            },
+            via: {
+              type: "object",
+              description: "Compact ticket creation channel information",
+              properties: {
+                channel: {
+                  type: "string",
+                  description: "Channel through which the ticket was created",
+                },
+              },
+            },
+            description_excerpt: {
+              type: "string",
+              description: "Up to the first 1,500 characters of the ticket description",
+            },
+            description_truncated: {
+              type: "boolean",
+              description: "Whether the full ticket description is longer than description_excerpt",
+            },
+            custom_fields: {
+              type: "array",
+              description:
+                "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
+              items: {
+                type: "object",
+              },
+            },
+            custom_fields_truncated: {
+              type: "boolean",
+              description:
+                "Whether populated custom fields or their values were truncated to keep the response bounded",
+            },
+          },
         },
       },
       count: {
         type: "number",
-        description: "Number of tickets found",
+        description: "Total number of matching tickets reported by Zendesk",
+      },
+      returned_count: {
+        type: "number",
+        description: "Number of compact ticket records returned in this response",
+      },
+      has_more: {
+        type: "boolean",
+        description: "Whether another page of matching tickets is available",
+      },
+      next_page: {
+        type: "integer",
+        description: "Page number to pass on the next call when has_more is true",
+      },
+      response_truncated: {
+        type: "boolean",
+        description: "Whether any large discovery fields were truncated to enforce the response-size budget",
       },
     },
   },

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2530,14 +2530,82 @@ export const zendeskListZendeskTicketsParamsSchema = z.object({
     .string()
     .regex(new RegExp("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"))
     .describe("The hostname-label subdomain of the Zendesk account, without a protocol, path, or .zendesk.com suffix"),
-  status: z.string().describe("Filter tickets by status (new, open, pending, hold, solved, closed)").optional(),
+  status: z
+    .enum(["new", "open", "pending", "hold", "solved", "closed"])
+    .describe("Filter tickets by status (new, open, pending, hold, solved, closed)")
+    .optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .gte(1)
+    .lte(50)
+    .describe("Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)")
+    .optional(),
+  page: z.coerce
+    .number()
+    .int()
+    .gte(1)
+    .describe(
+      "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
+    )
+    .optional(),
+  includeCustomFieldNames: z
+    .boolean()
+    .describe("Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)")
+    .optional(),
 });
 
 export type zendeskListZendeskTicketsParamsType = z.infer<typeof zendeskListZendeskTicketsParamsSchema>;
 
 export const zendeskListZendeskTicketsOutputSchema = z.object({
-  tickets: z.array(z.object({}).catchall(z.any())).describe("List of tickets"),
-  count: z.coerce.number().describe("Number of tickets found"),
+  tickets: z
+    .array(
+      z.object({
+        id: z.coerce.number().int().describe("Zendesk ticket ID"),
+        subject: z.string().nullable().describe("Ticket subject").optional(),
+        status: z.string().nullable().describe("Ticket status category").optional(),
+        custom_status_id: z.coerce.number().int().nullable().describe("Zendesk custom status ID").optional(),
+        type: z.string().nullable().describe("Ticket type such as question, incident, problem, or task").optional(),
+        priority: z.string().nullable().describe("Ticket priority").optional(),
+        created_at: z.string().nullable().describe("Ticket creation timestamp").optional(),
+        updated_at: z.string().nullable().describe("Ticket update timestamp").optional(),
+        requester_id: z.coerce.number().int().nullable().describe("Requester user ID").optional(),
+        assignee_id: z.coerce.number().int().nullable().describe("Assigned agent ID").optional(),
+        group_id: z.coerce.number().int().nullable().describe("Assigned group ID").optional(),
+        organization_id: z.coerce.number().int().nullable().describe("Requester organization ID").optional(),
+        brand_id: z.coerce.number().int().nullable().describe("Zendesk brand ID").optional(),
+        ticket_form_id: z.coerce.number().int().nullable().describe("Zendesk ticket form ID").optional(),
+        tags: z.array(z.string()).describe("Ticket tags, omitted when empty").optional(),
+        tags_truncated: z.boolean().describe("Whether some tags were omitted to keep the discovery response bounded"),
+        via: z
+          .object({ channel: z.string().describe("Channel through which the ticket was created").optional() })
+          .describe("Compact ticket creation channel information")
+          .optional(),
+        description_excerpt: z.string().describe("Up to the first 1,500 characters of the ticket description"),
+        description_truncated: z
+          .boolean()
+          .describe("Whether the full ticket description is longer than description_excerpt"),
+        custom_fields: z
+          .array(z.object({}).catchall(z.any()))
+          .describe(
+            "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
+          )
+          .optional(),
+        custom_fields_truncated: z
+          .boolean()
+          .describe("Whether populated custom fields or their values were truncated to keep the response bounded"),
+      }),
+    )
+    .describe(
+      "Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.",
+    ),
+  count: z.coerce.number().describe("Total number of tickets reported by Zendesk for the list query"),
+  returned_count: z.coerce.number().describe("Number of compact ticket records returned in this response"),
+  has_more: z.boolean().describe("Whether another page of tickets is available"),
+  next_page: z.coerce.number().int().describe("Page number to pass on the next call when has_more is true").optional(),
+  response_truncated: z
+    .boolean()
+    .describe("Whether any large discovery fields were truncated to enforce the response-size budget"),
 });
 
 export type zendeskListZendeskTicketsOutputType = z.infer<typeof zendeskListZendeskTicketsOutputSchema>;
@@ -2677,7 +2745,25 @@ export const zendeskSearchZendeskTicketsByQueryParamsSchema = z.object({
     .describe(
       'Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.',
     ),
-  limit: z.coerce.number().describe("Maximum number of tickets to return (optional, defaults to 100)").optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .gte(1)
+    .lte(50)
+    .describe("Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)")
+    .optional(),
+  page: z.coerce
+    .number()
+    .int()
+    .gte(1)
+    .describe(
+      "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
+    )
+    .optional(),
+  includeCustomFieldNames: z
+    .boolean()
+    .describe("Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)")
+    .optional(),
 });
 
 export type zendeskSearchZendeskTicketsByQueryParamsType = z.infer<
@@ -2685,8 +2771,52 @@ export type zendeskSearchZendeskTicketsByQueryParamsType = z.infer<
 >;
 
 export const zendeskSearchZendeskTicketsByQueryOutputSchema = z.object({
-  results: z.array(z.object({}).catchall(z.any())).describe("List of tickets matching the query"),
-  count: z.coerce.number().describe("Number of tickets found"),
+  results: z
+    .array(
+      z.object({
+        id: z.coerce.number().int().describe("Zendesk ticket ID"),
+        subject: z.string().nullable().describe("Ticket subject").optional(),
+        status: z.string().nullable().describe("Ticket status category").optional(),
+        custom_status_id: z.coerce.number().int().nullable().describe("Zendesk custom status ID").optional(),
+        type: z.string().nullable().describe("Ticket type such as question, incident, problem, or task").optional(),
+        priority: z.string().nullable().describe("Ticket priority").optional(),
+        created_at: z.string().nullable().describe("Ticket creation timestamp").optional(),
+        updated_at: z.string().nullable().describe("Ticket update timestamp").optional(),
+        requester_id: z.coerce.number().int().nullable().describe("Requester user ID").optional(),
+        assignee_id: z.coerce.number().int().nullable().describe("Assigned agent ID").optional(),
+        group_id: z.coerce.number().int().nullable().describe("Assigned group ID").optional(),
+        organization_id: z.coerce.number().int().nullable().describe("Requester organization ID").optional(),
+        brand_id: z.coerce.number().int().nullable().describe("Zendesk brand ID").optional(),
+        ticket_form_id: z.coerce.number().int().nullable().describe("Zendesk ticket form ID").optional(),
+        tags: z.array(z.string()).describe("Ticket tags, omitted when empty").optional(),
+        tags_truncated: z.boolean().describe("Whether some tags were omitted to keep the discovery response bounded"),
+        via: z
+          .object({ channel: z.string().describe("Channel through which the ticket was created").optional() })
+          .describe("Compact ticket creation channel information")
+          .optional(),
+        description_excerpt: z.string().describe("Up to the first 1,500 characters of the ticket description"),
+        description_truncated: z
+          .boolean()
+          .describe("Whether the full ticket description is longer than description_excerpt"),
+        custom_fields: z
+          .array(z.object({}).catchall(z.any()))
+          .describe(
+            "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
+          )
+          .optional(),
+        custom_fields_truncated: z
+          .boolean()
+          .describe("Whether populated custom fields or their values were truncated to keep the response bounded"),
+      }),
+    )
+    .describe("Compact ticket records matching the query. Full ticket details and comments are deliberately omitted."),
+  count: z.coerce.number().describe("Total number of matching tickets reported by Zendesk"),
+  returned_count: z.coerce.number().describe("Number of compact ticket records returned in this response"),
+  has_more: z.boolean().describe("Whether another page of matching tickets is available"),
+  next_page: z.coerce.number().int().describe("Page number to pass on the next call when has_more is true").optional(),
+  response_truncated: z
+    .boolean()
+    .describe("Whether any large discovery fields were truncated to enforce the response-size budget"),
 });
 
 export type zendeskSearchZendeskTicketsByQueryOutputType = z.infer<

--- a/src/actions/autogen/types.ts
+++ b/src/actions/autogen/types.ts
@@ -2549,10 +2549,6 @@ export const zendeskListZendeskTicketsParamsSchema = z.object({
       "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
     )
     .optional(),
-  includeCustomFieldNames: z
-    .boolean()
-    .describe("Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)")
-    .optional(),
 });
 
 export type zendeskListZendeskTicketsParamsType = z.infer<typeof zendeskListZendeskTicketsParamsSchema>;
@@ -2564,48 +2560,21 @@ export const zendeskListZendeskTicketsOutputSchema = z.object({
         id: z.coerce.number().int().describe("Zendesk ticket ID"),
         subject: z.string().nullable().describe("Ticket subject").optional(),
         status: z.string().nullable().describe("Ticket status category").optional(),
-        custom_status_id: z.coerce.number().int().nullable().describe("Zendesk custom status ID").optional(),
         type: z.string().nullable().describe("Ticket type such as question, incident, problem, or task").optional(),
         priority: z.string().nullable().describe("Ticket priority").optional(),
         created_at: z.string().nullable().describe("Ticket creation timestamp").optional(),
         updated_at: z.string().nullable().describe("Ticket update timestamp").optional(),
-        requester_id: z.coerce.number().int().nullable().describe("Requester user ID").optional(),
-        assignee_id: z.coerce.number().int().nullable().describe("Assigned agent ID").optional(),
-        group_id: z.coerce.number().int().nullable().describe("Assigned group ID").optional(),
-        organization_id: z.coerce.number().int().nullable().describe("Requester organization ID").optional(),
-        brand_id: z.coerce.number().int().nullable().describe("Zendesk brand ID").optional(),
-        ticket_form_id: z.coerce.number().int().nullable().describe("Zendesk ticket form ID").optional(),
-        tags: z.array(z.string()).describe("Ticket tags, omitted when empty").optional(),
-        tags_truncated: z.boolean().describe("Whether some tags were omitted to keep the discovery response bounded"),
-        via: z
-          .object({ channel: z.string().describe("Channel through which the ticket was created").optional() })
-          .describe("Compact ticket creation channel information")
-          .optional(),
-        description_excerpt: z.string().describe("Up to the first 1,500 characters of the ticket description"),
+        description_excerpt: z.string().describe("Up to the first 1,000 characters of the ticket description"),
         description_truncated: z
           .boolean()
           .describe("Whether the full ticket description is longer than description_excerpt"),
-        custom_fields: z
-          .array(z.object({}).catchall(z.any()))
-          .describe(
-            "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
-          )
-          .optional(),
-        custom_fields_truncated: z
-          .boolean()
-          .describe("Whether populated custom fields or their values were truncated to keep the response bounded"),
       }),
     )
-    .describe(
-      "Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.",
-    ),
+    .describe("Small ticket records for choosing which IDs to fetch with getTicketDetails"),
   count: z.coerce.number().describe("Total number of tickets reported by Zendesk for the list query"),
   returned_count: z.coerce.number().describe("Number of compact ticket records returned in this response"),
   has_more: z.boolean().describe("Whether another page of tickets is available"),
   next_page: z.coerce.number().int().describe("Page number to pass on the next call when has_more is true").optional(),
-  response_truncated: z
-    .boolean()
-    .describe("Whether any large discovery fields were truncated to enforce the response-size budget"),
 });
 
 export type zendeskListZendeskTicketsOutputType = z.infer<typeof zendeskListZendeskTicketsOutputSchema>;
@@ -2760,10 +2729,6 @@ export const zendeskSearchZendeskTicketsByQueryParamsSchema = z.object({
       "Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.",
     )
     .optional(),
-  includeCustomFieldNames: z
-    .boolean()
-    .describe("Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)")
-    .optional(),
 });
 
 export type zendeskSearchZendeskTicketsByQueryParamsType = z.infer<
@@ -2777,46 +2742,21 @@ export const zendeskSearchZendeskTicketsByQueryOutputSchema = z.object({
         id: z.coerce.number().int().describe("Zendesk ticket ID"),
         subject: z.string().nullable().describe("Ticket subject").optional(),
         status: z.string().nullable().describe("Ticket status category").optional(),
-        custom_status_id: z.coerce.number().int().nullable().describe("Zendesk custom status ID").optional(),
         type: z.string().nullable().describe("Ticket type such as question, incident, problem, or task").optional(),
         priority: z.string().nullable().describe("Ticket priority").optional(),
         created_at: z.string().nullable().describe("Ticket creation timestamp").optional(),
         updated_at: z.string().nullable().describe("Ticket update timestamp").optional(),
-        requester_id: z.coerce.number().int().nullable().describe("Requester user ID").optional(),
-        assignee_id: z.coerce.number().int().nullable().describe("Assigned agent ID").optional(),
-        group_id: z.coerce.number().int().nullable().describe("Assigned group ID").optional(),
-        organization_id: z.coerce.number().int().nullable().describe("Requester organization ID").optional(),
-        brand_id: z.coerce.number().int().nullable().describe("Zendesk brand ID").optional(),
-        ticket_form_id: z.coerce.number().int().nullable().describe("Zendesk ticket form ID").optional(),
-        tags: z.array(z.string()).describe("Ticket tags, omitted when empty").optional(),
-        tags_truncated: z.boolean().describe("Whether some tags were omitted to keep the discovery response bounded"),
-        via: z
-          .object({ channel: z.string().describe("Channel through which the ticket was created").optional() })
-          .describe("Compact ticket creation channel information")
-          .optional(),
-        description_excerpt: z.string().describe("Up to the first 1,500 characters of the ticket description"),
+        description_excerpt: z.string().describe("Up to the first 1,000 characters of the ticket description"),
         description_truncated: z
           .boolean()
           .describe("Whether the full ticket description is longer than description_excerpt"),
-        custom_fields: z
-          .array(z.object({}).catchall(z.any()))
-          .describe(
-            "Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.",
-          )
-          .optional(),
-        custom_fields_truncated: z
-          .boolean()
-          .describe("Whether populated custom fields or their values were truncated to keep the response bounded"),
       }),
     )
-    .describe("Compact ticket records matching the query. Full ticket details and comments are deliberately omitted."),
+    .describe("Small ticket records for choosing which IDs to fetch with getTicketDetails"),
   count: z.coerce.number().describe("Total number of matching tickets reported by Zendesk"),
   returned_count: z.coerce.number().describe("Number of compact ticket records returned in this response"),
   has_more: z.boolean().describe("Whether another page of matching tickets is available"),
   next_page: z.coerce.number().int().describe("Page number to pass on the next call when has_more is true").optional(),
-  response_truncated: z
-    .boolean()
-    .describe("Whether any large discovery fields were truncated to enforce the response-size budget"),
 });
 
 export type zendeskSearchZendeskTicketsByQueryOutputType = z.infer<

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { compactZendeskTickets, getTicketFieldNames } from "./utils/compactTicket.js";
+import { compactZendeskTickets, isZendeskTicketSearchResult } from "./utils/compactTicket.js";
 import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
@@ -17,7 +17,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   authParams: AuthParamsType;
 }): Promise<zendeskListZendeskTicketsOutputType> => {
   const { authToken } = authParams;
-  const { subdomain, status, limit = 20, page = 1, includeCustomFieldNames = true } = params;
+  const { subdomain, status, limit = 20, page = 1 } = params;
 
   // Calculate date 3 months ago from now
   const threeMonthsAgo = new Date();
@@ -44,31 +44,19 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   const response = await axiosClient.get(apiEndpoint.toString(), {
     headers,
   });
-  const rawTickets: unknown[] = Array.isArray(response.data.results)
-    ? response.data.results.filter(
-        (result: unknown) =>
-          typeof result === "object" && result !== null && "result_type" in result && result.result_type === "ticket",
-      )
+  const rawTickets = Array.isArray(response.data.results)
+    ? response.data.results.filter(isZendeskTicketSearchResult)
     : [];
-  const fieldNames = includeCustomFieldNames
-    ? await getTicketFieldNames({
-        tickets: rawTickets,
-        zendeskBaseUrl,
-        authToken,
-        axiosClient,
-      })
-    : new Map<number, string>();
-  const compactResult = compactZendeskTickets({ tickets: rawTickets, fieldNames });
+  const tickets = compactZendeskTickets(rawTickets);
   const count = typeof response.data.count === "number" ? response.data.count : rawTickets.length;
   const hasMore = typeof response.data.next_page === "string" && response.data.next_page.length > 0;
 
   return {
-    tickets: compactResult.tickets,
+    tickets,
     count,
-    returned_count: compactResult.tickets.length,
+    returned_count: tickets.length,
     has_more: hasMore,
     ...(hasMore ? { next_page: page + 1 } : {}),
-    response_truncated: compactResult.responseTruncated,
   };
 };
 

--- a/src/actions/providers/zendesk/listTickets.ts
+++ b/src/actions/providers/zendesk/listTickets.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { compactZendeskTickets, getTicketFieldNames } from "./utils/compactTicket.js";
 import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
@@ -16,7 +17,7 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   authParams: AuthParamsType;
 }): Promise<zendeskListZendeskTicketsOutputType> => {
   const { authToken } = authParams;
-  const { subdomain, status } = params;
+  const { subdomain, status, limit = 20, page = 1, includeCustomFieldNames = true } = params;
 
   // Calculate date 3 months ago from now
   const threeMonthsAgo = new Date();
@@ -28,26 +29,46 @@ const listZendeskTickets: zendeskListZendeskTicketsFunction = async ({
   }
 
   const zendeskBaseUrl = getZendeskBaseUrl({ subdomain });
-  const apiEndpoint = new URL("/api/v2/tickets.json", zendeskBaseUrl);
+  const apiEndpoint = new URL("/api/v2/search.json", zendeskBaseUrl);
   const axiosClient = createAxiosClientWithRetries({ timeout: 10000, retryCount: 4 });
 
-  // Add query parameters for filtering
-  apiEndpoint.searchParams.set("created_after", formattedDate);
+  const query = [`type:ticket`, `created>${formattedDate}`, ...(status ? [`status:${status}`] : [])].join(" ");
+  apiEndpoint.searchParams.set("query", query);
+  apiEndpoint.searchParams.set("per_page", limit.toString());
+  apiEndpoint.searchParams.set("page", page.toString());
 
-  if (status) {
-    apiEndpoint.searchParams.set("status", status);
-  }
-
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${authToken}`,
+  };
   const response = await axiosClient.get(apiEndpoint.toString(), {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${authToken}`,
-    },
+    headers,
   });
+  const rawTickets: unknown[] = Array.isArray(response.data.results)
+    ? response.data.results.filter(
+        (result: unknown) =>
+          typeof result === "object" && result !== null && "result_type" in result && result.result_type === "ticket",
+      )
+    : [];
+  const fieldNames = includeCustomFieldNames
+    ? await getTicketFieldNames({
+        tickets: rawTickets,
+        zendeskBaseUrl,
+        authToken,
+        axiosClient,
+      })
+    : new Map<number, string>();
+  const compactResult = compactZendeskTickets({ tickets: rawTickets, fieldNames });
+  const count = typeof response.data.count === "number" ? response.data.count : rawTickets.length;
+  const hasMore = typeof response.data.next_page === "string" && response.data.next_page.length > 0;
 
   return {
-    tickets: response.data.tickets,
-    count: response.data.count,
+    tickets: compactResult.tickets,
+    count,
+    returned_count: compactResult.tickets.length,
+    has_more: hasMore,
+    ...(hasMore ? { next_page: page + 1 } : {}),
+    response_truncated: compactResult.responseTruncated,
   };
 };
 

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
+import { compactZendeskTickets, getTicketFieldNames } from "./utils/compactTicket.js";
 import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
@@ -16,7 +17,7 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
   authParams: AuthParamsType;
 }): Promise<zendeskSearchZendeskTicketsByQueryOutputType> => {
   const { authToken } = authParams;
-  const { subdomain, query, limit = 100 } = params;
+  const { subdomain, query, limit = 20, page = 1, includeCustomFieldNames = true } = params;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
@@ -35,23 +36,42 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
 
   apiEndpoint.searchParams.set("query", `type:ticket ${sanitizedQuery}`.trim());
   apiEndpoint.searchParams.set("per_page", limit.toString());
+  apiEndpoint.searchParams.set("page", page.toString());
 
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${authToken}`,
+  };
   const response = await axiosClient.get(apiEndpoint.toString(), {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${authToken}`,
-    },
+    headers,
   });
 
   // Defense in depth: only return results Zendesk marks as tickets
-  const results = Array.isArray(response.data.results)
-    ? response.data.results.filter((result: { result_type?: string }) => result.result_type === "ticket")
+  const rawResults: unknown[] = Array.isArray(response.data.results)
+    ? response.data.results.filter(
+        (result: unknown) =>
+          typeof result === "object" && result !== null && "result_type" in result && result.result_type === "ticket",
+      )
     : [];
-  const count = typeof response.data.count === "number" ? response.data.count : results.length;
+  const fieldNames = includeCustomFieldNames
+    ? await getTicketFieldNames({
+        tickets: rawResults,
+        zendeskBaseUrl,
+        authToken,
+        axiosClient,
+      })
+    : new Map<number, string>();
+  const compactResult = compactZendeskTickets({ tickets: rawResults, fieldNames });
+  const count = typeof response.data.count === "number" ? response.data.count : rawResults.length;
+  const hasMore = typeof response.data.next_page === "string" && response.data.next_page.length > 0;
 
   return {
-    results,
+    results: compactResult.tickets,
     count,
+    returned_count: compactResult.tickets.length,
+    has_more: hasMore,
+    ...(hasMore ? { next_page: page + 1 } : {}),
+    response_truncated: compactResult.responseTruncated,
   };
 };
 

--- a/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
+++ b/src/actions/providers/zendesk/searchZendeskTicketsByQuery.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../autogen/types.js";
 import { createAxiosClientWithRetries } from "../../util/axiosClient.js";
 import { MISSING_AUTH_TOKEN } from "../../util/missingAuthConstants.js";
-import { compactZendeskTickets, getTicketFieldNames } from "./utils/compactTicket.js";
+import { compactZendeskTickets, isZendeskTicketSearchResult } from "./utils/compactTicket.js";
 import { getZendeskBaseUrl } from "./utils/getZendeskBaseUrl.js";
 
 const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = async ({
@@ -17,7 +17,7 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
   authParams: AuthParamsType;
 }): Promise<zendeskSearchZendeskTicketsByQueryOutputType> => {
   const { authToken } = authParams;
-  const { subdomain, query, limit = 20, page = 1, includeCustomFieldNames = true } = params;
+  const { subdomain, query, limit = 20, page = 1 } = params;
 
   if (!authToken) {
     throw new Error(MISSING_AUTH_TOKEN);
@@ -47,31 +47,19 @@ const searchZendeskTicketsByQuery: zendeskSearchZendeskTicketsByQueryFunction = 
   });
 
   // Defense in depth: only return results Zendesk marks as tickets
-  const rawResults: unknown[] = Array.isArray(response.data.results)
-    ? response.data.results.filter(
-        (result: unknown) =>
-          typeof result === "object" && result !== null && "result_type" in result && result.result_type === "ticket",
-      )
+  const rawResults = Array.isArray(response.data.results)
+    ? response.data.results.filter(isZendeskTicketSearchResult)
     : [];
-  const fieldNames = includeCustomFieldNames
-    ? await getTicketFieldNames({
-        tickets: rawResults,
-        zendeskBaseUrl,
-        authToken,
-        axiosClient,
-      })
-    : new Map<number, string>();
-  const compactResult = compactZendeskTickets({ tickets: rawResults, fieldNames });
+  const results = compactZendeskTickets(rawResults);
   const count = typeof response.data.count === "number" ? response.data.count : rawResults.length;
   const hasMore = typeof response.data.next_page === "string" && response.data.next_page.length > 0;
 
   return {
-    results: compactResult.tickets,
+    results,
     count,
-    returned_count: compactResult.tickets.length,
+    returned_count: results.length,
     has_more: hasMore,
     ...(hasMore ? { next_page: page + 1 } : {}),
-    response_truncated: compactResult.responseTruncated,
   };
 };
 

--- a/src/actions/providers/zendesk/utils/compactTicket.ts
+++ b/src/actions/providers/zendesk/utils/compactTicket.ts
@@ -1,0 +1,315 @@
+import type { AxiosInstance } from "axios";
+import type { zendeskListZendeskTicketsOutputType } from "../../../autogen/types.js";
+
+const DESCRIPTION_EXCERPT_CHARACTERS = 1500;
+const MAX_TAGS = 30;
+const MAX_TAG_CHARACTERS = 100;
+const MAX_CUSTOM_FIELD_VALUE_CHARACTERS = 1000;
+const MAX_CUSTOM_FIELDS_CHARACTERS_PER_TICKET = 6000;
+const MAX_DISCOVERY_RESPONSE_CHARACTERS = 80000;
+const MAX_TICKET_FIELD_PAGES = 10;
+
+type CompactTicket = zendeskListZendeskTicketsOutputType["tickets"][number];
+
+interface RawZendeskTicket extends Record<string, unknown> {
+  custom_fields?: unknown;
+  description?: unknown;
+  fields?: unknown;
+  id?: unknown;
+  tags?: unknown;
+  via?: unknown;
+}
+
+interface RawCustomField {
+  id?: unknown;
+  value?: unknown;
+}
+
+interface RawTicketFieldDefinition {
+  id?: unknown;
+  title?: unknown;
+}
+
+interface TicketFieldsResponse {
+  ticket_fields?: unknown;
+  meta?: {
+    after_cursor?: unknown;
+    has_more?: unknown;
+  };
+}
+
+export async function getTicketFieldNames({
+  tickets,
+  zendeskBaseUrl,
+  authToken,
+  axiosClient,
+}: {
+  tickets: unknown[];
+  zendeskBaseUrl: URL;
+  authToken: string;
+  axiosClient: AxiosInstance;
+}): Promise<Map<number, string>> {
+  if (!tickets.some(hasPopulatedCustomFields)) {
+    return new Map();
+  }
+
+  const fieldNames = new Map<number, string>();
+  const apiEndpoint = new URL("/api/v2/ticket_fields.json", zendeskBaseUrl);
+  apiEndpoint.searchParams.set("page[size]", "100");
+
+  try {
+    for (let page = 0; page < MAX_TICKET_FIELD_PAGES; page += 1) {
+      const response = await axiosClient.get<TicketFieldsResponse>(apiEndpoint.toString(), {
+        headers: zendeskHeaders(authToken),
+      });
+      const definitions = Array.isArray(response.data.ticket_fields) ? response.data.ticket_fields : [];
+
+      for (const definition of definitions) {
+        if (!isRecord(definition)) continue;
+        const { id, title } = definition as RawTicketFieldDefinition;
+        if (typeof id === "number" && typeof title === "string") {
+          fieldNames.set(id, title);
+        }
+      }
+
+      const hasMore = response.data.meta?.has_more === true;
+      const afterCursor = response.data.meta?.after_cursor;
+      if (!hasMore || typeof afterCursor !== "string" || afterCursor.length === 0) {
+        break;
+      }
+      apiEndpoint.searchParams.set("page[after]", afterCursor);
+    }
+  } catch {
+    // Field names improve discovery but should not make the ticket search fail.
+    return fieldNames;
+  }
+
+  return fieldNames;
+}
+
+export function compactZendeskTickets({
+  tickets,
+  fieldNames = new Map(),
+}: {
+  tickets: unknown[];
+  fieldNames?: Map<number, string>;
+}): { tickets: CompactTicket[]; responseTruncated: boolean } {
+  const compactTickets = tickets.flatMap(ticket => {
+    const compactTicket = compactZendeskTicket(ticket, fieldNames);
+    return compactTicket ? [compactTicket] : [];
+  });
+
+  return enforceResponseBudget(compactTickets);
+}
+
+function compactZendeskTicket(ticket: unknown, fieldNames: Map<number, string>): CompactTicket | undefined {
+  if (!isRecord(ticket) || typeof ticket.id !== "number") {
+    return undefined;
+  }
+
+  const id = ticket.id;
+  const rawTicket = ticket as RawZendeskTicket;
+  const description = typeof rawTicket.description === "string" ? rawTicket.description : "";
+  const compactTags = compactTicketTags(rawTicket.tags);
+  const compactCustomFields = compactTicketCustomFields(rawTicket.custom_fields, fieldNames);
+  const channel =
+    isRecord(rawTicket.via) && typeof rawTicket.via.channel === "string" ? rawTicket.via.channel : undefined;
+
+  return {
+    id,
+    subject: nullableString(rawTicket.subject),
+    status: nullableString(rawTicket.status),
+    custom_status_id: nullableNumber(rawTicket.custom_status_id),
+    type: nullableString(rawTicket.type),
+    priority: nullableString(rawTicket.priority),
+    created_at: nullableString(rawTicket.created_at),
+    updated_at: nullableString(rawTicket.updated_at),
+    requester_id: nullableNumber(rawTicket.requester_id),
+    assignee_id: nullableNumber(rawTicket.assignee_id),
+    group_id: nullableNumber(rawTicket.group_id),
+    organization_id: nullableNumber(rawTicket.organization_id),
+    brand_id: nullableNumber(rawTicket.brand_id),
+    ticket_form_id: nullableNumber(rawTicket.ticket_form_id),
+    ...(compactTags.tags.length > 0 ? { tags: compactTags.tags } : {}),
+    tags_truncated: compactTags.truncated,
+    ...(channel ? { via: { channel } } : {}),
+    description_excerpt: description.slice(0, DESCRIPTION_EXCERPT_CHARACTERS),
+    description_truncated: description.length > DESCRIPTION_EXCERPT_CHARACTERS,
+    ...(compactCustomFields.fields.length > 0 ? { custom_fields: compactCustomFields.fields } : {}),
+    custom_fields_truncated: compactCustomFields.truncated,
+  };
+}
+
+function compactTicketTags(value: unknown): { tags: string[]; truncated: boolean } {
+  if (!Array.isArray(value)) {
+    return { tags: [], truncated: false };
+  }
+
+  const stringTags = value.filter((tag): tag is string => typeof tag === "string");
+  const tags = stringTags.slice(0, MAX_TAGS).map(tag => tag.slice(0, MAX_TAG_CHARACTERS));
+  const truncated =
+    stringTags.length > MAX_TAGS ||
+    stringTags.some((tag, index) => index < MAX_TAGS && tag.length > MAX_TAG_CHARACTERS);
+
+  return { tags, truncated };
+}
+
+function compactTicketCustomFields(
+  value: unknown,
+  fieldNames: Map<number, string>,
+): { fields: Array<Record<string, unknown>>; truncated: boolean } {
+  if (!Array.isArray(value)) {
+    return { fields: [], truncated: false };
+  }
+
+  const fields: Array<Record<string, unknown>> = [];
+  let serializedCharacters = 2;
+  let truncated = false;
+
+  for (const candidate of value) {
+    if (!isRecord(candidate)) continue;
+    const field = candidate as RawCustomField;
+    if (typeof field.id !== "number" || field.value === null || field.value === undefined) continue;
+
+    const compactValue = compactCustomFieldValue(field.value);
+    const compactField: Record<string, unknown> = {
+      id: field.id,
+      ...(fieldNames.has(field.id) ? { name: fieldNames.get(field.id) } : {}),
+      value: compactValue.value,
+    };
+    const fieldCharacters = JSON.stringify(compactField).length + 1;
+
+    if (serializedCharacters + fieldCharacters > MAX_CUSTOM_FIELDS_CHARACTERS_PER_TICKET) {
+      truncated = true;
+      continue;
+    }
+
+    fields.push(compactField);
+    serializedCharacters += fieldCharacters;
+    truncated ||= compactValue.truncated;
+  }
+
+  return { fields, truncated };
+}
+
+function compactCustomFieldValue(value: unknown): { value: unknown; truncated: boolean } {
+  if (typeof value === "string") {
+    return {
+      value: value.slice(0, MAX_CUSTOM_FIELD_VALUE_CHARACTERS),
+      truncated: value.length > MAX_CUSTOM_FIELD_VALUE_CHARACTERS,
+    };
+  }
+
+  const serializedValue = safelySerialize(value);
+  if (serializedValue.length <= MAX_CUSTOM_FIELD_VALUE_CHARACTERS) {
+    return { value, truncated: false };
+  }
+
+  return {
+    value: serializedValue.slice(0, MAX_CUSTOM_FIELD_VALUE_CHARACTERS),
+    truncated: true,
+  };
+}
+
+function enforceResponseBudget(tickets: CompactTicket[]): {
+  tickets: CompactTicket[];
+  responseTruncated: boolean;
+} {
+  let responseTruncated = tickets.some(
+    ticket => ticket.description_truncated || ticket.custom_fields_truncated || ticket.tags_truncated,
+  );
+
+  while (JSON.stringify(tickets).length > MAX_DISCOVERY_RESPONSE_CHARACTERS) {
+    const ticketWithCustomFields = tickets
+      .filter(ticket => ticket.custom_fields && ticket.custom_fields.length > 0)
+      .sort((left, right) => (right.custom_fields?.length ?? 0) - (left.custom_fields?.length ?? 0))[0];
+    if (ticketWithCustomFields?.custom_fields?.length) {
+      ticketWithCustomFields.custom_fields.pop();
+      ticketWithCustomFields.custom_fields_truncated = true;
+      if (ticketWithCustomFields.custom_fields.length === 0) {
+        delete ticketWithCustomFields.custom_fields;
+      }
+      responseTruncated = true;
+      continue;
+    }
+
+    const ticketWithTags = tickets
+      .filter(ticket => ticket.tags && ticket.tags.length > 0)
+      .sort((left, right) => (right.tags?.length ?? 0) - (left.tags?.length ?? 0))[0];
+    if (ticketWithTags?.tags?.length) {
+      ticketWithTags.tags.pop();
+      ticketWithTags.tags_truncated = true;
+      if (ticketWithTags.tags.length === 0) {
+        delete ticketWithTags.tags;
+      }
+      responseTruncated = true;
+      continue;
+    }
+
+    const ticketWithDescription = tickets
+      .filter(ticket => ticket.description_excerpt.length > 250)
+      .sort((left, right) => right.description_excerpt.length - left.description_excerpt.length)[0];
+    if (ticketWithDescription) {
+      ticketWithDescription.description_excerpt = ticketWithDescription.description_excerpt.slice(
+        0,
+        Math.max(250, ticketWithDescription.description_excerpt.length - 250),
+      );
+      ticketWithDescription.description_truncated = true;
+      responseTruncated = true;
+      continue;
+    }
+
+    const ticketWithLongSubject = tickets
+      .filter(ticket => typeof ticket.subject === "string" && ticket.subject.length > 100)
+      .sort((left, right) => (right.subject?.length ?? 0) - (left.subject?.length ?? 0))[0];
+    if (ticketWithLongSubject && typeof ticketWithLongSubject.subject === "string") {
+      ticketWithLongSubject.subject = ticketWithLongSubject.subject.slice(
+        0,
+        Math.max(100, ticketWithLongSubject.subject.length - 100),
+      );
+      responseTruncated = true;
+      continue;
+    }
+
+    break;
+  }
+
+  return { tickets, responseTruncated };
+}
+
+function hasPopulatedCustomFields(ticket: unknown): boolean {
+  return (
+    isRecord(ticket) &&
+    Array.isArray(ticket.custom_fields) &&
+    ticket.custom_fields.some(
+      field => isRecord(field) && typeof field.id === "number" && field.value !== null && field.value !== undefined,
+    )
+  );
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function safelySerialize(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function zendeskHeaders(authToken: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${authToken}`,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/actions/providers/zendesk/utils/compactTicket.ts
+++ b/src/actions/providers/zendesk/utils/compactTicket.ts
@@ -1,315 +1,62 @@
-import type { AxiosInstance } from "axios";
 import type { zendeskListZendeskTicketsOutputType } from "../../../autogen/types.js";
 
-const DESCRIPTION_EXCERPT_CHARACTERS = 1500;
-const MAX_TAGS = 30;
-const MAX_TAG_CHARACTERS = 100;
-const MAX_CUSTOM_FIELD_VALUE_CHARACTERS = 1000;
-const MAX_CUSTOM_FIELDS_CHARACTERS_PER_TICKET = 6000;
-const MAX_DISCOVERY_RESPONSE_CHARACTERS = 80000;
-const MAX_TICKET_FIELD_PAGES = 10;
+const DESCRIPTION_EXCERPT_CHARACTERS = 1000;
 
 type CompactTicket = zendeskListZendeskTicketsOutputType["tickets"][number];
 
-interface RawZendeskTicket extends Record<string, unknown> {
-  custom_fields?: unknown;
-  description?: unknown;
-  fields?: unknown;
-  id?: unknown;
-  tags?: unknown;
-  via?: unknown;
+export interface ZendeskTicketSearchResult {
+  id: number;
+  result_type: "ticket";
+  subject?: string | null;
+  status?: string | null;
+  type?: string | null;
+  priority?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  description?: string | null;
 }
 
-interface RawCustomField {
-  id?: unknown;
-  value?: unknown;
-}
+/**
+ * Narrows an unknown Zendesk Search API result to the ticket fields used for discovery.
+ */
+export function isZendeskTicketSearchResult(value: unknown): value is ZendeskTicketSearchResult {
+  if (typeof value !== "object" || value === null) return false;
 
-interface RawTicketFieldDefinition {
-  id?: unknown;
-  title?: unknown;
-}
-
-interface TicketFieldsResponse {
-  ticket_fields?: unknown;
-  meta?: {
-    after_cursor?: unknown;
-    has_more?: unknown;
-  };
-}
-
-export async function getTicketFieldNames({
-  tickets,
-  zendeskBaseUrl,
-  authToken,
-  axiosClient,
-}: {
-  tickets: unknown[];
-  zendeskBaseUrl: URL;
-  authToken: string;
-  axiosClient: AxiosInstance;
-}): Promise<Map<number, string>> {
-  if (!tickets.some(hasPopulatedCustomFields)) {
-    return new Map();
-  }
-
-  const fieldNames = new Map<number, string>();
-  const apiEndpoint = new URL("/api/v2/ticket_fields.json", zendeskBaseUrl);
-  apiEndpoint.searchParams.set("page[size]", "100");
-
-  try {
-    for (let page = 0; page < MAX_TICKET_FIELD_PAGES; page += 1) {
-      const response = await axiosClient.get<TicketFieldsResponse>(apiEndpoint.toString(), {
-        headers: zendeskHeaders(authToken),
-      });
-      const definitions = Array.isArray(response.data.ticket_fields) ? response.data.ticket_fields : [];
-
-      for (const definition of definitions) {
-        if (!isRecord(definition)) continue;
-        const { id, title } = definition as RawTicketFieldDefinition;
-        if (typeof id === "number" && typeof title === "string") {
-          fieldNames.set(id, title);
-        }
-      }
-
-      const hasMore = response.data.meta?.has_more === true;
-      const afterCursor = response.data.meta?.after_cursor;
-      if (!hasMore || typeof afterCursor !== "string" || afterCursor.length === 0) {
-        break;
-      }
-      apiEndpoint.searchParams.set("page[after]", afterCursor);
-    }
-  } catch {
-    // Field names improve discovery but should not make the ticket search fail.
-    return fieldNames;
-  }
-
-  return fieldNames;
-}
-
-export function compactZendeskTickets({
-  tickets,
-  fieldNames = new Map(),
-}: {
-  tickets: unknown[];
-  fieldNames?: Map<number, string>;
-}): { tickets: CompactTicket[]; responseTruncated: boolean } {
-  const compactTickets = tickets.flatMap(ticket => {
-    const compactTicket = compactZendeskTicket(ticket, fieldNames);
-    return compactTicket ? [compactTicket] : [];
-  });
-
-  return enforceResponseBudget(compactTickets);
-}
-
-function compactZendeskTicket(ticket: unknown, fieldNames: Map<number, string>): CompactTicket | undefined {
-  if (!isRecord(ticket) || typeof ticket.id !== "number") {
-    return undefined;
-  }
-
-  const id = ticket.id;
-  const rawTicket = ticket as RawZendeskTicket;
-  const description = typeof rawTicket.description === "string" ? rawTicket.description : "";
-  const compactTags = compactTicketTags(rawTicket.tags);
-  const compactCustomFields = compactTicketCustomFields(rawTicket.custom_fields, fieldNames);
-  const channel =
-    isRecord(rawTicket.via) && typeof rawTicket.via.channel === "string" ? rawTicket.via.channel : undefined;
-
-  return {
-    id,
-    subject: nullableString(rawTicket.subject),
-    status: nullableString(rawTicket.status),
-    custom_status_id: nullableNumber(rawTicket.custom_status_id),
-    type: nullableString(rawTicket.type),
-    priority: nullableString(rawTicket.priority),
-    created_at: nullableString(rawTicket.created_at),
-    updated_at: nullableString(rawTicket.updated_at),
-    requester_id: nullableNumber(rawTicket.requester_id),
-    assignee_id: nullableNumber(rawTicket.assignee_id),
-    group_id: nullableNumber(rawTicket.group_id),
-    organization_id: nullableNumber(rawTicket.organization_id),
-    brand_id: nullableNumber(rawTicket.brand_id),
-    ticket_form_id: nullableNumber(rawTicket.ticket_form_id),
-    ...(compactTags.tags.length > 0 ? { tags: compactTags.tags } : {}),
-    tags_truncated: compactTags.truncated,
-    ...(channel ? { via: { channel } } : {}),
-    description_excerpt: description.slice(0, DESCRIPTION_EXCERPT_CHARACTERS),
-    description_truncated: description.length > DESCRIPTION_EXCERPT_CHARACTERS,
-    ...(compactCustomFields.fields.length > 0 ? { custom_fields: compactCustomFields.fields } : {}),
-    custom_fields_truncated: compactCustomFields.truncated,
-  };
-}
-
-function compactTicketTags(value: unknown): { tags: string[]; truncated: boolean } {
-  if (!Array.isArray(value)) {
-    return { tags: [], truncated: false };
-  }
-
-  const stringTags = value.filter((tag): tag is string => typeof tag === "string");
-  const tags = stringTags.slice(0, MAX_TAGS).map(tag => tag.slice(0, MAX_TAG_CHARACTERS));
-  const truncated =
-    stringTags.length > MAX_TAGS ||
-    stringTags.some((tag, index) => index < MAX_TAGS && tag.length > MAX_TAG_CHARACTERS);
-
-  return { tags, truncated };
-}
-
-function compactTicketCustomFields(
-  value: unknown,
-  fieldNames: Map<number, string>,
-): { fields: Array<Record<string, unknown>>; truncated: boolean } {
-  if (!Array.isArray(value)) {
-    return { fields: [], truncated: false };
-  }
-
-  const fields: Array<Record<string, unknown>> = [];
-  let serializedCharacters = 2;
-  let truncated = false;
-
-  for (const candidate of value) {
-    if (!isRecord(candidate)) continue;
-    const field = candidate as RawCustomField;
-    if (typeof field.id !== "number" || field.value === null || field.value === undefined) continue;
-
-    const compactValue = compactCustomFieldValue(field.value);
-    const compactField: Record<string, unknown> = {
-      id: field.id,
-      ...(fieldNames.has(field.id) ? { name: fieldNames.get(field.id) } : {}),
-      value: compactValue.value,
-    };
-    const fieldCharacters = JSON.stringify(compactField).length + 1;
-
-    if (serializedCharacters + fieldCharacters > MAX_CUSTOM_FIELDS_CHARACTERS_PER_TICKET) {
-      truncated = true;
-      continue;
-    }
-
-    fields.push(compactField);
-    serializedCharacters += fieldCharacters;
-    truncated ||= compactValue.truncated;
-  }
-
-  return { fields, truncated };
-}
-
-function compactCustomFieldValue(value: unknown): { value: unknown; truncated: boolean } {
-  if (typeof value === "string") {
-    return {
-      value: value.slice(0, MAX_CUSTOM_FIELD_VALUE_CHARACTERS),
-      truncated: value.length > MAX_CUSTOM_FIELD_VALUE_CHARACTERS,
-    };
-  }
-
-  const serializedValue = safelySerialize(value);
-  if (serializedValue.length <= MAX_CUSTOM_FIELD_VALUE_CHARACTERS) {
-    return { value, truncated: false };
-  }
-
-  return {
-    value: serializedValue.slice(0, MAX_CUSTOM_FIELD_VALUE_CHARACTERS),
-    truncated: true,
-  };
-}
-
-function enforceResponseBudget(tickets: CompactTicket[]): {
-  tickets: CompactTicket[];
-  responseTruncated: boolean;
-} {
-  let responseTruncated = tickets.some(
-    ticket => ticket.description_truncated || ticket.custom_fields_truncated || ticket.tags_truncated,
-  );
-
-  while (JSON.stringify(tickets).length > MAX_DISCOVERY_RESPONSE_CHARACTERS) {
-    const ticketWithCustomFields = tickets
-      .filter(ticket => ticket.custom_fields && ticket.custom_fields.length > 0)
-      .sort((left, right) => (right.custom_fields?.length ?? 0) - (left.custom_fields?.length ?? 0))[0];
-    if (ticketWithCustomFields?.custom_fields?.length) {
-      ticketWithCustomFields.custom_fields.pop();
-      ticketWithCustomFields.custom_fields_truncated = true;
-      if (ticketWithCustomFields.custom_fields.length === 0) {
-        delete ticketWithCustomFields.custom_fields;
-      }
-      responseTruncated = true;
-      continue;
-    }
-
-    const ticketWithTags = tickets
-      .filter(ticket => ticket.tags && ticket.tags.length > 0)
-      .sort((left, right) => (right.tags?.length ?? 0) - (left.tags?.length ?? 0))[0];
-    if (ticketWithTags?.tags?.length) {
-      ticketWithTags.tags.pop();
-      ticketWithTags.tags_truncated = true;
-      if (ticketWithTags.tags.length === 0) {
-        delete ticketWithTags.tags;
-      }
-      responseTruncated = true;
-      continue;
-    }
-
-    const ticketWithDescription = tickets
-      .filter(ticket => ticket.description_excerpt.length > 250)
-      .sort((left, right) => right.description_excerpt.length - left.description_excerpt.length)[0];
-    if (ticketWithDescription) {
-      ticketWithDescription.description_excerpt = ticketWithDescription.description_excerpt.slice(
-        0,
-        Math.max(250, ticketWithDescription.description_excerpt.length - 250),
-      );
-      ticketWithDescription.description_truncated = true;
-      responseTruncated = true;
-      continue;
-    }
-
-    const ticketWithLongSubject = tickets
-      .filter(ticket => typeof ticket.subject === "string" && ticket.subject.length > 100)
-      .sort((left, right) => (right.subject?.length ?? 0) - (left.subject?.length ?? 0))[0];
-    if (ticketWithLongSubject && typeof ticketWithLongSubject.subject === "string") {
-      ticketWithLongSubject.subject = ticketWithLongSubject.subject.slice(
-        0,
-        Math.max(100, ticketWithLongSubject.subject.length - 100),
-      );
-      responseTruncated = true;
-      continue;
-    }
-
-    break;
-  }
-
-  return { tickets, responseTruncated };
-}
-
-function hasPopulatedCustomFields(ticket: unknown): boolean {
+  const result = value as Partial<ZendeskTicketSearchResult>;
   return (
-    isRecord(ticket) &&
-    Array.isArray(ticket.custom_fields) &&
-    ticket.custom_fields.some(
-      field => isRecord(field) && typeof field.id === "number" && field.value !== null && field.value !== undefined,
-    )
+    typeof result.id === "number" &&
+    result.result_type === "ticket" &&
+    isOptionalNullableString(result.subject) &&
+    isOptionalNullableString(result.status) &&
+    isOptionalNullableString(result.type) &&
+    isOptionalNullableString(result.priority) &&
+    isOptionalNullableString(result.created_at) &&
+    isOptionalNullableString(result.updated_at) &&
+    isOptionalNullableString(result.description)
   );
 }
 
-function nullableString(value: unknown): string | null {
-  return typeof value === "string" ? value : null;
+/**
+ * Projects Zendesk tickets into small records for choosing which IDs to fetch with getTicketDetails.
+ */
+export function compactZendeskTickets(tickets: ZendeskTicketSearchResult[]): CompactTicket[] {
+  return tickets.map(ticket => {
+    const description = ticket.description ?? "";
+
+    return {
+      id: ticket.id,
+      subject: ticket.subject ?? null,
+      status: ticket.status ?? null,
+      type: ticket.type ?? null,
+      priority: ticket.priority ?? null,
+      created_at: ticket.created_at ?? null,
+      updated_at: ticket.updated_at ?? null,
+      description_excerpt: description.slice(0, DESCRIPTION_EXCERPT_CHARACTERS),
+      description_truncated: description.length > DESCRIPTION_EXCERPT_CHARACTERS,
+    };
+  });
 }
 
-function nullableNumber(value: unknown): number | null {
-  return typeof value === "number" ? value : null;
-}
-
-function safelySerialize(value: unknown): string {
-  try {
-    return JSON.stringify(value) ?? String(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function zendeskHeaders(authToken: string): Record<string, string> {
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${authToken}`,
-  };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+function isOptionalNullableString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
 }

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -2020,19 +2020,16 @@ actions:
             type: integer
             minimum: 1
             description: Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.
-          includeCustomFieldNames:
-            type: boolean
-            description: Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)
       output:
         type: object
-        required: [tickets, count, returned_count, has_more, response_truncated]
+        required: [tickets, count, returned_count, has_more]
         properties:
           tickets:
             type: array
-            description: Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.
+            description: Small ticket records for choosing which IDs to fetch with getTicketDetails
             items:
               type: object
-              required: [id, description_excerpt, description_truncated, custom_fields_truncated, tags_truncated]
+              required: [id, description_excerpt, description_truncated]
               properties:
                 id:
                   type: integer
@@ -2045,10 +2042,6 @@ actions:
                   type: string
                   nullable: true
                   description: Ticket status category
-                custom_status_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk custom status ID
                 type:
                   type: string
                   nullable: true
@@ -2065,59 +2058,12 @@ actions:
                   type: string
                   nullable: true
                   description: Ticket update timestamp
-                requester_id:
-                  type: integer
-                  nullable: true
-                  description: Requester user ID
-                assignee_id:
-                  type: integer
-                  nullable: true
-                  description: Assigned agent ID
-                group_id:
-                  type: integer
-                  nullable: true
-                  description: Assigned group ID
-                organization_id:
-                  type: integer
-                  nullable: true
-                  description: Requester organization ID
-                brand_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk brand ID
-                ticket_form_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk ticket form ID
-                tags:
-                  type: array
-                  description: Ticket tags, omitted when empty
-                  items:
-                    type: string
-                tags_truncated:
-                  type: boolean
-                  description: Whether some tags were omitted to keep the discovery response bounded
-                via:
-                  type: object
-                  description: Compact ticket creation channel information
-                  properties:
-                    channel:
-                      type: string
-                      description: Channel through which the ticket was created
                 description_excerpt:
                   type: string
-                  description: Up to the first 1,500 characters of the ticket description
+                  description: Up to the first 1,000 characters of the ticket description
                 description_truncated:
                   type: boolean
                   description: Whether the full ticket description is longer than description_excerpt
-                custom_fields:
-                  type: array
-                  description: Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.
-                  items:
-                    type: object
-                custom_fields_truncated:
-                  type: boolean
-                  description: Whether populated custom fields or their values were truncated to keep the response bounded
           count:
             type: number
             description: Total number of tickets reported by Zendesk for the list query
@@ -2130,9 +2076,6 @@ actions:
           next_page:
             type: integer
             description: Page number to pass on the next call when has_more is true
-          response_truncated:
-            type: boolean
-            description: Whether any large discovery fields were truncated to enforce the response-size budget
     getTicketDetails:
       displayName: Get ticket details
       description: Get the full ticket object for a selected Zendesk ticket.
@@ -2287,19 +2230,16 @@ actions:
             type: integer
             minimum: 1
             description: Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.
-          includeCustomFieldNames:
-            type: boolean
-            description: Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)
       output:
         type: object
-        required: [results, count, returned_count, has_more, response_truncated]
+        required: [results, count, returned_count, has_more]
         properties:
           results:
             type: array
-            description: Compact ticket records matching the query. Full ticket details and comments are deliberately omitted.
+            description: Small ticket records for choosing which IDs to fetch with getTicketDetails
             items:
               type: object
-              required: [id, description_excerpt, description_truncated, custom_fields_truncated, tags_truncated]
+              required: [id, description_excerpt, description_truncated]
               properties:
                 id:
                   type: integer
@@ -2312,10 +2252,6 @@ actions:
                   type: string
                   nullable: true
                   description: Ticket status category
-                custom_status_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk custom status ID
                 type:
                   type: string
                   nullable: true
@@ -2332,59 +2268,12 @@ actions:
                   type: string
                   nullable: true
                   description: Ticket update timestamp
-                requester_id:
-                  type: integer
-                  nullable: true
-                  description: Requester user ID
-                assignee_id:
-                  type: integer
-                  nullable: true
-                  description: Assigned agent ID
-                group_id:
-                  type: integer
-                  nullable: true
-                  description: Assigned group ID
-                organization_id:
-                  type: integer
-                  nullable: true
-                  description: Requester organization ID
-                brand_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk brand ID
-                ticket_form_id:
-                  type: integer
-                  nullable: true
-                  description: Zendesk ticket form ID
-                tags:
-                  type: array
-                  description: Ticket tags, omitted when empty
-                  items:
-                    type: string
-                tags_truncated:
-                  type: boolean
-                  description: Whether some tags were omitted to keep the discovery response bounded
-                via:
-                  type: object
-                  description: Compact ticket creation channel information
-                  properties:
-                    channel:
-                      type: string
-                      description: Channel through which the ticket was created
                 description_excerpt:
                   type: string
-                  description: Up to the first 1,500 characters of the ticket description
+                  description: Up to the first 1,000 characters of the ticket description
                 description_truncated:
                   type: boolean
                   description: Whether the full ticket description is longer than description_excerpt
-                custom_fields:
-                  type: array
-                  description: Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.
-                  items:
-                    type: object
-                custom_fields_truncated:
-                  type: boolean
-                  description: Whether populated custom fields or their values were truncated to keep the response bounded
           count:
             type: number
             description: Total number of matching tickets reported by Zendesk
@@ -2397,9 +2286,6 @@ actions:
           next_page:
             type: integer
             description: Page number to pass on the next call when has_more is true
-          response_truncated:
-            type: boolean
-            description: Whether any large discovery fields were truncated to enforce the response-size budget
   linkedin:
     createShareLinkedinPostUrl:
       displayName: Create a share LinkedIn post URL

--- a/src/actions/schema.yaml
+++ b/src/actions/schema.yaml
@@ -1996,7 +1996,7 @@ actions:
             description: The URL of the ticket created
     listZendeskTickets:
       displayName: List Zendesk tickets
-      description: List tickets in Zendesk from the past 3 months
+      description: List compact ticket discovery records from Zendesk from the past 3 months. Use getTicketDetails to investigate selected tickets.
       scopes: []
       parameters:
         type: object
@@ -2009,22 +2009,133 @@ actions:
             tags: [recommend-predefined]
           status:
             type: string
+            enum: [new, open, pending, hold, solved, closed]
             description: Filter tickets by status (new, open, pending, hold, solved, closed)
+          limit:
+            type: integer
+            minimum: 1
+            maximum: 50
+            description: Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)
+          page:
+            type: integer
+            minimum: 1
+            description: Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.
+          includeCustomFieldNames:
+            type: boolean
+            description: Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)
       output:
         type: object
-        required: [tickets, count]
+        required: [tickets, count, returned_count, has_more, response_truncated]
         properties:
           tickets:
             type: array
-            description: List of tickets
+            description: Compact ticket records intended for discovery. Full ticket details and comments are deliberately omitted.
             items:
               type: object
+              required: [id, description_excerpt, description_truncated, custom_fields_truncated, tags_truncated]
+              properties:
+                id:
+                  type: integer
+                  description: Zendesk ticket ID
+                subject:
+                  type: string
+                  nullable: true
+                  description: Ticket subject
+                status:
+                  type: string
+                  nullable: true
+                  description: Ticket status category
+                custom_status_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk custom status ID
+                type:
+                  type: string
+                  nullable: true
+                  description: Ticket type such as question, incident, problem, or task
+                priority:
+                  type: string
+                  nullable: true
+                  description: Ticket priority
+                created_at:
+                  type: string
+                  nullable: true
+                  description: Ticket creation timestamp
+                updated_at:
+                  type: string
+                  nullable: true
+                  description: Ticket update timestamp
+                requester_id:
+                  type: integer
+                  nullable: true
+                  description: Requester user ID
+                assignee_id:
+                  type: integer
+                  nullable: true
+                  description: Assigned agent ID
+                group_id:
+                  type: integer
+                  nullable: true
+                  description: Assigned group ID
+                organization_id:
+                  type: integer
+                  nullable: true
+                  description: Requester organization ID
+                brand_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk brand ID
+                ticket_form_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk ticket form ID
+                tags:
+                  type: array
+                  description: Ticket tags, omitted when empty
+                  items:
+                    type: string
+                tags_truncated:
+                  type: boolean
+                  description: Whether some tags were omitted to keep the discovery response bounded
+                via:
+                  type: object
+                  description: Compact ticket creation channel information
+                  properties:
+                    channel:
+                      type: string
+                      description: Channel through which the ticket was created
+                description_excerpt:
+                  type: string
+                  description: Up to the first 1,500 characters of the ticket description
+                description_truncated:
+                  type: boolean
+                  description: Whether the full ticket description is longer than description_excerpt
+                custom_fields:
+                  type: array
+                  description: Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.
+                  items:
+                    type: object
+                custom_fields_truncated:
+                  type: boolean
+                  description: Whether populated custom fields or their values were truncated to keep the response bounded
           count:
             type: number
-            description: Number of tickets found
+            description: Total number of tickets reported by Zendesk for the list query
+          returned_count:
+            type: number
+            description: Number of compact ticket records returned in this response
+          has_more:
+            type: boolean
+            description: Whether another page of tickets is available
+          next_page:
+            type: integer
+            description: Page number to pass on the next call when has_more is true
+          response_truncated:
+            type: boolean
+            description: Whether any large discovery fields were truncated to enforce the response-size budget
     getTicketDetails:
       displayName: Get ticket details
-      description: Get details of a ticket in Zendesk
+      description: Get the full ticket object for a selected Zendesk ticket.
       scopes: []
       parameters:
         type: object
@@ -2153,7 +2264,7 @@ actions:
             description: Number of objects found
     searchZendeskTicketsByQuery:
       displayName: Search Zendesk tickets with a query
-      description: Search Zendesk tickets by query with flexible filtering options. Only returns tickets, never any other type of Zendesk resource.
+      description: Search compact Zendesk ticket discovery records with flexible filtering options. Only returns tickets. Use getTicketDetails to investigate selected tickets.
       scopes: []
       parameters:
         type: object
@@ -2168,20 +2279,127 @@ actions:
             type: string
             description: Search query string that can include filters like status, priority, tags, assignee, etc. Examples - status:open, priority:high, tags:bug, assignee:user@example.com, or combination like "status:open priority:high". The search is always restricted to tickets, so any type filter in the query is ignored.
           limit:
-            type: number
-            description: Maximum number of tickets to return (optional, defaults to 100)
+            type: integer
+            minimum: 1
+            maximum: 50
+            description: Number of compact ticket records to return per page (optional, defaults to 20, maximum 50)
+          page:
+            type: integer
+            minimum: 1
+            description: Offset page number to retrieve (optional, defaults to 1). Pass next_page from a previous response to continue.
+          includeCustomFieldNames:
+            type: boolean
+            description: Whether to resolve populated custom field IDs to their Zendesk field names (optional, defaults to true)
       output:
         type: object
-        required: [results, count]
+        required: [results, count, returned_count, has_more, response_truncated]
         properties:
           results:
             type: array
-            description: List of tickets matching the query
+            description: Compact ticket records matching the query. Full ticket details and comments are deliberately omitted.
             items:
               type: object
+              required: [id, description_excerpt, description_truncated, custom_fields_truncated, tags_truncated]
+              properties:
+                id:
+                  type: integer
+                  description: Zendesk ticket ID
+                subject:
+                  type: string
+                  nullable: true
+                  description: Ticket subject
+                status:
+                  type: string
+                  nullable: true
+                  description: Ticket status category
+                custom_status_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk custom status ID
+                type:
+                  type: string
+                  nullable: true
+                  description: Ticket type such as question, incident, problem, or task
+                priority:
+                  type: string
+                  nullable: true
+                  description: Ticket priority
+                created_at:
+                  type: string
+                  nullable: true
+                  description: Ticket creation timestamp
+                updated_at:
+                  type: string
+                  nullable: true
+                  description: Ticket update timestamp
+                requester_id:
+                  type: integer
+                  nullable: true
+                  description: Requester user ID
+                assignee_id:
+                  type: integer
+                  nullable: true
+                  description: Assigned agent ID
+                group_id:
+                  type: integer
+                  nullable: true
+                  description: Assigned group ID
+                organization_id:
+                  type: integer
+                  nullable: true
+                  description: Requester organization ID
+                brand_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk brand ID
+                ticket_form_id:
+                  type: integer
+                  nullable: true
+                  description: Zendesk ticket form ID
+                tags:
+                  type: array
+                  description: Ticket tags, omitted when empty
+                  items:
+                    type: string
+                tags_truncated:
+                  type: boolean
+                  description: Whether some tags were omitted to keep the discovery response bounded
+                via:
+                  type: object
+                  description: Compact ticket creation channel information
+                  properties:
+                    channel:
+                      type: string
+                      description: Channel through which the ticket was created
+                description_excerpt:
+                  type: string
+                  description: Up to the first 1,500 characters of the ticket description
+                description_truncated:
+                  type: boolean
+                  description: Whether the full ticket description is longer than description_excerpt
+                custom_fields:
+                  type: array
+                  description: Populated custom fields only. Each item contains id, value, and name when name resolution succeeds.
+                  items:
+                    type: object
+                custom_fields_truncated:
+                  type: boolean
+                  description: Whether populated custom fields or their values were truncated to keep the response bounded
           count:
             type: number
-            description: Number of tickets found
+            description: Total number of matching tickets reported by Zendesk
+          returned_count:
+            type: number
+            description: Number of compact ticket records returned in this response
+          has_more:
+            type: boolean
+            description: Whether another page of matching tickets is available
+          next_page:
+            type: integer
+            description: Page number to pass on the next call when has_more is true
+          response_truncated:
+            type: boolean
+            description: Whether any large discovery fields were truncated to enforce the response-size budget
   linkedin:
     createShareLinkedinPostUrl:
       displayName: Create a share LinkedIn post URL

--- a/tests/zendesk/searchZendeskTicketsByQuery.test.ts
+++ b/tests/zendesk/searchZendeskTicketsByQuery.test.ts
@@ -141,98 +141,28 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
     expect(result.next_page).toBe(2);
   });
 
-  it("keeps only discovery fields, populated custom fields, and description excerpts", async () => {
+  it("returns only enough ticket information to choose IDs for getTicketDetails", async () => {
     const description = "x".repeat(2000);
-    mockGet
-      .mockResolvedValueOnce({
-        data: {
-          results: [
-            {
-              id: 1,
-              result_type: "ticket",
-              subject: "Investigate this",
-              description,
-              status: "open",
-              tags: ["support"],
-              via: {
-                channel: "email",
-                source: { from: { address: "requester@example.com" } },
-              },
-              custom_fields: [
-                { id: 100, value: null },
-                { id: 200, value: "technical_support" },
-              ],
-              fields: [
-                { id: 100, value: null },
-                { id: 200, value: "technical_support" },
-              ],
-              generated_timestamp: 123,
-              url: "https://example-account.zendesk.com/api/v2/tickets/1.json",
-            },
-          ],
-          count: 1,
-          next_page: null,
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          ticket_fields: [{ id: 200, title: "Request Type" }],
-          meta: { has_more: false },
-        },
-      });
-
-    const result = await searchZendeskTicketsByQuery({
-      params: {
-        subdomain: "example-account",
-        query: "status:open",
-      },
-      authParams: AUTH,
-    });
-
-    expect(mockGet).toHaveBeenCalledTimes(2);
-    const [ticketFieldsUrl] = mockGet.mock.calls[1] as [string];
-    expect(new URL(ticketFieldsUrl).pathname).toBe(
-      "/api/v2/ticket_fields.json",
-    );
-    expect(result.results[0]).toEqual(
-      expect.objectContaining({
-        id: 1,
-        subject: "Investigate this",
-        status: "open",
-        tags: ["support"],
-        via: { channel: "email" },
-        description_excerpt: "x".repeat(1500),
-        description_truncated: true,
-        custom_fields: [
-          { id: 200, name: "Request Type", value: "technical_support" },
-        ],
-      }),
-    );
-    expect(result.results[0]).not.toHaveProperty("fields");
-    expect(result.results[0]).not.toHaveProperty("generated_timestamp");
-    expect(result.results[0]).not.toHaveProperty("url");
-    expect(result.response_truncated).toBe(true);
-  });
-
-  it("keeps the compact search response under its character budget without dropping ticket IDs", async () => {
-    const tickets = Array.from({ length: 50 }, (_, index) => ({
-      id: index + 1,
-      result_type: "ticket",
-      subject: `Ticket ${index + 1}`,
-      description: "d".repeat(5000),
-      tags: Array.from(
-        { length: 40 },
-        (_, tagIndex) => `tag-${tagIndex}-${"t".repeat(100)}`,
-      ),
-      custom_fields: Array.from({ length: 20 }, (_, fieldIndex) => ({
-        id: fieldIndex + 1,
-        value: "v".repeat(1000),
-      })),
-    }));
     mockGet.mockResolvedValueOnce({
       data: {
-        results: tickets,
-        count: tickets.length,
+        results: [
+          {
+            id: 1,
+            result_type: "ticket",
+            subject: "Investigate this",
+            description,
+            status: "open",
+            type: "incident",
+            priority: "high",
+            created_at: "2026-08-01T12:00:00Z",
+            updated_at: "2026-08-02T12:00:00Z",
+            tags: ["support"],
+            custom_fields: [{ id: 200, value: "technical_support" }],
+            generated_timestamp: 123,
+            url: "https://example-account.zendesk.com/api/v2/tickets/1.json",
+          },
+        ],
+        count: 1,
         next_page: null,
       },
     });
@@ -241,18 +171,24 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
       params: {
         subdomain: "example-account",
         query: "status:open",
-        limit: 50,
-        includeCustomFieldNames: false,
       },
       authParams: AUTH,
     });
 
-    expect(result.results).toHaveLength(50);
-    expect(result.results.map((ticket) => ticket.id)).toEqual(
-      tickets.map((ticket) => ticket.id),
-    );
-    expect(JSON.stringify(result.results).length).toBeLessThanOrEqual(80000);
-    expect(result.response_truncated).toBe(true);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(result.results).toEqual([
+      {
+        id: 1,
+        subject: "Investigate this",
+        status: "open",
+        type: "incident",
+        priority: "high",
+        created_at: "2026-08-01T12:00:00Z",
+        updated_at: "2026-08-02T12:00:00Z",
+        description_excerpt: "x".repeat(1000),
+        description_truncated: true,
+      },
+    ]);
   });
 
   it("returns compact list records with bounded pagination", async () => {

--- a/tests/zendesk/searchZendeskTicketsByQuery.test.ts
+++ b/tests/zendesk/searchZendeskTicketsByQuery.test.ts
@@ -101,12 +101,14 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it("forces ticket searches, filters non-ticket results, and preserves the total count", async () => {
+  it("forces ticket searches and returns compact paginated discovery records", async () => {
     const ticket = { id: 1, result_type: "ticket" };
     mockGet.mockResolvedValueOnce({
       data: {
         results: [ticket, { id: 2, result_type: "user" }],
         count: 275,
+        next_page:
+          "https://example-account.zendesk.com/api/v2/search.json?page=2",
       },
     });
 
@@ -124,8 +126,180 @@ describe("zendesk searchZendeskTicketsByQuery", () => {
     expect(parsedUrl.hostname).toBe("example-account.zendesk.com");
     expect(parsedUrl.searchParams.get("query")).toBe("type:ticket status:open");
     expect(parsedUrl.searchParams.get("per_page")).toBe("10");
-    expect(result.results).toEqual([ticket]);
+    expect(parsedUrl.searchParams.get("page")).toBe("1");
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        id: 1,
+        description_excerpt: "",
+        description_truncated: false,
+      }),
+    ]);
+    expect(result.results[0]).not.toHaveProperty("result_type");
     expect(result.count).toBe(275);
+    expect(result.returned_count).toBe(1);
+    expect(result.has_more).toBe(true);
+    expect(result.next_page).toBe(2);
+  });
+
+  it("keeps only discovery fields, populated custom fields, and description excerpts", async () => {
+    const description = "x".repeat(2000);
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          results: [
+            {
+              id: 1,
+              result_type: "ticket",
+              subject: "Investigate this",
+              description,
+              status: "open",
+              tags: ["support"],
+              via: {
+                channel: "email",
+                source: { from: { address: "requester@example.com" } },
+              },
+              custom_fields: [
+                { id: 100, value: null },
+                { id: 200, value: "technical_support" },
+              ],
+              fields: [
+                { id: 100, value: null },
+                { id: 200, value: "technical_support" },
+              ],
+              generated_timestamp: 123,
+              url: "https://example-account.zendesk.com/api/v2/tickets/1.json",
+            },
+          ],
+          count: 1,
+          next_page: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ticket_fields: [{ id: 200, title: "Request Type" }],
+          meta: { has_more: false },
+        },
+      });
+
+    const result = await searchZendeskTicketsByQuery({
+      params: {
+        subdomain: "example-account",
+        query: "status:open",
+      },
+      authParams: AUTH,
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    const [ticketFieldsUrl] = mockGet.mock.calls[1] as [string];
+    expect(new URL(ticketFieldsUrl).pathname).toBe(
+      "/api/v2/ticket_fields.json",
+    );
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        id: 1,
+        subject: "Investigate this",
+        status: "open",
+        tags: ["support"],
+        via: { channel: "email" },
+        description_excerpt: "x".repeat(1500),
+        description_truncated: true,
+        custom_fields: [
+          { id: 200, name: "Request Type", value: "technical_support" },
+        ],
+      }),
+    );
+    expect(result.results[0]).not.toHaveProperty("fields");
+    expect(result.results[0]).not.toHaveProperty("generated_timestamp");
+    expect(result.results[0]).not.toHaveProperty("url");
+    expect(result.response_truncated).toBe(true);
+  });
+
+  it("keeps the compact search response under its character budget without dropping ticket IDs", async () => {
+    const tickets = Array.from({ length: 50 }, (_, index) => ({
+      id: index + 1,
+      result_type: "ticket",
+      subject: `Ticket ${index + 1}`,
+      description: "d".repeat(5000),
+      tags: Array.from(
+        { length: 40 },
+        (_, tagIndex) => `tag-${tagIndex}-${"t".repeat(100)}`,
+      ),
+      custom_fields: Array.from({ length: 20 }, (_, fieldIndex) => ({
+        id: fieldIndex + 1,
+        value: "v".repeat(1000),
+      })),
+    }));
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: tickets,
+        count: tickets.length,
+        next_page: null,
+      },
+    });
+
+    const result = await searchZendeskTicketsByQuery({
+      params: {
+        subdomain: "example-account",
+        query: "status:open",
+        limit: 50,
+        includeCustomFieldNames: false,
+      },
+      authParams: AUTH,
+    });
+
+    expect(result.results).toHaveLength(50);
+    expect(result.results.map((ticket) => ticket.id)).toEqual(
+      tickets.map((ticket) => ticket.id),
+    );
+    expect(JSON.stringify(result.results).length).toBeLessThanOrEqual(80000);
+    expect(result.response_truncated).toBe(true);
+  });
+
+  it("returns compact list records with bounded pagination", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            id: 1,
+            result_type: "ticket",
+            subject: "Listed ticket",
+            description: "Summary",
+          },
+        ],
+        count: 21,
+        next_page:
+          "https://example-account.zendesk.com/api/v2/search.json?page=2",
+      },
+    });
+
+    const result = await listZendeskTickets({
+      params: {
+        subdomain: "example-account",
+        status: "open",
+        limit: 20,
+        page: 1,
+      },
+      authParams: AUTH,
+    });
+
+    const [requestUrl] = mockGet.mock.calls[0] as [string];
+    const parsedUrl = new URL(requestUrl);
+    expect(parsedUrl.pathname).toBe("/api/v2/search.json");
+    expect(parsedUrl.searchParams.get("query")).toMatch(
+      /^type:ticket created>\d{4}-\d{2}-\d{2} status:open$/,
+    );
+    expect(parsedUrl.searchParams.get("per_page")).toBe("20");
+    expect(parsedUrl.searchParams.get("page")).toBe("1");
+    expect(result.tickets).toEqual([
+      expect.objectContaining({
+        id: 1,
+        subject: "Listed ticket",
+        description_excerpt: "Summary",
+      }),
+    ]);
+    expect(result.returned_count).toBe(1);
+    expect(result.has_more).toBe(true);
+    expect(result.next_page).toBe(2);
   });
 
   it("validates the subdomain in every generated Zendesk parameter schema", () => {


### PR DESCRIPTION
**Context:**
Right now when ACF users pull their tickets, even just 10 they get too large of a response and it errors out (when using the search Zendesk ticket with query action). 

**Summary:**
- Return compact discovery records from Zendesk ticket List/Search actions instead of full ticket objects.
- Include key ticket metadata, description excerpts, and populated custom fields with resolved names.
- Add bounded pagination and an 80,000-character response budget while preserving ticket IDs.
- Correct List Tickets date/status filtering by using Zendesk Search.
- Add tests for projection, pagination, custom fields, truncation, and payload limits.

**Testing:**
Adding test coverage as a part of the PR and validate locally: https://www.loom.com/share/46cada1530a14b87a318926b8bedc7d9