### PR TITLE
bump xmldom override version to non-vulnerable one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.231",
+  "version": "0.2.232",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.231",
+      "version": "0.2.232",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.231",
+  "version": "0.2.232",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,
@@ -85,7 +85,7 @@
     "zod": "^3.25.0"
   },
   "overrides": {
-    "@xmldom/xmldom": "^0.8.13",
+    "@xmldom/xmldom": "^0.8.15",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.7.0",
     "minimatch": "^10.2.1",


### PR DESCRIPTION
bumping in response to https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6