### PR TITLE
Override snowflake-sdk's toml dep to 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.233",
+  "version": "0.2.234",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@credal/actions",
-      "version": "0.2.233",
+      "version": "0.2.234",
       "license": "ISC",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12111,10 +12111,13 @@
       }
     },
     "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "license": "MIT"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-5.0.0.tgz",
+      "integrity": "sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tr46": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credal/actions",
-  "version": "0.2.233",
+  "version": "0.2.234",
   "type": "module",
   "description": "AI Actions by Credal AI",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "fast-xml-parser": "^5.7.0",
     "minimatch": "^10.2.1",
     "file-type": "^22.0.0",
-    "pdfjs-dist": "^6.2.108"
+    "pdfjs-dist": "^6.2.108",
+    "snowflake-sdk": {
+      "toml": "^5.0.0"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-connector-nodejs/issues/1476#issuecomment-5541423246 greenlit `snowflake-sdk@3.3.0` to have `toml` overridden by 2 major versions - to 5.x. to address the existing vuln in toml 3
This PR puts that into practice.
Followup to https://github.com/Credal-ai/actions-sdk which upgraded our `snowflake-sdk` version to `3.3.0` so we could be aligned with the greenlit version